### PR TITLE
Add example for needless borrowed ref lint and register it

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -267,6 +267,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box mutex_atomic::MutexAtomic);
     reg.register_late_lint_pass(box needless_update::Pass);
     reg.register_late_lint_pass(box needless_borrow::NeedlessBorrow);
+    reg.register_late_lint_pass(box needless_borrowed_ref::NeedlessBorrowedRef);
     reg.register_late_lint_pass(box no_effect::Pass);
     reg.register_late_lint_pass(box map_clone::Pass);
     reg.register_late_lint_pass(box temporary_assignment::Pass);

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -3,25 +3,33 @@
 //! This lint is **warn** by default
 
 use rustc::lint::*;
-<<<<<<< HEAD
-use rustc::hir::{MutImmutable, Pat, PatKind, BindingAnnotation};
-=======
-use rustc::hir::{MutImmutable, Pat, PatKind};
-<<<<<<< HEAD
->>>>>>> e30bf721... Improve needless_borrowed_ref and add suggestion to it.
+use rustc::hir::{MutImmutable, Pat, PatKind, BindByRef};
 use rustc::ty;
-=======
->>>>>>> 4ae45c87... Improve needless_borrowed_ref lint: remove the hand rolled span part.
 use utils::{span_lint_and_then, in_macro, snippet};
-use rustc::hir::BindingMode::BindByRef;
 
 /// **What it does:** Checks for useless borrowed references.
 ///
-/// **Why is this bad?** It is completely useless and make the code look more
-/// complex than it
+/// **Why is this bad?** It is mostly useless and make the code look more complex than it
 /// actually is.
 ///
-/// **Known problems:** None.
+/// **Known problems:** It seems that the `&ref` pattern is sometimes useful.
+/// For instance in the following snippet:
+/// ```rust
+/// enum Animal {
+///     Cat(u64),
+///     Dog(u64),
+/// }
+///
+/// fn foo(a: &Animal, b: &Animal) {
+///     match (a, b) {
+///         (&Animal::Cat(v), k) | (k, &Animal::Cat(v)) => (), // lifetime mismatch error
+///         (&Animal::Dog(ref c), &Animal::Dog(_)) => ()
+///     }
+/// }
+/// ```
+/// There is a lifetime mismatch error for `k` (indeed a and b have distinct lifetime).
+/// This can be fixed by using the `&ref` pattern.
+/// However, the code can also be fixed by much cleaner ways
 ///
 /// **Example:**
 /// ```rust
@@ -75,3 +83,4 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrowedRef {
         }}
     }
 }
+

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -48,11 +48,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrowedRef {
 
         if_let_chain! {[
             // Pat is a pattern whose node
-            // is a binding which "involves" a immutable reference...
+            // is a binding which "involves" an immutable reference...
             let PatKind::Binding(BindingAnnotation::Ref, ..) = pat.node,
             // Pattern's type is a reference. Get the type and mutability of referenced value (tam: TypeAndMut).
             let ty::TyRef(_, ref tam) = cx.tables.pat_ty(pat).sty,
-            // This is an immutable reference.
+            // Only lint immutable refs, because `&mut ref T` may be useful.
             tam.mutbl == MutImmutable,
         ], {
             span_lint(cx, NEEDLESS_BORROWED_REFERENCE, pat.span, "this pattern takes a reference on something that is being de-referenced")

--- a/clippy_tests/examples/needless_borrowed_ref.rs
+++ b/clippy_tests/examples/needless_borrowed_ref.rs
@@ -8,13 +8,24 @@ fn main() {
     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
     //                            ^ should be linted
 
-    let mut var = 5;
-    let thingy = Some(&mut var);
-    if let Some(&mut ref v) = thingy {
+    let var = 3;
+    let thingy = Some(&var);
+    if let Some(&ref v) = thingy {
+        //          ^ should be linted
+    }
+
+    let mut var2 = 5;
+    let thingy2 = Some(&mut var2);
+    if let Some(&mut ref mut v) = thingy2 {
         //          ^ should *not* be linted
-        // here, var is borrowed as immutable.
+        // v is borrowed as mutable.
+        *v = 10;
+    }
+    if let Some(&mut ref v) = thingy2 {
+        //          ^ should *not* be linted
+        // here, v is borrowed as immutable.
         // can't do that:
-        //*v = 10;
+        //*v = 15;
     }
 }
 

--- a/clippy_tests/examples/needless_borrowed_ref.rs
+++ b/clippy_tests/examples/needless_borrowed_ref.rs
@@ -1,0 +1,9 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#[warn(needless_borrowed_reference)]
+fn main() {
+    let mut v = Vec::<String>::new();
+    let _ = v.iter_mut().filter(|&ref a| a.is_empty());
+}
+

--- a/clippy_tests/examples/needless_borrowed_ref.rs
+++ b/clippy_tests/examples/needless_borrowed_ref.rs
@@ -2,8 +2,36 @@
 #![plugin(clippy)]
 
 #[warn(needless_borrowed_reference)]
+#[allow(unused_variables)]
 fn main() {
     let mut v = Vec::<String>::new();
     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
+    //                            ^ should be linted
+
+    let mut var = 5;
+    let thingy = Some(&mut var);
+    if let Some(&mut ref v) = thingy {
+        //          ^ should *not* be linted
+        // here, var is borrowed as immutable.
+        // can't do that:
+        //*v = 10;
+    }
+}
+
+#[allow(dead_code)]
+enum Animal {
+    Cat(u64),
+    Dog(u64),
+}
+
+#[allow(unused_variables)]
+#[allow(dead_code)]
+fn foo(a: &Animal, b: &Animal) {
+    match (a, b) {
+        (&Animal::Cat(v), &ref k) | (&ref k, &Animal::Cat(v)) => (), // lifetime mismatch error if there is no '&ref'
+        //                  ^    and   ^ should *not* be linted
+        (&Animal::Dog(ref a), &Animal::Dog(_)) => ()
+        //              ^ should *not* be linted
+    }
 }
 

--- a/clippy_tests/examples/needless_borrowed_ref.stderr
+++ b/clippy_tests/examples/needless_borrowed_ref.stderr
@@ -1,0 +1,8 @@
+warning: this pattern takes a reference on something that is being de-referenced
+ --> needless_borrowed_ref.rs:7:35
+  |
+7 |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
+  |                                   ^^^^^
+  |
+  = note: #[warn(needless_borrowed_reference)] on by default
+  = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference

--- a/clippy_tests/examples/needless_borrowed_ref.stderr
+++ b/clippy_tests/examples/needless_borrowed_ref.stderr
@@ -1,8 +1,41 @@
-warning: this pattern takes a reference on something that is being de-referenced
- --> needless_borrowed_ref.rs:7:35
+error: this pattern takes a reference on something that is being de-referenced
+ --> examples/needless_borrowed_ref.rs:8:34
   |
-7 |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
-  |                                   ^^^^^
+8 |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
+  |                                  ^^^^^^ help: try removing the `&ref` part and just keep `a`
   |
-  = note: #[warn(needless_borrowed_reference)] on by default
+  = note: `-D needless-borrowed-reference` implied by `-D warnings`
   = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
+
+error: this pattern takes a reference on something that is being de-referenced
+  --> examples/needless_borrowed_ref.rs:13:17
+   |
+13 |     if let Some(&ref v) = thingy {
+   |                 ^^^^^^ help: try removing the `&ref` part and just keep `v`
+   |
+   = note: `-D needless-borrowed-reference` implied by `-D warnings`
+   = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
+
+error: this pattern takes a reference on something that is being de-referenced
+  --> examples/needless_borrowed_ref.rs:42:27
+   |
+42 |         (&Animal::Cat(v), &ref k) | (&ref k, &Animal::Cat(v)) => (), // lifetime mismatch error if there is no '&ref'
+   |                           ^^^^^^ help: try removing the `&ref` part and just keep `k`
+   |
+   = note: `-D needless-borrowed-reference` implied by `-D warnings`
+   = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
+
+error: this pattern takes a reference on something that is being de-referenced
+  --> examples/needless_borrowed_ref.rs:42:38
+   |
+42 |         (&Animal::Cat(v), &ref k) | (&ref k, &Animal::Cat(v)) => (), // lifetime mismatch error if there is no '&ref'
+   |                                      ^^^^^^ help: try removing the `&ref` part and just keep `k`
+   |
+   = note: `-D needless-borrowed-reference` implied by `-D warnings`
+   = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
+
+error: aborting due to previous error(s)
+
+error: Could not compile `clippy_tests`.
+
+To learn more, run the command again with --verbose.

--- a/clippy_tests/examples/needless_borrowed_ref.stderr
+++ b/clippy_tests/examples/needless_borrowed_ref.stderr
@@ -1,5 +1,5 @@
 error: this pattern takes a reference on something that is being de-referenced
- --> examples/needless_borrowed_ref.rs:8:34
+ --> needless_borrowed_ref.rs:8:34
   |
 8 |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
   |                                  ^^^^^^ help: try removing the `&ref` part and just keep `a`
@@ -8,30 +8,27 @@ error: this pattern takes a reference on something that is being de-referenced
   = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
 
 error: this pattern takes a reference on something that is being de-referenced
-  --> examples/needless_borrowed_ref.rs:13:17
+  --> needless_borrowed_ref.rs:13:17
    |
 13 |     if let Some(&ref v) = thingy {
    |                 ^^^^^^ help: try removing the `&ref` part and just keep `v`
    |
-   = note: `-D needless-borrowed-reference` implied by `-D warnings`
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
 
 error: this pattern takes a reference on something that is being de-referenced
-  --> examples/needless_borrowed_ref.rs:42:27
+  --> needless_borrowed_ref.rs:42:27
    |
 42 |         (&Animal::Cat(v), &ref k) | (&ref k, &Animal::Cat(v)) => (), // lifetime mismatch error if there is no '&ref'
    |                           ^^^^^^ help: try removing the `&ref` part and just keep `k`
    |
-   = note: `-D needless-borrowed-reference` implied by `-D warnings`
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
 
 error: this pattern takes a reference on something that is being de-referenced
-  --> examples/needless_borrowed_ref.rs:42:38
+  --> needless_borrowed_ref.rs:42:38
    |
 42 |         (&Animal::Cat(v), &ref k) | (&ref k, &Animal::Cat(v)) => (), // lifetime mismatch error if there is no '&ref'
    |                                      ^^^^^^ help: try removing the `&ref` part and just keep `k`
    |
-   = note: `-D needless-borrowed-reference` implied by `-D warnings`
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_borrowed_reference
 
 error: aborting due to previous error(s)

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -18,11 +18,25 @@ error: this expression borrows a reference that is immediately dereferenced by t
 27 |         46 => &&a,
    |               ^^^
 
+error: this pattern takes a reference on something that is being de-referenced
+  --> $DIR/needless_borrow.rs:49:34
+   |
+49 |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
+   |                                  ^^^^^^ help: try removing the `&ref` part and just keep: `a`
+   |
+   = note: `-D needless-borrowed-reference` implied by `-D warnings`
+
+error: this pattern takes a reference on something that is being de-referenced
+  --> $DIR/needless_borrow.rs:50:30
+   |
+50 |     let _ = v.iter().filter(|&ref a| a.is_empty());
+   |                              ^^^^^^ help: try removing the `&ref` part and just keep: `a`
+
 error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow.rs:50:31
    |
 50 |     let _ = v.iter().filter(|&ref a| a.is_empty());
    |                               ^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Add example for needless borrowed ref lint.
See https://github.com/Manishearth/rust-clippy/pull/1536. Issue https://github.com/Manishearth/rust-clippy/issues/1434 may be closed after this is merged.

I found why the lint wasn't "working": I forgot to register it in lib.rs after updating my fork. So I fixed that too (and improved my code comments I think).

Let me know if anything needs to be changed. Thanks!