### PR TITLE
remove stars at the beginning of multiline comments

### DIFF
--- a/tests/ui/doc.rs
+++ b/tests/ui/doc.rs
@@ -153,3 +153,9 @@ fn issue_902_comment() {}
 /// }
 /// ```
 fn issue_1469() {}
+
+/**
+ * This is a doc comment that should not be a list
+ *This would also be an error under a strict common mark interpretation
+ */
+fn issue_1920() {}


### PR DESCRIPTION
This fixes #1920 (at least the docs should no longer be a problem)