### PR TITLE
lint #1674: lifetimed types exclusion

### DIFF
--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -79,24 +79,6 @@ error: methods called `new` usually return `Self`
    = note: `-D new-ret-no-self` implied by `-D warnings`
 
 error: unnecessary structure name repetition
-  --> $DIR/methods.rs:40:35
-   |
-40 |     pub fn new<'b>(s: &'b str) -> Lt<'b> { unimplemented!() }
-   |                                   ^^^^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
-  --> $DIR/methods.rs:49:28
-   |
-49 |     pub fn new(s: &str) -> Lt2 { unimplemented!() }
-   |                            ^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
-  --> $DIR/methods.rs:58:21
-   |
-58 |     pub fn new() -> Lt3<'static> { unimplemented!() }
-   |                     ^^^^^^^^^^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
   --> $DIR/methods.rs:74:24
    |
 74 |     fn new() -> Option<V<T>> { None }
@@ -730,5 +712,5 @@ error: called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec
     |
     = note: `-D iter-cloned-collect` implied by `-D warnings`
 
-error: aborting due to 106 previous errors
+error: aborting due to 103 previous errors
 

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -2,6 +2,7 @@
 #![plugin(clippy)]
 #![warn(use_self)]
 #![allow(dead_code)]
+#![allow(should_implement_trait)]
 
 
 fn main() {}
@@ -40,6 +41,28 @@ mod better {
     impl Default for Foo {
         fn default() -> Self {
             Self::new()
+        }
+    }
+}
+
+//todo the lint does not handle lifetimed struct
+//the following module should trigger the lint on the third method only
+mod lifetimes {
+    struct Foo<'a>{foo_str: &'a str}
+
+    impl<'a> Foo<'a> {
+        // Cannot use `Self` as return type, because the function is actually `fn foo<'b>(s: &'b str) -> Foo<'b>`
+        fn foo(s: &str) -> Foo {
+            Foo { foo_str: s }
+        }
+        // cannot replace with `Self`, because that's `Foo<'a>`
+        fn bar() -> Foo<'static> {
+            Foo { foo_str: "foo"}
+        }
+
+        // `Self` is applicable here
+        fn clone(&self) -> Foo<'a> {
+            Foo {foo_str: self.foo_str}
         }
     }
 }

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -1,39 +1,39 @@
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:13:21
+  --> $DIR/use_self.rs:14:21
    |
-13 |         fn new() -> Foo {
+14 |         fn new() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
    |
    = note: `-D use-self` implied by `-D warnings`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:14:13
+  --> $DIR/use_self.rs:15:13
    |
-14 |             Foo {}
+15 |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:16:22
+  --> $DIR/use_self.rs:17:22
    |
-16 |         fn test() -> Foo {
+17 |         fn test() -> Foo {
    |                      ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:17:13
+  --> $DIR/use_self.rs:18:13
    |
-17 |             Foo::new()
+18 |             Foo::new()
    |             ^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:22:25
+  --> $DIR/use_self.rs:23:25
    |
-22 |         fn default() -> Foo {
+23 |         fn default() -> Foo {
    |                         ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:23:13
+  --> $DIR/use_self.rs:24:13
    |
-23 |             Foo::new()
+24 |             Foo::new()
    |             ^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: aborting due to 6 previous errors


### PR DESCRIPTION
The `use_self` lint (issue #1674) causes false positives on "lifetimed" structures. This excludes them from linting for now. See PR #1965.