### PR TITLE
Enhance CHARS_*_CMP lint

### DIFF
--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -547,3 +547,33 @@ fn iter_clone_collect() {
     let v3 : HashSet<isize> = v.iter().cloned().collect();
     let v4 : VecDeque<isize> = v.iter().cloned().collect();
 }
+
+fn chars_cmp_with_unwrap() {
+    let s = String::from("foo");
+    if s.chars().next().unwrap() == 'f' { // s.starts_with('f')
+        // Nothing here
+    }
+    if s.chars().next_back().unwrap() == 'o' { // s.ends_with('o')
+        // Nothing here
+    }
+    if s.chars().last().unwrap() == 'o' { // s.ends_with('o')
+        // Nothing here
+    }
+    if s.chars().next().unwrap() != 'f' { // !s.starts_with('f')
+        // Nothing here
+    }
+    if s.chars().next_back().unwrap() != 'o' { // !s.ends_with('o')
+        // Nothing here
+    }
+    if s.chars().last().unwrap() != 'o' { // !s.ends_with('o')
+        // Nothing here
+    }
+}
+
+#[allow(unnecessary_operation)]
+fn ends_with() {
+    "".chars().last() == Some(' ');
+    Some(' ') != "".chars().last();
+    "".chars().next_back() == Some(' ');
+    Some(' ') != "".chars().next_back();
+}

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -738,5 +738,103 @@ error: called `cloned().collect()` on a slice to create a `Vec`. Calling `to_vec
     |
     = note: `-D iter-cloned-collect` implied by `-D warnings`
 
-error: aborting due to 107 previous errors
+error: you should use the `starts_with` method
+   --> $DIR/methods.rs:553:8
+    |
+553 |     if s.chars().next().unwrap() == 'f' { // s.starts_with('f')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `s.starts_with('f')`
+
+error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+   --> $DIR/methods.rs:553:8
+    |
+553 |     if s.chars().next().unwrap() == 'f' { // s.starts_with('f')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:556:8
+    |
+556 |     if s.chars().next_back().unwrap() == 'o' { // s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `s.ends_with('o')`
+    |
+    = note: `-D chars-last-cmp` implied by `-D warnings`
+
+error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+   --> $DIR/methods.rs:556:8
+    |
+556 |     if s.chars().next_back().unwrap() == 'o' { // s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:559:8
+    |
+559 |     if s.chars().last().unwrap() == 'o' { // s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `s.ends_with('o')`
+
+error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+   --> $DIR/methods.rs:559:8
+    |
+559 |     if s.chars().last().unwrap() == 'o' { // s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you should use the `starts_with` method
+   --> $DIR/methods.rs:562:8
+    |
+562 |     if s.chars().next().unwrap() != 'f' { // !s.starts_with('f')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.starts_with('f')`
+
+error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+   --> $DIR/methods.rs:562:8
+    |
+562 |     if s.chars().next().unwrap() != 'f' { // !s.starts_with('f')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:565:8
+    |
+565 |     if s.chars().next_back().unwrap() != 'o' { // !s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.ends_with('o')`
+
+error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+   --> $DIR/methods.rs:565:8
+    |
+565 |     if s.chars().next_back().unwrap() != 'o' { // !s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:568:8
+    |
+568 |     if s.chars().last().unwrap() != 'o' { // !s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.ends_with('o')`
+
+error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+   --> $DIR/methods.rs:568:8
+    |
+568 |     if s.chars().last().unwrap() != 'o' { // !s.ends_with('o')
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:575:5
+    |
+575 |     "".chars().last() == Some(' ');
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `"".ends_with(' ')`
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:576:5
+    |
+576 |     Some(' ') != "".chars().last();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".ends_with(' ')`
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:577:5
+    |
+577 |     "".chars().next_back() == Some(' ');
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `"".ends_with(' ')`
+
+error: you should use the `ends_with` method
+   --> $DIR/methods.rs:578:5
+    |
+578 |     Some(' ') != "".chars().next_back();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".ends_with(' ')`
+
+error: aborting due to 123 previous errors
 


### PR DESCRIPTION
This PR 
1. updates `chars_next_cmp` lint to warn against method call with `unwrap()` (cc #1818).
2. adds `chars_last_cmp` lint, which is similar to `chars_next_cmp`.

Closes #1818.