### PR TITLE
Move the number of lints back to the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@
 
 A collection of lints to catch common mistakes and improve your Rust code.
 
+[There are 209 lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
+
+More to come, please [file an issue](https://github.com/rust-lang-nursery/rust-clippy/issues) if you have ideas!
+
 Table of contents:
 
-*   [Lint list](#lints)
 *   [Usage instructions](#usage)
 *   [Configuration](#configuration)
 *   [License](#license)
@@ -176,12 +179,6 @@ transparently:
 ```rust
 #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
 ```
-
-## Lints
-
-[There are 209 lints included in this crate](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
-
-More to come, please [file an issue](https://github.com/rust-lang-nursery/rust-clippy/issues) if you have ideas!
 
 ## License
 


### PR DESCRIPTION
This used to be at the top and was moved at the bottom when the big list of lints started to be so ridiculously long that people had to scroll for 10 minutes to have usage information :smile: