### PR TITLE
Fix verbose_bit_mask off by one error

### DIFF
--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BitMask {
                                "bit mask could be simplified with a call to `trailing_zeros`",
                                |db| {
                 let sugg = Sugg::hir(cx, left1, "...").maybe_par();
-                db.span_suggestion(e.span, "try", format!("{}.trailing_zeros() > {}", sugg, n.count_ones()));
+                db.span_suggestion(e.span, "try", format!("{}.trailing_zeros() >= {}", sugg, n.count_ones()));
             });
         }}
     }

--- a/tests/ui/bit_masks.stderr
+++ b/tests/ui/bit_masks.stderr
@@ -10,7 +10,7 @@ error: bit mask could be simplified with a call to `trailing_zeros`
   --> $DIR/bit_masks.rs:12:5
    |
 12 |     x & 0 == 0;
-   |     ^^^^^^^^^^ help: try: `x.trailing_zeros() > 0`
+   |     ^^^^^^^^^^ help: try: `x.trailing_zeros() >= 0`
    |
    = note: `-D verbose-bit-mask` implied by `-D warnings`
 
@@ -18,7 +18,7 @@ error: bit mask could be simplified with a call to `trailing_zeros`
   --> $DIR/bit_masks.rs:14:5
    |
 14 |     x & 1 == 0; //ok, compared with zero
-   |     ^^^^^^^^^^ help: try: `x.trailing_zeros() > 1`
+   |     ^^^^^^^^^^ help: try: `x.trailing_zeros() >= 1`
 
 error: incompatible bit mask: `_ & 2` can never be equal to `1`
   --> $DIR/bit_masks.rs:15:5

--- a/tests/ui/trailing_zeros.stderr
+++ b/tests/ui/trailing_zeros.stderr
@@ -2,7 +2,7 @@ error: bit mask could be simplified with a call to `trailing_zeros`
  --> $DIR/trailing_zeros.rs:7:31
   |
 7 |     let _ = #[clippy(author)] (x & 0b1111 == 0);  // suggest trailing_zeros
-  |                               ^^^^^^^^^^^^^^^^^ help: try: `x.trailing_zeros() > 4`
+  |                               ^^^^^^^^^^^^^^^^^ help: try: `x.trailing_zeros() >= 4`
   |
   = note: `-D verbose-bit-mask` implied by `-D warnings`
 
@@ -10,7 +10,7 @@ error: bit mask could be simplified with a call to `trailing_zeros`
  --> $DIR/trailing_zeros.rs:8:13
   |
 8 |     let _ = x & 0b1_1111 == 0; // suggest trailing_zeros
-  |             ^^^^^^^^^^^^^^^^^ help: try: `x.trailing_zeros() > 5`
+  |             ^^^^^^^^^^^^^^^^^ help: try: `x.trailing_zeros() >= 5`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #1940 

What would be preferred solution, replacing `>` with `>=` or incrementing `n.count_ones()`?