### PR TITLE
Fix "further information" link

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -566,7 +566,7 @@ impl<'a> DiagnosticWrapper<'a> {
     fn docs_link(&mut self, lint: &'static Lint) {
         if env::var("CLIPPY_DISABLE_DOCS_LINKS").is_err() {
             self.0.help(&format!(
-                "for further information visit https://rust-lang-nursery.github.io/rust-clippy/{}/index.html#{}",
+                "for further information visit https://rust-lang-nursery.github.io/rust-clippy/v{}/index.html#{}",
                 env!("CARGO_PKG_VERSION"),
                 lint.name_lower()
             ));


### PR DESCRIPTION
"further information" link was missing the `v` part (version prefix) from the url.
e.g.
wrong (404 not found): https://rust-lang-nursery.github.io/rust-clippy/0.0.157/index.html#map_entry
correct: https://rust-lang-nursery.github.io/rust-clippy/v0.0.157/index.html#map_entry