### PR TITLE
Add a lint for lossless casts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,7 @@ All notable changes to this project will be documented in this file.
 [`box_vec`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#box_vec
 [`boxed_local`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#boxed_local
 [`builtin_type_shadow`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#builtin_type_shadow
+[`cast_lossless`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_lossless
 [`cast_possible_truncation`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_possible_truncation
 [`cast_possible_wrap`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_possible_wrap
 [`cast_precision_loss`]: https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_precision_loss

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ transparently:
 
 ## Lints
 
-There are 208 lints included in this crate:
+There are 209 lints included in this crate:
 
 name                                                                                                                         | default | triggers on
 -----------------------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------
@@ -198,6 +198,7 @@ name                                                                            
 [box_vec](https://github.com/rust-lang-nursery/rust-clippy/wiki#box_vec)                                                     | warn    | usage of `Box<Vec<T>>`, vector elements are already on the heap
 [boxed_local](https://github.com/rust-lang-nursery/rust-clippy/wiki#boxed_local)                                             | warn    | using `Box<T>` where unnecessary
 [builtin_type_shadow](https://github.com/rust-lang-nursery/rust-clippy/wiki#builtin_type_shadow)                             | warn    | shadowing a builtin type
+[cast_lossless](https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_lossless)                                         | allow   | casts using `as` that are known to be lossless, e.g. `x as u64` where `x: u8`
 [cast_possible_truncation](https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_possible_truncation)                   | allow   | casts that may cause truncation of the value, e.g. `x as u8` where `x: u32`, or `x as i32` where `x: f32`
 [cast_possible_wrap](https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_possible_wrap)                               | allow   | casts that may cause wrapping around the value, e.g. `x as i32` where `x: u32` and `x > i32::MAX`
 [cast_precision_loss](https://github.com/rust-lang-nursery/rust-clippy/wiki#cast_precision_loss)                             | allow   | casts that cause loss of precision, e.g. `x as f32` where `x: u64`

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -54,8 +54,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnportableVariant {
                     let bad = match cx.tcx.at(expr.span).const_eval(
                         param_env.and((did, substs)),
                     ) {
-                        Ok(ConstVal::Integral(Usize(Us64(i)))) => i as u32 as u64 != i,
-                        Ok(ConstVal::Integral(Isize(Is64(i)))) => i as i32 as i64 != i,
+                        Ok(ConstVal::Integral(Usize(Us64(i)))) => u64::from(i as u32) != i,
+                        Ok(ConstVal::Integral(Isize(Is64(i)))) => i64::from(i as i32) != i,
                         _ => false,
                     };
                     if bad {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -359,6 +359,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         shadow::SHADOW_UNRELATED,
         strings::STRING_ADD,
         strings::STRING_ADD_ASSIGN,
+        types::CAST_LOSSLESS,
         types::CAST_POSSIBLE_TRUNCATION,
         types::CAST_POSSIBLE_WRAP,
         types::CAST_PRECISION_LOSS,

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -430,17 +430,17 @@ fn is_allowed(cx: &LateContext, expr: &Expr) -> bool {
             FloatTy::F32 => {
                 let zero = ConstFloat {
                     ty: FloatTy::F32,
-                    bits: 0.0_f32.to_bits() as u128,
+                    bits: u128::from(0.0_f32.to_bits()),
                 };
 
                 let infinity = ConstFloat {
                     ty: FloatTy::F32,
-                    bits: ::std::f32::INFINITY.to_bits() as u128,
+                    bits: u128::from(::std::f32::INFINITY.to_bits()),
                 };
 
                 let neg_infinity = ConstFloat {
                     ty: FloatTy::F32,
-                    bits: ::std::f32::NEG_INFINITY.to_bits() as u128,
+                    bits: u128::from(::std::f32::NEG_INFINITY.to_bits()),
                 };
 
                 val.try_cmp(zero) == Ok(Ordering::Equal) || val.try_cmp(infinity) == Ok(Ordering::Equal) ||
@@ -449,17 +449,17 @@ fn is_allowed(cx: &LateContext, expr: &Expr) -> bool {
             FloatTy::F64 => {
                 let zero = ConstFloat {
                     ty: FloatTy::F64,
-                    bits: 0.0_f64.to_bits() as u128,
+                    bits: u128::from(0.0_f64.to_bits()),
                 };
 
                 let infinity = ConstFloat {
                     ty: FloatTy::F64,
-                    bits: ::std::f64::INFINITY.to_bits() as u128,
+                    bits: u128::from(::std::f64::INFINITY.to_bits()),
                 };
 
                 let neg_infinity = ConstFloat {
                     ty: FloatTy::F64,
-                    bits: ::std::f64::NEG_INFINITY.to_bits() as u128,
+                    bits: u128::from(::std::f64::NEG_INFINITY.to_bits()),
                 };
 
                 val.try_cmp(zero) == Ok(Ordering::Equal) || val.try_cmp(infinity) == Ok(Ordering::Equal) ||

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -1,7 +1,7 @@
 #![feature(plugin)]
 #![plugin(clippy)]
 
-#[warn(cast_precision_loss, cast_possible_truncation, cast_sign_loss, cast_possible_wrap)]
+#[warn(cast_precision_loss, cast_possible_truncation, cast_sign_loss, cast_possible_wrap, cast_lossless)]
 #[allow(no_effect, unnecessary_operation)]
 fn main() {
     // Test cast_precision_loss
@@ -11,8 +11,6 @@ fn main() {
     1u32 as f32;
     1u64 as f32;
     1u64 as f64;
-    1i32 as f64; // Should not trigger the lint
-    1u32 as f64; // Should not trigger the lint
     // Test cast_possible_truncation
     1f32 as i32;
     1f32 as u32;
@@ -27,6 +25,38 @@ fn main() {
     1u32 as i32;
     1u64 as i64;
     1usize as isize;
+    // Test cast_lossless with casts to integer types
+    1i8 as i16;
+    1i8 as i32;
+    1i8 as i64;
+    1u8 as i16;
+    1u8 as i32;
+    1u8 as i64;
+    1u8 as u16;
+    1u8 as u32;
+    1u8 as u64;
+    1i16 as i32;
+    1i16 as i64;
+    1u16 as i32;
+    1u16 as i64;
+    1u16 as u32;
+    1u16 as u64;
+    1i32 as i64;
+    1u32 as i64;
+    1u32 as u64;
+    // Test cast_lossless with casts to floating-point types
+    1i8 as f32;
+    1i8 as f64;
+    1u8 as f32;
+    1u8 as f64;
+    1i16 as f32;
+    1i16 as f64;
+    1u16 as f32;
+    1u16 as f64;
+    1i32 as f64;
+    1u32 as f64;
+    // Test cast_lossless with casts from floating-point types
+    1.0f32 as f64;
     // Test cast_sign_loss
     1i32 as u32;
     1isize as usize;
@@ -56,7 +86,6 @@ fn main() {
     false as bool;
     &1i32 as &i32;
     // Should not trigger
-    1i32 as i64;
     let v = vec!(1);
     &v as &[i32];
     1.0 as f64;

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -37,246 +37,422 @@ error: casting u64 to f64 causes a loss of precision (u64 is 64 bits wide, but f
    |     ^^^^^^^^^^^
 
 error: casting f32 to i32 may truncate the value
-  --> $DIR/cast.rs:17:5
+  --> $DIR/cast.rs:15:5
    |
-17 |     1f32 as i32;
+15 |     1f32 as i32;
    |     ^^^^^^^^^^^
    |
    = note: `-D cast-possible-truncation` implied by `-D warnings`
 
 error: casting f32 to u32 may truncate the value
-  --> $DIR/cast.rs:18:5
+  --> $DIR/cast.rs:16:5
    |
-18 |     1f32 as u32;
+16 |     1f32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting f32 to u32 may lose the sign of the value
-  --> $DIR/cast.rs:18:5
+  --> $DIR/cast.rs:16:5
    |
-18 |     1f32 as u32;
+16 |     1f32 as u32;
    |     ^^^^^^^^^^^
    |
    = note: `-D cast-sign-loss` implied by `-D warnings`
 
 error: casting f64 to f32 may truncate the value
-  --> $DIR/cast.rs:19:5
+  --> $DIR/cast.rs:17:5
    |
-19 |     1f64 as f32;
+17 |     1f64 as f32;
    |     ^^^^^^^^^^^
 
 error: casting i32 to i8 may truncate the value
-  --> $DIR/cast.rs:20:5
+  --> $DIR/cast.rs:18:5
    |
-20 |     1i32 as i8;
+18 |     1i32 as i8;
    |     ^^^^^^^^^^
 
 error: casting i32 to u8 may lose the sign of the value
-  --> $DIR/cast.rs:21:5
+  --> $DIR/cast.rs:19:5
    |
-21 |     1i32 as u8;
+19 |     1i32 as u8;
    |     ^^^^^^^^^^
 
 error: casting i32 to u8 may truncate the value
-  --> $DIR/cast.rs:21:5
+  --> $DIR/cast.rs:19:5
    |
-21 |     1i32 as u8;
+19 |     1i32 as u8;
    |     ^^^^^^^^^^
 
 error: casting f64 to isize may truncate the value
-  --> $DIR/cast.rs:22:5
+  --> $DIR/cast.rs:20:5
    |
-22 |     1f64 as isize;
+20 |     1f64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting f64 to usize may truncate the value
-  --> $DIR/cast.rs:23:5
+  --> $DIR/cast.rs:21:5
    |
-23 |     1f64 as usize;
+21 |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting f64 to usize may lose the sign of the value
-  --> $DIR/cast.rs:23:5
+  --> $DIR/cast.rs:21:5
    |
-23 |     1f64 as usize;
+21 |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u8 to i8 may wrap around the value
-  --> $DIR/cast.rs:25:5
+  --> $DIR/cast.rs:23:5
    |
-25 |     1u8 as i8;
+23 |     1u8 as i8;
    |     ^^^^^^^^^
    |
    = note: `-D cast-possible-wrap` implied by `-D warnings`
 
 error: casting u16 to i16 may wrap around the value
-  --> $DIR/cast.rs:26:5
+  --> $DIR/cast.rs:24:5
    |
-26 |     1u16 as i16;
+24 |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting u32 to i32 may wrap around the value
-  --> $DIR/cast.rs:27:5
+  --> $DIR/cast.rs:25:5
    |
-27 |     1u32 as i32;
+25 |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting u64 to i64 may wrap around the value
-  --> $DIR/cast.rs:28:5
+  --> $DIR/cast.rs:26:5
    |
-28 |     1u64 as i64;
+26 |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting usize to isize may wrap around the value
-  --> $DIR/cast.rs:29:5
+  --> $DIR/cast.rs:27:5
    |
-29 |     1usize as isize;
+27 |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
-error: casting i32 to u32 may lose the sign of the value
+error: casting i8 to i16 may become silently lossy if types change
+  --> $DIR/cast.rs:29:5
+   |
+29 |     1i8 as i16;
+   |     ^^^^^^^^^^ help: try: `i16::from(1i8)`
+   |
+   = note: `-D cast-lossless` implied by `-D warnings`
+
+error: casting i8 to i32 may become silently lossy if types change
+  --> $DIR/cast.rs:30:5
+   |
+30 |     1i8 as i32;
+   |     ^^^^^^^^^^ help: try: `i32::from(1i8)`
+
+error: casting i8 to i64 may become silently lossy if types change
   --> $DIR/cast.rs:31:5
    |
-31 |     1i32 as u32;
+31 |     1i8 as i64;
+   |     ^^^^^^^^^^ help: try: `i64::from(1i8)`
+
+error: casting u8 to i16 may become silently lossy if types change
+  --> $DIR/cast.rs:32:5
+   |
+32 |     1u8 as i16;
+   |     ^^^^^^^^^^ help: try: `i16::from(1u8)`
+
+error: casting u8 to i32 may become silently lossy if types change
+  --> $DIR/cast.rs:33:5
+   |
+33 |     1u8 as i32;
+   |     ^^^^^^^^^^ help: try: `i32::from(1u8)`
+
+error: casting u8 to i64 may become silently lossy if types change
+  --> $DIR/cast.rs:34:5
+   |
+34 |     1u8 as i64;
+   |     ^^^^^^^^^^ help: try: `i64::from(1u8)`
+
+error: casting u8 to u16 may become silently lossy if types change
+  --> $DIR/cast.rs:35:5
+   |
+35 |     1u8 as u16;
+   |     ^^^^^^^^^^ help: try: `u16::from(1u8)`
+
+error: casting u8 to u32 may become silently lossy if types change
+  --> $DIR/cast.rs:36:5
+   |
+36 |     1u8 as u32;
+   |     ^^^^^^^^^^ help: try: `u32::from(1u8)`
+
+error: casting u8 to u64 may become silently lossy if types change
+  --> $DIR/cast.rs:37:5
+   |
+37 |     1u8 as u64;
+   |     ^^^^^^^^^^ help: try: `u64::from(1u8)`
+
+error: casting i16 to i32 may become silently lossy if types change
+  --> $DIR/cast.rs:38:5
+   |
+38 |     1i16 as i32;
+   |     ^^^^^^^^^^^ help: try: `i32::from(1i16)`
+
+error: casting i16 to i64 may become silently lossy if types change
+  --> $DIR/cast.rs:39:5
+   |
+39 |     1i16 as i64;
+   |     ^^^^^^^^^^^ help: try: `i64::from(1i16)`
+
+error: casting u16 to i32 may become silently lossy if types change
+  --> $DIR/cast.rs:40:5
+   |
+40 |     1u16 as i32;
+   |     ^^^^^^^^^^^ help: try: `i32::from(1u16)`
+
+error: casting u16 to i64 may become silently lossy if types change
+  --> $DIR/cast.rs:41:5
+   |
+41 |     1u16 as i64;
+   |     ^^^^^^^^^^^ help: try: `i64::from(1u16)`
+
+error: casting u16 to u32 may become silently lossy if types change
+  --> $DIR/cast.rs:42:5
+   |
+42 |     1u16 as u32;
+   |     ^^^^^^^^^^^ help: try: `u32::from(1u16)`
+
+error: casting u16 to u64 may become silently lossy if types change
+  --> $DIR/cast.rs:43:5
+   |
+43 |     1u16 as u64;
+   |     ^^^^^^^^^^^ help: try: `u64::from(1u16)`
+
+error: casting i32 to i64 may become silently lossy if types change
+  --> $DIR/cast.rs:44:5
+   |
+44 |     1i32 as i64;
+   |     ^^^^^^^^^^^ help: try: `i64::from(1i32)`
+
+error: casting u32 to i64 may become silently lossy if types change
+  --> $DIR/cast.rs:45:5
+   |
+45 |     1u32 as i64;
+   |     ^^^^^^^^^^^ help: try: `i64::from(1u32)`
+
+error: casting u32 to u64 may become silently lossy if types change
+  --> $DIR/cast.rs:46:5
+   |
+46 |     1u32 as u64;
+   |     ^^^^^^^^^^^ help: try: `u64::from(1u32)`
+
+error: casting i8 to f32 may become silently lossy if types change
+  --> $DIR/cast.rs:48:5
+   |
+48 |     1i8 as f32;
+   |     ^^^^^^^^^^ help: try: `f32::from(1i8)`
+
+error: casting i8 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:49:5
+   |
+49 |     1i8 as f64;
+   |     ^^^^^^^^^^ help: try: `f64::from(1i8)`
+
+error: casting u8 to f32 may become silently lossy if types change
+  --> $DIR/cast.rs:50:5
+   |
+50 |     1u8 as f32;
+   |     ^^^^^^^^^^ help: try: `f32::from(1u8)`
+
+error: casting u8 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:51:5
+   |
+51 |     1u8 as f64;
+   |     ^^^^^^^^^^ help: try: `f64::from(1u8)`
+
+error: casting i16 to f32 may become silently lossy if types change
+  --> $DIR/cast.rs:52:5
+   |
+52 |     1i16 as f32;
+   |     ^^^^^^^^^^^ help: try: `f32::from(1i16)`
+
+error: casting i16 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:53:5
+   |
+53 |     1i16 as f64;
+   |     ^^^^^^^^^^^ help: try: `f64::from(1i16)`
+
+error: casting u16 to f32 may become silently lossy if types change
+  --> $DIR/cast.rs:54:5
+   |
+54 |     1u16 as f32;
+   |     ^^^^^^^^^^^ help: try: `f32::from(1u16)`
+
+error: casting u16 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:55:5
+   |
+55 |     1u16 as f64;
+   |     ^^^^^^^^^^^ help: try: `f64::from(1u16)`
+
+error: casting i32 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:56:5
+   |
+56 |     1i32 as f64;
+   |     ^^^^^^^^^^^ help: try: `f64::from(1i32)`
+
+error: casting u32 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:57:5
+   |
+57 |     1u32 as f64;
+   |     ^^^^^^^^^^^ help: try: `f64::from(1u32)`
+
+error: casting f32 to f64 may become silently lossy if types change
+  --> $DIR/cast.rs:59:5
+   |
+59 |     1.0f32 as f64;
+   |     ^^^^^^^^^^^^^ help: try: `f64::from(1.0f32)`
+
+error: casting i32 to u32 may lose the sign of the value
+  --> $DIR/cast.rs:61:5
+   |
+61 |     1i32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting isize to usize may lose the sign of the value
-  --> $DIR/cast.rs:32:5
+  --> $DIR/cast.rs:62:5
    |
-32 |     1isize as usize;
+62 |     1isize as usize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting isize to i8 may truncate the value
-  --> $DIR/cast.rs:35:5
+  --> $DIR/cast.rs:65:5
    |
-35 |     1isize as i8;
+65 |     1isize as i8;
    |     ^^^^^^^^^^^^
 
 error: casting isize to f64 causes a loss of precision on targets with 64-bit wide pointers (isize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:36:5
+  --> $DIR/cast.rs:66:5
    |
-36 |     1isize as f64;
+66 |     1isize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:37:5
+  --> $DIR/cast.rs:67:5
    |
-37 |     1usize as f64;
+67 |     1usize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to f32 causes a loss of precision (isize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:38:5
+  --> $DIR/cast.rs:68:5
    |
-38 |     1isize as f32;
+68 |     1isize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:39:5
+  --> $DIR/cast.rs:69:5
    |
-39 |     1usize as f32;
+69 |     1usize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:40:5
+  --> $DIR/cast.rs:70:5
    |
-40 |     1isize as i32;
+70 |     1isize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may lose the sign of the value
-  --> $DIR/cast.rs:41:5
+  --> $DIR/cast.rs:71:5
    |
-41 |     1isize as u32;
+71 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:41:5
+  --> $DIR/cast.rs:71:5
    |
-41 |     1isize as u32;
+71 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:42:5
+  --> $DIR/cast.rs:72:5
    |
-42 |     1usize as u32;
+72 |     1usize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:43:5
+  --> $DIR/cast.rs:73:5
    |
-43 |     1usize as i32;
+73 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:43:5
+  --> $DIR/cast.rs:73:5
    |
-43 |     1usize as i32;
+73 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:45:5
+  --> $DIR/cast.rs:75:5
    |
-45 |     1i64 as isize;
+75 |     1i64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may lose the sign of the value
-  --> $DIR/cast.rs:46:5
+  --> $DIR/cast.rs:76:5
    |
-46 |     1i64 as usize;
+76 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:46:5
+  --> $DIR/cast.rs:76:5
    |
-46 |     1i64 as usize;
+76 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:47:5
+  --> $DIR/cast.rs:77:5
    |
-47 |     1u64 as isize;
+77 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may wrap around the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:47:5
+  --> $DIR/cast.rs:77:5
    |
-47 |     1u64 as isize;
+77 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:48:5
+  --> $DIR/cast.rs:78:5
    |
-48 |     1u64 as usize;
+78 |     1u64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u32 to isize may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:49:5
+  --> $DIR/cast.rs:79:5
    |
-49 |     1u32 as isize;
+79 |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i32 to usize may lose the sign of the value
-  --> $DIR/cast.rs:52:5
+  --> $DIR/cast.rs:82:5
    |
-52 |     1i32 as usize;
+82 |     1i32 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:54:5
+  --> $DIR/cast.rs:84:5
    |
-54 |     1i32 as i32;
+84 |     1i32 as i32;
    |     ^^^^^^^^^^^
    |
    = note: `-D unnecessary-cast` implied by `-D warnings`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:55:5
+  --> $DIR/cast.rs:85:5
    |
-55 |     1f32 as f32;
+85 |     1f32 as f32;
    |     ^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:56:5
+  --> $DIR/cast.rs:86:5
    |
-56 |     false as bool;
+86 |     false as bool;
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 45 previous errors
+error: aborting due to 74 previous errors
 


### PR DESCRIPTION
This patch adds a lint for numeric casts that are always lossless. Such casts can be replaced by safe conversion functions.

Rust's ~~`at`~~`as` keyword will perform many kinds of conversions, including silently lossy conversions. Conversion functions such as `i32::from` will only perform lossless conversions. Using the conversion functions prevents conversions from turning into silent lossy conversions if the types of the input expressions ever change, and make it easier for people reading the code to know that the conversion is lossless.

I'm new to Rust, and would also be interested in other approaches.