### PR TITLE
Fix let_unit_value with for loop iterating over units

### DIFF
--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -114,6 +114,13 @@ pub fn range(expr: &hir::Expr) -> Option<Range> {
 
 /// Checks if a `let` decl is from a `for` loop desugaring.
 pub fn is_from_for_desugar(decl: &hir::Decl) -> bool {
+    // This will detect plain for-loops without an actual variable binding:
+    //
+    // ```
+    // for x in some_vec {
+    //   // do stuff
+    // }
+    // ```
     if_let_chain! {[
         let hir::DeclLocal(ref loc) = decl.node,
         let Some(ref expr) = loc.init,

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -121,6 +121,22 @@ pub fn is_from_for_desugar(decl: &hir::Decl) -> bool {
     ], {
         return true;
     }}
+
+    // This detects a variable binding in for loop to avoid `let_unit_value`
+    // lint (see issue #1964).
+    //
+    // ```
+    // for _ in vec![()] {
+    //   // anything
+    // }
+    // ```
+    if_let_chain! {[
+        let hir::DeclLocal(ref loc) = decl.node,
+        let hir::LocalSource::ForLoopDesugar = loc.source,
+    ], {
+        return true;
+    }}
+
     false
 }
 

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -33,9 +33,11 @@ fn consume_units_with_for_loop() {
     }
     assert_eq!(count, 3);
 
-    // Same for consuming from some other Iterator<()>.
+    // Same for consuming from some other Iterator<Item = ()>.
     let (tx, rx) = ::std::sync::mpsc::channel();
     tx.send(()).unwrap();
+    drop(tx);
+
     count = 0;
     for _ in rx.iter() {
         count += 1;

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -18,7 +18,29 @@ fn main() {
         let _a = ();
     }
 
+    consume_units_with_for_loop(); // should be fine as well
+
     let_and_return!(()) // should be fine
+}
+
+// Related to issue #1964
+fn consume_units_with_for_loop() {
+    // `for_let_unit` lint should not be triggered by consuming them using for loop.
+    let v = vec![(), (), ()];
+    let mut count = 0;
+    for _ in v {
+        count += 1;
+    }
+    assert_eq!(count, 3);
+
+    // Same for consuming from some other Iterator<()>.
+    let (tx, rx) = ::std::sync::mpsc::channel();
+    tx.send(()).unwrap();
+    count = 0;
+    for _ in rx.iter() {
+        count += 1;
+    }
+    assert_eq!(count, 1);
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This will fix #1964, which simplifies to the code below getting lint `let_unit_value`:

```
for _ in &[()] {
  // anything
}
```

Fix is to modify `is_from_for_desugar` to detect HIR-level `let _ = for _ in ... {}` in addition to the previously detected HIR-level `let _ = for something in ... {}`. Also adds comments to explain the previous desugaring detection.

Does not add the test case suggested by @oli-obk:
> Also add an example that would have triggered if the first if_let_chain were removed, so we don't have to hope dogfood will catch it but have an explicit test in the suite.

I did not add a new case because commenting out the first check (and disabling `tests/dogfood.rs`) will cause a large number of `tests/ui/for_loop.rs` to receive `for_let_unit` lints such as:

```
error: this let-binding has unit value. Consider omitting `let for _v in hm.iter() { } =`
   --> $DIR/for_loop.rs:234:5
    |
234 |     for _v in hm.iter() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^
```

Only ui-test changes are included as I didn't find any test cases for the `is_from_for_desugar`. I'd imagine something like the example below would be awesome but might not be possible at the moment (I don't know the rustc at all).

```
assert!(is_from_for_desugar(hir! { for _ in 0.. {} });
```