### PR TITLE
fix #768 by checking for message macro expansion

### DIFF
--- a/clippy_lints/src/panic.rs
+++ b/clippy_lints/src/panic.rs
@@ -45,7 +45,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             is_direct_expn_of(expr.span, "panic").is_some(),
             let LitKind::Str(ref string, _) = lit.node,
             let Some(par) = string.as_str().find('{'),
-            string.as_str()[par..].contains('}')
+            string.as_str()[par..].contains('}'),
+            params[0].span.source_callee().is_none()
         ], {
             span_lint(cx, PANIC_PARAMS, params[0].span,
                       "you probably are missing some parameter in your format string");

--- a/tests/ui/panic.rs
+++ b/tests/ui/panic.rs
@@ -34,10 +34,18 @@ fn ok_bracket() {
     }
 }
 
+const ONE : u32= 1;
+
+fn ok_nomsg() {
+    assert!({ 1 == ONE });
+    assert!(if 1 == ONE { ONE == 1 } else { false });
+}
+
 fn main() {
     missing();
     ok_single();
     ok_multiple();
     ok_bracket();
     ok_inner();
+    ok_nomsg();
 }

--- a/tests/ui/panic.stderr
+++ b/tests/ui/panic.stderr
@@ -18,13 +18,5 @@ error: you probably are missing some parameter in your format string
 12 |         assert!(true, "here be missing values: {}");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: you probably are missing some parameter in your format string
-  --> $DIR/panic.rs:22:5
-   |
-22 |     assert!("foo bar".contains(&format!("foo {}", "bar")));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro outside of the current crate
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #768. Fixes #1706.

This just checks if the format string was itself macro-expanded. A more thorough check would look if the macro expansion was a `concat!` with a `stringify!`, but this should work well enough for now.