### PR TITLE
Generate version index for docs domain index

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -33,6 +33,19 @@ if [ -n "$TRAVIS_TAG" ]; then
     ln -s "$TRAVIS_TAG" out/current
 fi
 
+# Generate version index that is shown as root index page
+(
+    cp util/gh-pages/versions.html out/index.html
+
+    cd out
+    python -c '\
+        import os, json;\
+        print json.dumps([\
+            dir for dir in os.listdir(".")\
+            if not dir.startswith(".") and os.path.isdir(dir)\
+        ])' > versions.json
+)
+
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
     # Tags should deploy

--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -94,7 +94,7 @@
         </div>
     </div>
 
-    <a href="https://github.com/Manishearth/rust-clippy">
+    <a href="https://github.com/rust-lang-nursery/rust-clippy">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"/>
     </a>
 

--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+    <title>Clippy</title>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
+    <style>
+        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }
+    </style>
+</head>
+<body>
+    <div class="container" ng-app="clippy" ng-controller="docVersions">
+        <div class="page-header">
+            <h1>Clippy lints documention</h1>
+        </div>
+
+        <div ng-cloak>
+            <div class="alert alert-info" role="alert" ng-if="loading">
+                Loading&#x2026;
+            </div>
+            <div class="alert alert-danger" role="alert" ng-if="error">
+                Error loading versions!<br/>
+                You can always try to get <a href="master/index.html">the master branch docs</a>.
+            </div>
+
+            <article class="panel panel-default" ng-show="data">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        Available versions
+                    </h3>
+                </div>
+
+                <ul class="list-group">
+                    <a class="list-group-item" ng-repeat="version in data | orderBy"
+                       href="./{{version}}/index.html">
+                        {{version}}
+                    </a>
+                </ul>
+            </article>
+        </div>
+    </div>
+
+    <a href="https://github.com/rust-lang-nursery/rust-clippy">
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"/>
+    </a>
+
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.12/angular.min.js"></script>
+    <script>
+        angular.module('clippy', [])
+        .controller('docVersions', function ($scope, $http) {
+            $scope.loading = true;
+
+            $http.get('./versions.json')
+            .success(function (data) {
+                $scope.data = data;
+                $scope.loading = false;
+            })
+            .error(function (data) {
+                $scope.error = data;
+                $scope.loading = false;
+            });
+        })
+        ;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Uses the basically the same code as the lint docs page as I didn't want
to reinvent anything: A simple python script (inline in deploy script)
writes an array of versions to a JSON file, which gets turned into a
list of links using a bit of angular.js code.

Fixes #1917