### PR TITLE
Rename `match_path_old` to `match_path`

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -3,7 +3,7 @@ use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use syntax::codemap::Span;
 use utils::paths;
-use utils::{is_automatically_derived, span_lint_and_then, match_path_old, is_copy};
+use utils::{is_automatically_derived, span_lint_and_then, match_path, is_copy};
 
 /// **What it does:** Checks for deriving `Hash` but implementing `PartialEq`
 /// explicitly.
@@ -92,7 +92,7 @@ fn check_hash_peq<'a, 'tcx>(
     hash_is_automatically_derived: bool,
 ) {
     if_let_chain! {[
-        match_path_old(&trait_ref.path, &paths::HASH),
+        match_path(&trait_ref.path, &paths::HASH),
         let Some(peq_trait_def_id) = cx.tcx.lang_items.eq_trait()
     ], {
         // Look for the PartialEq implementations for `ty`
@@ -132,7 +132,7 @@ fn check_hash_peq<'a, 'tcx>(
 
 /// Implementation of the `EXPL_IMPL_CLONE_ON_COPY` lint.
 fn check_copy_clone<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, item: &Item, trait_ref: &TraitRef, ty: Ty<'tcx>) {
-    if match_path_old(&trait_ref.path, &paths::CLONE_TRAIT) {
+    if match_path(&trait_ref.path, &paths::CLONE_TRAIT) {
         if !is_copy(cx, ty) {
             return;
         }

--- a/clippy_lints/src/if_let_redundant_pattern_matching.rs
+++ b/clippy_lints/src/if_let_redundant_pattern_matching.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use syntax::codemap::Span;
-use utils::{paths, span_lint_and_then, match_path, snippet};
+use utils::{paths, span_lint_and_then, match_qpath, snippet};
 
 /// **What it does:*** Lint for redundant pattern matching over `Result` or
 /// `Option`
@@ -53,18 +53,18 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
                 let good_method = match arms[0].pats[0].node {
                     PatKind::TupleStruct(ref path, ref pats, _) if pats.len() == 1 && pats[0].node == PatKind::Wild => {
-                        if match_path(path, &paths::RESULT_OK) {
+                        if match_qpath(path, &paths::RESULT_OK) {
                             "is_ok()"
-                        } else if match_path(path, &paths::RESULT_ERR) {
+                        } else if match_qpath(path, &paths::RESULT_ERR) {
                             "is_err()"
-                        } else if match_path(path, &paths::OPTION_SOME) {
+                        } else if match_qpath(path, &paths::OPTION_SOME) {
                             "is_some()"
                         } else {
                             return;
                         }
                     },
 
-                    PatKind::Path(ref path) if match_path(path, &paths::OPTION_NONE) => "is_none()",
+                    PatKind::Path(ref path) if match_qpath(path, &paths::OPTION_NONE) => "is_none()",
 
                     _ => return,
                 };

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -2,7 +2,7 @@ use rustc::lint::*;
 use rustc::hir::*;
 use rustc::ty;
 use syntax::ast;
-use utils::{is_adjusted, match_path, match_trait_method, match_type, remove_blocks, paths, snippet,
+use utils::{is_adjusted, match_qpath, match_trait_method, match_type, remove_blocks, paths, snippet,
             span_help_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth, iter_input_pats};
 
 /// **What it does:** Checks for mapping `clone()` over an iterator.
@@ -74,7 +74,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                         }}
                     },
                     ExprPath(ref path) => {
-                        if match_path(path, &paths::CLONE) {
+                        if match_qpath(path, &paths::CLONE) {
                             let type_name = get_type_name(cx, expr, &args[0]).unwrap_or("_");
                             span_help_and_lint(
                                 cx,

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -8,10 +8,10 @@ use rustc_const_eval::ConstContext;
 use std::borrow::Cow;
 use std::fmt;
 use syntax::codemap::Span;
-use utils::{get_trait_def_id, implements_trait, in_external_macro, in_macro, is_copy, match_path, match_trait_method,
+use utils::{get_trait_def_id, implements_trait, in_external_macro, in_macro, is_copy, match_qpath, match_trait_method,
             match_type, method_chain_args, return_ty, same_tys, snippet, span_lint, span_lint_and_then,
             span_lint_and_sugg, span_note_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth, last_path_segment,
-            single_segment_path, match_def_path, is_self, is_self_ty, iter_input_pats, match_path_old};
+            single_segment_path, match_def_path, is_self, is_self_ty, iter_input_pats, match_path};
 use utils::paths;
 use utils::sugg;
 
@@ -1462,7 +1462,7 @@ fn is_as_ref_or_mut_trait(ty: &hir::Ty, self_ty: &hir::Ty, generics: &hir::Gener
                 param.bounds.iter().any(|bound| {
                     if let hir::TyParamBound::TraitTyParamBound(ref ptr, ..) = *bound {
                         let path = &ptr.trait_ref.path;
-                        match_path_old(path, name) &&
+                        match_path(path, name) &&
                             path.segments.last().map_or(false, |s| {
                                 if let hir::PathParameters::AngleBracketedParameters(ref data) = s.parameters {
                                     data.types.len() == 1 &&
@@ -1540,7 +1540,7 @@ impl OutType {
 
 fn is_bool(ty: &hir::Ty) -> bool {
     if let hir::TyPath(ref p) = ty.node {
-        match_path(p, &["bool"])
+        match_qpath(p, &["bool"])
     } else {
         false
     }

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -8,7 +8,7 @@ use rustc::ty::subst::Substs;
 use rustc_const_eval::ConstContext;
 use rustc_const_math::ConstFloat;
 use syntax::codemap::{Span, ExpnFormat};
-use utils::{get_item_name, get_parent_expr, implements_trait, in_macro, is_integer_literal, match_path, snippet,
+use utils::{get_item_name, get_parent_expr, implements_trait, in_macro, is_integer_literal, match_qpath, snippet,
             span_lint, span_lint_and_then, walk_ptrs_ty, last_path_segment, iter_input_pats, in_constant,
             match_trait_method, paths};
 use utils::sugg::Sugg;
@@ -486,7 +486,7 @@ fn check_to_owned(cx: &LateContext, expr: &Expr, other: &Expr) {
         },
         ExprCall(ref path, ref v) if v.len() == 1 => {
             if let ExprPath(ref path) = path.node {
-                if match_path(path, &["String", "from_str"]) || match_path(path, &["String", "from"]) {
+                if match_qpath(path, &["String", "from_str"]) || match_qpath(path, &["String", "from"]) {
                     (cx.tables.expr_ty_adjusted(&v[0]), snippet(cx, v[0].span, ".."))
                 } else {
                     return;

--- a/clippy_lints/src/print.rs
+++ b/clippy_lints/src/print.rs
@@ -2,7 +2,7 @@ use rustc::hir::*;
 use rustc::hir::map::Node::{NodeItem, NodeImplItem};
 use rustc::lint::*;
 use utils::paths;
-use utils::{is_expn_of, match_def_path, resolve_node, span_lint, match_path_old};
+use utils::{is_expn_of, match_def_path, resolve_node, span_lint, match_path};
 use format::get_argument_fmtstr_parts;
 
 /// **What it does:** This lint warns when you using `print!()` with a format
@@ -144,7 +144,7 @@ fn is_in_debug_impl(cx: &LateContext, expr: &Expr) -> bool {
         // `Debug` impl
         if let Some(NodeItem(item)) = map.find(map.get_parent(item.id)) {
             if let ItemImpl(_, _, _, _, Some(ref tr), _, _) = item.node {
-                return match_path_old(&tr.path, &["Debug"]);
+                return match_path(&tr.path, &["Debug"]);
             }
         }
     }

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -7,7 +7,7 @@ use rustc::ty;
 use syntax::ast::NodeId;
 use syntax::codemap::Span;
 use syntax_pos::MultiSpan;
-use utils::{match_path, match_type, paths, span_lint, span_lint_and_then};
+use utils::{match_qpath, match_type, paths, span_lint, span_lint_and_then};
 
 /// **What it does:** This lint checks for function arguments of type `&String`
 /// or `&Vec` unless
@@ -190,7 +190,7 @@ fn is_null_path(expr: &Expr) -> bool {
     if let ExprCall(ref pathexp, ref args) = expr.node {
         if args.is_empty() {
             if let ExprPath(ref path) = pathexp.node {
-                return match_path(path, &paths::PTR_NULL) || match_path(path, &paths::PTR_NULL_MUT);
+                return match_qpath(path, &paths::PTR_NULL) || match_qpath(path, &paths::PTR_NULL_MUT);
             }
         }
     }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -10,7 +10,7 @@ use syntax::ast::{IntTy, UintTy, FloatTy};
 use syntax::attr::IntType;
 use syntax::codemap::Span;
 use utils::{comparisons, higher, in_external_macro, in_macro, match_def_path, snippet, span_help_and_lint, span_lint,
-            span_lint_and_sugg, opt_def_id, last_path_segment, type_size, match_path_old};
+            span_lint_and_sugg, opt_def_id, last_path_segment, type_size, match_path};
 use utils::paths;
 
 /// Handles all the linting of funky types
@@ -261,7 +261,7 @@ fn is_any_trait(t: &hir::Ty) -> bool {
         traits.len() >= 1,
         // Only Send/Sync can be used as additional traits, so it is enough to
         // check only the first trait.
-        match_path_old(&traits[0].trait_ref.path, &paths::ANY_TRAIT)
+        match_path(&traits[0].trait_ref.path, &paths::ANY_TRAIT)
     ], {
         return true;
     }}

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir;
-use utils::{span_lint, match_path, match_trait_method, is_try, paths};
+use utils::{span_lint, match_qpath, match_trait_method, is_try, paths};
 
 /// **What it does:** Checks for unused written/read amount.
 ///
@@ -49,7 +49,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedIoAmount {
             hir::ExprMatch(ref res, _, _) if is_try(expr).is_some() => {
                 if let hir::ExprCall(ref func, ref args) = res.node {
                     if let hir::ExprPath(ref path) = func.node {
-                        if match_path(path, &paths::TRY_INTO_RESULT) && args.len() == 1 {
+                        if match_qpath(path, &paths::TRY_INTO_RESULT) && args.len() == 1 {
                             check_method_call(cx, &args[0], expr);
                         }
                     }

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -428,7 +428,7 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
     }
 
     fn visit_qpath(&mut self, path: &QPath, _: NodeId, _: Span) {
-        print!("    match_path({}, &[", self.current);
+        print!("    match_qpath({}, &[", self.current);
         print_path(path, &mut true);
         println!("]),");
     }

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -6,7 +6,7 @@
 use rustc::hir;
 use rustc::lint::LateContext;
 use syntax::ast;
-use utils::{is_expn_of, match_path, match_def_path, resolve_node, paths};
+use utils::{is_expn_of, match_qpath, match_def_path, resolve_node, paths};
 
 /// Convert a hir binary operator to the corresponding `ast` type.
 pub fn binop(op: hir::BinOp_) -> ast::BinOpKind {
@@ -63,7 +63,7 @@ pub fn range(expr: &hir::Expr) -> Option<Range> {
 
     match expr.node {
         hir::ExprPath(ref path) => {
-            if match_path(path, &paths::RANGE_FULL_STD) || match_path(path, &paths::RANGE_FULL) {
+            if match_qpath(path, &paths::RANGE_FULL_STD) || match_qpath(path, &paths::RANGE_FULL) {
                 Some(Range {
                     start: None,
                     end: None,
@@ -74,31 +74,31 @@ pub fn range(expr: &hir::Expr) -> Option<Range> {
             }
         },
         hir::ExprStruct(ref path, ref fields, None) => {
-            if match_path(path, &paths::RANGE_FROM_STD) || match_path(path, &paths::RANGE_FROM) {
+            if match_qpath(path, &paths::RANGE_FROM_STD) || match_qpath(path, &paths::RANGE_FROM) {
                 Some(Range {
                     start: get_field("start", fields),
                     end: None,
                     limits: ast::RangeLimits::HalfOpen,
                 })
-            } else if match_path(path, &paths::RANGE_INCLUSIVE_STD) || match_path(path, &paths::RANGE_INCLUSIVE) {
+            } else if match_qpath(path, &paths::RANGE_INCLUSIVE_STD) || match_qpath(path, &paths::RANGE_INCLUSIVE) {
                 Some(Range {
                     start: get_field("start", fields),
                     end: get_field("end", fields),
                     limits: ast::RangeLimits::Closed,
                 })
-            } else if match_path(path, &paths::RANGE_STD) || match_path(path, &paths::RANGE) {
+            } else if match_qpath(path, &paths::RANGE_STD) || match_qpath(path, &paths::RANGE) {
                 Some(Range {
                     start: get_field("start", fields),
                     end: get_field("end", fields),
                     limits: ast::RangeLimits::HalfOpen,
                 })
-            } else if match_path(path, &paths::RANGE_TO_INCLUSIVE_STD) || match_path(path, &paths::RANGE_TO_INCLUSIVE) {
+            } else if match_qpath(path, &paths::RANGE_TO_INCLUSIVE_STD) || match_qpath(path, &paths::RANGE_TO_INCLUSIVE) {
                 Some(Range {
                     start: None,
                     end: get_field("end", fields),
                     limits: ast::RangeLimits::Closed,
                 })
-            } else if match_path(path, &paths::RANGE_TO_STD) || match_path(path, &paths::RANGE_TO) {
+            } else if match_qpath(path, &paths::RANGE_TO_STD) || match_qpath(path, &paths::RANGE_TO) {
                 Some(Range {
                     start: None,
                     end: get_field("end", fields),

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use rustc::hir::intravisit::{Visitor, walk_expr, NestedVisitorMap};
-use utils::{paths, match_path, span_lint};
+use utils::{paths, match_qpath, span_lint};
 use syntax::symbol::InternedString;
 use syntax::ast::{Name, NodeId, ItemKind, Crate as AstCrate};
 use syntax::codemap::Span;
@@ -167,7 +167,7 @@ fn is_lint_ref_type(ty: &Ty) -> bool {
             return false;
         }
         if let TyPath(ref path) = inner.node {
-            return match_path(path, &paths::LINT);
+            return match_qpath(path, &paths::LINT);
         }
     }
     false
@@ -176,7 +176,7 @@ fn is_lint_ref_type(ty: &Ty) -> bool {
 
 fn is_lint_array_type(ty: &Ty) -> bool {
     if let TyPath(ref path) = ty.node {
-        match_path(path, &paths::LINT_ARRAY)
+        match_qpath(path, &paths::LINT_ARRAY)
     } else {
         false
     }

--- a/tests/ui/trailing_zeros.stdout
+++ b/tests/ui/trailing_zeros.stdout
@@ -4,7 +4,7 @@ if_let_chain!{[
     let Expr_::ExprBinary(ref op1, ref left1, ref right1) = left.node,
     BinOp_::BiBitAnd == op1.node,
     let Expr_::ExprPath(ref path) = left1.node,
-    match_path(path, &["x"]),
+    match_qpath(path, &["x"]),
     let Expr_::ExprLit(ref lit) = right1.node,
     let LitKind::Int(15, _) = lit.node,
     let Expr_::ExprLit(ref lit1) = right.node,


### PR DESCRIPTION
The old `match_path` was renamed to `match_qpath`.

I haven't renamed the [`match_path_ast`](https://github.com/rust-lang-nursery/rust-clippy/blob/master/clippy_lints/src/utils/mod.rs#L272) function, let me know if I should.

As per #1983.