### PR TITLE
Added test for panic involving complicated match blocks

### DIFF
--- a/tests/issue-1782.rs
+++ b/tests/issue-1782.rs
@@ -1,0 +1,14 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+use std::{mem, ptr};
+
+#[test]
+fn match_transmute_write() {
+    match Some(()) {
+        Some(_) => unsafe { ptr::write(ptr::null_mut() as *mut u32, mem::transmute::<[u8; 4], _>([0, 0, 0, 255])) },
+        None => unsafe { ptr::write(ptr::null_mut() as *mut u32, mem::transmute::<[u8; 4], _>([13, 246, 24, 255])) },
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
I implemented a test that causes a panic using the latest nightly compiler.  See tracking issue #1782 for a more detailed explanation.