### PR TITLE
When suggesting `from(x)` for lossless casts, strip parens from `x`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Upcoming
+* New lint: [`manual_memcpy`]
+
 ## 0.0.157 - 2017-09-04
 * Update to *rustc 1.22.0-nightly (981ce7d8d 2017-09-03)*
 * New lint: [`unit_expr`]
@@ -511,6 +514,7 @@ All notable changes to this project will be documented in this file.
 [`let_unit_value`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#let_unit_value
 [`linkedlist`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#linkedlist
 [`logic_bug`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#logic_bug
+[`manual_memcpy`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#manual_memcpy
 [`manual_swap`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#manual_swap
 [`many_single_char_names`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#many_single_char_names
 [`map_clone`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#map_clone

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -444,6 +444,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         loops::FOR_LOOP_OVER_OPTION,
         loops::FOR_LOOP_OVER_RESULT,
         loops::ITER_NEXT_LOOP,
+        loops::MANUAL_MEMCPY,
         loops::NEEDLESS_RANGE_LOOP,
         loops::NEVER_LOOP,
         loops::REVERSE_RANGE_LOOP,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -580,12 +580,21 @@ fn span_precision_loss_lint(cx: &LateContext, expr: &Expr, cast_from: Ty, cast_t
     );
 }
 
+fn should_strip_parens(op: &Expr, snip: &str) -> bool {
+    if let ExprBinary(_, _, _) = op.node {
+        if snip.starts_with('(') && snip.ends_with(')') {
+            return true;
+        }
+    }
+    false
+}
+
 fn span_lossless_lint(cx: &LateContext, expr: &Expr, op: &Expr, cast_from: Ty, cast_to: Ty) {
     // The suggestion is to use a function call, so if the original expression
     // has parens on the outside, they are no longer needed.
     let opt = snippet_opt(cx, op.span);
     let sugg = if let Some(ref snip) = opt {
-        if snip.starts_with('(') && snip.ends_with(')') {
+        if should_strip_parens(op, snip) {
             &snip[1..snip.len()-1]
         } else {
             snip.as_str()

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -57,6 +57,8 @@ fn main() {
     1u32 as f64;
     // Test cast_lossless with casts from floating-point types
     1.0f32 as f64;
+    // Test cast_lossless with an expression wrapped in parens
+    (1u8 + 1u8) as u16;
     // Test cast_sign_loss
     1i32 as u32;
     1isize as usize;

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -59,7 +59,6 @@ fn main() {
     1.0f32 as f64;
     // Test cast_lossless with an expression wrapped in parens
     (1u8 + 1u8) as u16;
-    (1u16) + (1u8) as u16;
     // Test cast_sign_loss
     1i32 as u32;
     1isize as usize;

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -59,6 +59,7 @@ fn main() {
     1.0f32 as f64;
     // Test cast_lossless with an expression wrapped in parens
     (1u8 + 1u8) as u16;
+    (1u16) + (1u8) as u16;
     // Test cast_sign_loss
     1i32 as u32;
     1isize as usize;

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -314,151 +314,157 @@ error: casting u8 to u16 may become silently lossy if types change
 61 |     (1u8 + 1u8) as u16;
    |     ^^^^^^^^^^^^^^^^^^ help: try: `u16::from(1u8 + 1u8)`
 
-error: casting i32 to u32 may lose the sign of the value
-  --> $DIR/cast.rs:63:5
+error: casting u8 to u16 may become silently lossy if types change
+  --> $DIR/cast.rs:62:14
    |
-63 |     1i32 as u32;
+62 |     (1u16) + (1u8) as u16;
+   |              ^^^^^^^^^^^^ help: try: `u16::from(1u8)`
+
+error: casting i32 to u32 may lose the sign of the value
+  --> $DIR/cast.rs:64:5
+   |
+64 |     1i32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting isize to usize may lose the sign of the value
-  --> $DIR/cast.rs:64:5
+  --> $DIR/cast.rs:65:5
    |
-64 |     1isize as usize;
+65 |     1isize as usize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting isize to i8 may truncate the value
-  --> $DIR/cast.rs:67:5
+  --> $DIR/cast.rs:68:5
    |
-67 |     1isize as i8;
+68 |     1isize as i8;
    |     ^^^^^^^^^^^^
 
 error: casting isize to f64 causes a loss of precision on targets with 64-bit wide pointers (isize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:68:5
+  --> $DIR/cast.rs:69:5
    |
-68 |     1isize as f64;
+69 |     1isize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:69:5
+  --> $DIR/cast.rs:70:5
    |
-69 |     1usize as f64;
+70 |     1usize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to f32 causes a loss of precision (isize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:70:5
+  --> $DIR/cast.rs:71:5
    |
-70 |     1isize as f32;
+71 |     1isize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:71:5
+  --> $DIR/cast.rs:72:5
    |
-71 |     1usize as f32;
+72 |     1usize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:72:5
+  --> $DIR/cast.rs:73:5
    |
-72 |     1isize as i32;
+73 |     1isize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may lose the sign of the value
-  --> $DIR/cast.rs:73:5
+  --> $DIR/cast.rs:74:5
    |
-73 |     1isize as u32;
+74 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:73:5
+  --> $DIR/cast.rs:74:5
    |
-73 |     1isize as u32;
+74 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:74:5
+  --> $DIR/cast.rs:75:5
    |
-74 |     1usize as u32;
+75 |     1usize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:75:5
+  --> $DIR/cast.rs:76:5
    |
-75 |     1usize as i32;
+76 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:75:5
+  --> $DIR/cast.rs:76:5
    |
-75 |     1usize as i32;
+76 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:77:5
+  --> $DIR/cast.rs:78:5
    |
-77 |     1i64 as isize;
+78 |     1i64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may lose the sign of the value
-  --> $DIR/cast.rs:78:5
+  --> $DIR/cast.rs:79:5
    |
-78 |     1i64 as usize;
+79 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:78:5
+  --> $DIR/cast.rs:79:5
    |
-78 |     1i64 as usize;
+79 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:79:5
+  --> $DIR/cast.rs:80:5
    |
-79 |     1u64 as isize;
+80 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may wrap around the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:79:5
+  --> $DIR/cast.rs:80:5
    |
-79 |     1u64 as isize;
+80 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:80:5
+  --> $DIR/cast.rs:81:5
    |
-80 |     1u64 as usize;
+81 |     1u64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u32 to isize may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:81:5
+  --> $DIR/cast.rs:82:5
    |
-81 |     1u32 as isize;
+82 |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i32 to usize may lose the sign of the value
-  --> $DIR/cast.rs:84:5
+  --> $DIR/cast.rs:85:5
    |
-84 |     1i32 as usize;
+85 |     1i32 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:86:5
+  --> $DIR/cast.rs:87:5
    |
-86 |     1i32 as i32;
+87 |     1i32 as i32;
    |     ^^^^^^^^^^^
    |
    = note: `-D unnecessary-cast` implied by `-D warnings`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:87:5
+  --> $DIR/cast.rs:88:5
    |
-87 |     1f32 as f32;
+88 |     1f32 as f32;
    |     ^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:88:5
+  --> $DIR/cast.rs:89:5
    |
-88 |     false as bool;
+89 |     false as bool;
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 75 previous errors
+error: aborting due to 76 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -314,157 +314,151 @@ error: casting u8 to u16 may become silently lossy if types change
 61 |     (1u8 + 1u8) as u16;
    |     ^^^^^^^^^^^^^^^^^^ help: try: `u16::from(1u8 + 1u8)`
 
-error: casting u8 to u16 may become silently lossy if types change
-  --> $DIR/cast.rs:62:14
-   |
-62 |     (1u16) + (1u8) as u16;
-   |              ^^^^^^^^^^^^ help: try: `u16::from(1u8)`
-
 error: casting i32 to u32 may lose the sign of the value
-  --> $DIR/cast.rs:64:5
+  --> $DIR/cast.rs:63:5
    |
-64 |     1i32 as u32;
+63 |     1i32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting isize to usize may lose the sign of the value
-  --> $DIR/cast.rs:65:5
+  --> $DIR/cast.rs:64:5
    |
-65 |     1isize as usize;
+64 |     1isize as usize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting isize to i8 may truncate the value
-  --> $DIR/cast.rs:68:5
+  --> $DIR/cast.rs:67:5
    |
-68 |     1isize as i8;
+67 |     1isize as i8;
    |     ^^^^^^^^^^^^
 
 error: casting isize to f64 causes a loss of precision on targets with 64-bit wide pointers (isize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:69:5
+  --> $DIR/cast.rs:68:5
    |
-69 |     1isize as f64;
+68 |     1isize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:70:5
+  --> $DIR/cast.rs:69:5
    |
-70 |     1usize as f64;
+69 |     1usize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to f32 causes a loss of precision (isize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:71:5
+  --> $DIR/cast.rs:70:5
    |
-71 |     1isize as f32;
+70 |     1isize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:72:5
+  --> $DIR/cast.rs:71:5
    |
-72 |     1usize as f32;
+71 |     1usize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:73:5
+  --> $DIR/cast.rs:72:5
    |
-73 |     1isize as i32;
+72 |     1isize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may lose the sign of the value
-  --> $DIR/cast.rs:74:5
+  --> $DIR/cast.rs:73:5
    |
-74 |     1isize as u32;
+73 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:74:5
+  --> $DIR/cast.rs:73:5
    |
-74 |     1isize as u32;
+73 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:75:5
+  --> $DIR/cast.rs:74:5
    |
-75 |     1usize as u32;
+74 |     1usize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:76:5
+  --> $DIR/cast.rs:75:5
    |
-76 |     1usize as i32;
+75 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:76:5
+  --> $DIR/cast.rs:75:5
    |
-76 |     1usize as i32;
+75 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:78:5
+  --> $DIR/cast.rs:77:5
    |
-78 |     1i64 as isize;
+77 |     1i64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may lose the sign of the value
-  --> $DIR/cast.rs:79:5
+  --> $DIR/cast.rs:78:5
    |
-79 |     1i64 as usize;
+78 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:79:5
+  --> $DIR/cast.rs:78:5
    |
-79 |     1i64 as usize;
+78 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:80:5
+  --> $DIR/cast.rs:79:5
    |
-80 |     1u64 as isize;
+79 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may wrap around the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:80:5
+  --> $DIR/cast.rs:79:5
    |
-80 |     1u64 as isize;
+79 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:81:5
+  --> $DIR/cast.rs:80:5
    |
-81 |     1u64 as usize;
+80 |     1u64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u32 to isize may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:82:5
+  --> $DIR/cast.rs:81:5
    |
-82 |     1u32 as isize;
+81 |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i32 to usize may lose the sign of the value
-  --> $DIR/cast.rs:85:5
+  --> $DIR/cast.rs:84:5
    |
-85 |     1i32 as usize;
+84 |     1i32 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:87:5
+  --> $DIR/cast.rs:86:5
    |
-87 |     1i32 as i32;
+86 |     1i32 as i32;
    |     ^^^^^^^^^^^
    |
    = note: `-D unnecessary-cast` implied by `-D warnings`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:88:5
+  --> $DIR/cast.rs:87:5
    |
-88 |     1f32 as f32;
+87 |     1f32 as f32;
    |     ^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:89:5
+  --> $DIR/cast.rs:88:5
    |
-89 |     false as bool;
+88 |     false as bool;
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 76 previous errors
+error: aborting due to 75 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -308,151 +308,157 @@ error: casting f32 to f64 may become silently lossy if types change
 59 |     1.0f32 as f64;
    |     ^^^^^^^^^^^^^ help: try: `f64::from(1.0f32)`
 
-error: casting i32 to u32 may lose the sign of the value
+error: casting u8 to u16 may become silently lossy if types change
   --> $DIR/cast.rs:61:5
    |
-61 |     1i32 as u32;
+61 |     (1u8 + 1u8) as u16;
+   |     ^^^^^^^^^^^^^^^^^^ help: try: `u16::from(1u8 + 1u8)`
+
+error: casting i32 to u32 may lose the sign of the value
+  --> $DIR/cast.rs:63:5
+   |
+63 |     1i32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting isize to usize may lose the sign of the value
-  --> $DIR/cast.rs:62:5
+  --> $DIR/cast.rs:64:5
    |
-62 |     1isize as usize;
+64 |     1isize as usize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting isize to i8 may truncate the value
-  --> $DIR/cast.rs:65:5
+  --> $DIR/cast.rs:67:5
    |
-65 |     1isize as i8;
+67 |     1isize as i8;
    |     ^^^^^^^^^^^^
 
 error: casting isize to f64 causes a loss of precision on targets with 64-bit wide pointers (isize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:66:5
+  --> $DIR/cast.rs:68:5
    |
-66 |     1isize as f64;
+68 |     1isize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:67:5
+  --> $DIR/cast.rs:69:5
    |
-67 |     1usize as f64;
+69 |     1usize as f64;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to f32 causes a loss of precision (isize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:68:5
+  --> $DIR/cast.rs:70:5
    |
-68 |     1isize as f32;
+70 |     1isize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:69:5
+  --> $DIR/cast.rs:71:5
    |
-69 |     1usize as f32;
+71 |     1usize as f32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:70:5
+  --> $DIR/cast.rs:72:5
    |
-70 |     1isize as i32;
+72 |     1isize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may lose the sign of the value
-  --> $DIR/cast.rs:71:5
+  --> $DIR/cast.rs:73:5
    |
-71 |     1isize as u32;
+73 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting isize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:71:5
+  --> $DIR/cast.rs:73:5
    |
-71 |     1isize as u32;
+73 |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to u32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:72:5
+  --> $DIR/cast.rs:74:5
    |
-72 |     1usize as u32;
+74 |     1usize as u32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may truncate the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:73:5
+  --> $DIR/cast.rs:75:5
    |
-73 |     1usize as i32;
+75 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting usize to i32 may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:73:5
+  --> $DIR/cast.rs:75:5
    |
-73 |     1usize as i32;
+75 |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:75:5
+  --> $DIR/cast.rs:77:5
    |
-75 |     1i64 as isize;
+77 |     1i64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may lose the sign of the value
-  --> $DIR/cast.rs:76:5
+  --> $DIR/cast.rs:78:5
    |
-76 |     1i64 as usize;
+78 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting i64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:76:5
+  --> $DIR/cast.rs:78:5
    |
-76 |     1i64 as usize;
+78 |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:77:5
+  --> $DIR/cast.rs:79:5
    |
-77 |     1u64 as isize;
+79 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to isize may wrap around the value on targets with 64-bit wide pointers
-  --> $DIR/cast.rs:77:5
+  --> $DIR/cast.rs:79:5
    |
-77 |     1u64 as isize;
+79 |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting u64 to usize may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:78:5
+  --> $DIR/cast.rs:80:5
    |
-78 |     1u64 as usize;
+80 |     1u64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u32 to isize may wrap around the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:79:5
+  --> $DIR/cast.rs:81:5
    |
-79 |     1u32 as isize;
+81 |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting i32 to usize may lose the sign of the value
-  --> $DIR/cast.rs:82:5
+  --> $DIR/cast.rs:84:5
    |
-82 |     1i32 as usize;
+84 |     1i32 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:84:5
+  --> $DIR/cast.rs:86:5
    |
-84 |     1i32 as i32;
+86 |     1i32 as i32;
    |     ^^^^^^^^^^^
    |
    = note: `-D unnecessary-cast` implied by `-D warnings`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:85:5
+  --> $DIR/cast.rs:87:5
    |
-85 |     1f32 as f32;
+87 |     1f32 as f32;
    |     ^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:86:5
+  --> $DIR/cast.rs:88:5
    |
-86 |     false as bool;
+88 |     false as bool;
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 74 previous errors
+error: aborting due to 75 previous errors
 


### PR DESCRIPTION
https://github.com/rust-lang-nursery/rust-clippy/issues/2003 reports that the new lossless-cast lint suggestions contain redundant parens in some cases.

The lint runs in a LateLintPass, where it seems information about paren expressions is lost, so this PR strips the redundant parens off the suggestion string manually. If there's a better way to implement this, I'd be happy to abandon this PR.