### PR TITLE
rustc fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,12 +64,13 @@ impl<'a> CompilerCalls<'a> for ClippyCompilerCalls {
         &mut self,
         matches: &getopts::Matches,
         sess: &Session,
+        crate_stores: &rustc::middle::cstore::CrateStore,
         input: &Input,
         odir: &Option<PathBuf>,
         ofile: &Option<PathBuf>,
     ) -> Compilation {
         self.default
-            .late_callback(matches, sess, input, odir, ofile)
+            .late_callback(matches, sess, crate_stores, input, odir, ofile)
     }
     fn build_controller(&mut self, sess: &Session, matches: &getopts::Matches) -> driver::CompileController<'a> {
         let mut control = self.default.build_controller(sess, matches);

--- a/tests/ui/never_loop.stderr
+++ b/tests/ui/never_loop.stderr
@@ -24,12 +24,12 @@ error: this loop never actually loops
 error: this loop never actually loops
   --> $DIR/never_loop.rs:47:2
    |
-47 | / \tloop { // never loops
-48 | | \t       while i == 0 { // never loops
-49 | | \t           break
-50 | | \t       }
-51 | | \t       return
-52 | | \t}
+47 | /  loop { // never loops
+48 | |         while i == 0 { // never loops
+49 | |             break
+50 | |         }
+51 | |         return
+52 | |  }
    | |__^
 
 error: this loop never actually loops
@@ -45,20 +45,20 @@ error: this loop never actually loops
    |
 57 | /     'outer: loop { // never loops
 58 | |         x += 1;
-59 | | \t\tloop { // never loops
+59 | |   loop { // never loops
 60 | |             if x == 5 { break }
 ...  |
-63 | | \t\treturn
-64 | | \t}
+63 | |   return
+64 | |  }
    | |__^
 
 error: this loop never actually loops
   --> $DIR/never_loop.rs:59:3
    |
-59 | / \t\tloop { // never loops
-60 | | \t\t          if x == 5 { break }
-61 | | \t\t\tcontinue 'outer
-62 | | \t\t}
+59 | /   loop { // never loops
+60 | |             if x == 5 { break }
+61 | |    continue 'outer
+62 | |   }
    | |___^
 
 error: this loop never actually loops

--- a/tests/ui/overflow_check_conditional.stderr
+++ b/tests/ui/overflow_check_conditional.stderr
@@ -1,52 +1,52 @@
 error: You are trying to use classic C overflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:11:5
    |
-11 | \tif a + b < a {
-   | \t   ^^^^^^^^^
+11 |  if a + b < a {
+   |     ^^^^^^^^^
    |
    = note: `-D overflow-check-conditional` implied by `-D warnings`
 
 error: You are trying to use classic C overflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:14:5
    |
-14 | \tif a > a + b {
-   | \t   ^^^^^^^^^
+14 |  if a > a + b {
+   |     ^^^^^^^^^
 
 error: You are trying to use classic C overflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:17:5
    |
-17 | \tif a + b < b {
-   | \t   ^^^^^^^^^
+17 |  if a + b < b {
+   |     ^^^^^^^^^
 
 error: You are trying to use classic C overflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:20:5
    |
-20 | \tif b > a + b {
-   | \t   ^^^^^^^^^
+20 |  if b > a + b {
+   |     ^^^^^^^^^
 
 error: You are trying to use classic C underflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:23:5
    |
-23 | \tif a - b > b {
-   | \t   ^^^^^^^^^
+23 |  if a - b > b {
+   |     ^^^^^^^^^
 
 error: You are trying to use classic C underflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:26:5
    |
-26 | \tif b < a - b {
-   | \t   ^^^^^^^^^
+26 |  if b < a - b {
+   |     ^^^^^^^^^
 
 error: You are trying to use classic C underflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:29:5
    |
-29 | \tif a - b > a {
-   | \t   ^^^^^^^^^
+29 |  if a - b > a {
+   |     ^^^^^^^^^
 
 error: You are trying to use classic C underflow conditions that will fail in Rust.
   --> $DIR/overflow_check_conditional.rs:32:5
    |
-32 | \tif a < a - b {
-   | \t   ^^^^^^^^^
+32 |  if a < a - b {
+   |     ^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/redundant_closure_call.stderr
+++ b/tests/ui/redundant_closure_call.stderr
@@ -1,34 +1,34 @@
 error: Closure called just once immediately after it was declared
   --> $DIR/redundant_closure_call.rs:15:2
    |
-15 | \ti = closure();
-   | \t^^^^^^^^^^^^^
+15 |  i = closure();
+   |  ^^^^^^^^^^^^^
    |
    = note: `-D redundant-closure-call` implied by `-D warnings`
 
 error: Closure called just once immediately after it was declared
   --> $DIR/redundant_closure_call.rs:18:2
    |
-18 | \ti = closure(3);
-   | \t^^^^^^^^^^^^^^
+18 |  i = closure(3);
+   |  ^^^^^^^^^^^^^^
 
 error: Try not to call a closure in the expression where it is declared.
  --> $DIR/redundant_closure_call.rs:7:10
   |
-7 | \tlet a = (|| 42)();
-  | \t        ^^^^^^^^^ help: Try doing something like: : `42`
+7 |  let a = (|| 42)();
+  |          ^^^^^^^^^ help: Try doing something like: : `42`
 
 error: Try not to call a closure in the expression where it is declared.
   --> $DIR/redundant_closure_call.rs:10:14
    |
-10 | \tlet mut k = (|m| m+1)(i);
-   | \t            ^^^^^^^^^^^^
+10 |  let mut k = (|m| m+1)(i);
+   |              ^^^^^^^^^^^^
 
 error: Try not to call a closure in the expression where it is declared.
   --> $DIR/redundant_closure_call.rs:12:6
    |
-12 | \tk = (|a,b| a*b)(1,5);
-   | \t    ^^^^^^^^^^^^^^^^
+12 |  k = (|a,b| a*b)(1,5);
+   |      ^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
`cargo install clippy` fails on `rustc 1.22.0-nightly (539f2083d 2017-09-13)`. This PR fixes it.

fixes #2050