### PR TITLE
CONTRIBUTING: add manual testing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,19 @@ Of course there's little sense in writing the output yourself or copying it arou
 Therefore you can simply run `tests/ui/update-all-references.sh` and check whether
 the output looks as you expect with `git diff`. Commit all `*.stderr` files, too.
 
+### Testing manually
+
+Manually testing against an example file is useful if you have added some
+`println!`s and test suite output becomes unreadable.  To try clippy with your
+local modifications, run `cargo run -- -L ./target/debug input.rs` from the
+working copy root. Your test file, here `input.rs`, needs to have clippy
+enabled as a plugin:
+
+```rust
+#![feature(plugin)]
+#![plugin(clippy)]
+```
+
 ## Contributions
 
 Clippy welcomes contributions from everyone.


### PR DESCRIPTION
When I created my first PR #1967 it took some `println!`s to understand what was going on with the HIR matching. I looked and asked around for advice on how to run my local version but eventually figured it out myself. I am not sure if this is the correct way though.

I think mentioning how to manually test local clippy build might help anyone learning clippy with the trusted `println!` method :)