### PR TITLE
Docs index: Sort versions in a nice way

### DIFF
--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -34,9 +34,9 @@
                 </div>
 
                 <ul class="list-group">
-                    <a class="list-group-item" ng-repeat="version in data | orderBy"
+                    <a class="list-group-item" ng-repeat="version in data | orderBy:versionOrder:true"
                        href="./{{version}}/index.html">
-                        {{version}}
+                        {{normalizeVersion(version)}}
                     </a>
                 </ul>
             </article>
@@ -53,6 +53,22 @@
         angular.module('clippy', [])
         .controller('docVersions', function ($scope, $http) {
             $scope.loading = true;
+
+            $scope.normalizeVersion = function(v) {
+                return v.replace(/^v/, '');
+            };
+
+            $scope.versionOrder = function(v) {
+                if (v === 'master') { return Infinity; }
+                if (v === 'current') { return Number.MAX_VALUE; }
+
+                return $scope.normalizeVersion(v)
+                    .split('.')
+                    .reverse()
+                    .reduce(function(acc, val, index) {
+                        return acc + (val * Math.pow(100, index));
+                    }, 0);
+            }
 
             $http.get('./versions.json')
             .success(function (data) {


### PR DESCRIPTION
This introduces a very sophisticated algorithm to determine the ordering
of versions on the rendered docs' start page.

(Spoiler alert: It maps "master" and "current" to the largest possible
float values and converts a version like "1.2.3" to "1002003".)