### PR TITLE
Canonicalize --manifest-path argument before comparing it to cargo metadata.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ script:
  - cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
  - cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
  - cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../../..
+ - PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy && cd ..
+ - cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy && cd ../..
  - set +e
 
 after_success: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
  - cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
  - cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
  - cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../../..
- - PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy && cd ..
+ - PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy
  - cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy && cd ../..
  - set +e
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,12 +191,14 @@ pub fn main() {
                 process::exit(101);
             };
 
-        let manifest_path = manifest_path_arg.map(|arg| PathBuf::from(Path::new(&arg["--manifest-path=".len()..])));
+        let manifest_path = manifest_path_arg.map(|arg| Path::new(&arg["--manifest-path=".len()..])
+            .canonicalize().expect("manifest path could not be canonicalized"));
 
         let package_index = {
-                if let Some(ref manifest_path) = manifest_path {
+                if let Some(manifest_path) = manifest_path {
                     metadata.packages.iter().position(|package| {
-                        let package_manifest_path = Path::new(&package.manifest_path);
+                        let package_manifest_path = Path::new(&package.manifest_path)
+                            .canonicalize().expect("package manifest path could not be canonicalized");
                         package_manifest_path == manifest_path
                     })
                 } else {


### PR DESCRIPTION
Before this change, a relative path like `--manifest-path=./Cargo.toml` would
fail to find a matching package in the cargo metadata. With this change,
both the argument and the cargo metadata path are canonicalized before
comparison.