### PR TITLE
panic_params: don't lint escaped squigglies

### DIFF
--- a/clippy_lints/src/panic.rs
+++ b/clippy_lints/src/panic.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use rustc::hir::*;
 use rustc::lint::*;
 use syntax::ast::LitKind;
@@ -45,6 +46,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             is_direct_expn_of(cx, params[0].span, "panic").is_some(),
             let LitKind::Str(ref string, _) = lit.node,
             let Some(par) = string.as_str().find('{'),
+            !string.as_str()[par + 1..min(par + 2, string.as_str().len())].contains('{'),
             string.as_str()[par..].contains('}')
         ], {
             span_lint(cx, PANIC_PARAMS, params[0].span,

--- a/tests/ui/panic.rs
+++ b/tests/ui/panic.rs
@@ -42,6 +42,9 @@ fn ok_escaped() {
     panic!(" }or }} this ?");
     panic!(" {or }} that ?");
     panic!(" }or { this ?");
+    panic!("{{ test }");
+    panic!("{case }}");
+    panic!("{{{this}}}");
 }
 
 fn main() {

--- a/tests/ui/panic.rs
+++ b/tests/ui/panic.rs
@@ -36,6 +36,12 @@ fn ok_bracket() {
 
 fn ok_escaped() {
     panic!("{{ why should this not be ok? }}");
+    panic!(" or {{ that ?");
+    panic!(" or }} this ?");
+    panic!(" {or {{ that ?");
+    panic!(" }or }} this ?");
+    panic!(" {or }} that ?");
+    panic!(" }or { this ?");
 }
 
 fn main() {

--- a/tests/ui/panic.rs
+++ b/tests/ui/panic.rs
@@ -34,10 +34,15 @@ fn ok_bracket() {
     }
 }
 
+fn ok_escaped() {
+    panic!("{{ why should this not be ok? }}");
+}
+
 fn main() {
     missing();
     ok_single();
     ok_multiple();
     ok_bracket();
     ok_inner();
+    ok_escaped();
 }


### PR DESCRIPTION
With format strings, squiggly brackets can be doubled to escape them, e.g. `"{{this}}"` (which will actually format to `"{this}"`). The `panic_params` lint should check for those; with this PR it does.