### PR TITLE
Don't cache builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ os:
 
 sudo: false
 
-cache:
-  cargo: true
-  directories:
-  - target
-
 env:
  global:
    # TRAVIS_TOKEN_CLIPPY_SERVICE


### PR DESCRIPTION
The caches cause more problems than they solve. Every time we get a new nightly they become useless anyway.