### PR TITLE
add suggestions for .clone() in ptr_arg fns

### DIFF
--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -2,7 +2,8 @@ use rustc::hir::*;
 use rustc::lint::*;
 use rustc::ty;
 use syntax::ast::{Name, UintTy};
-use utils::{contains_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg, walk_ptrs_ty};
+use utils::{contains_name, get_pat_name, match_type, paths, single_segment_path,
+            snippet, span_lint_and_sugg, walk_ptrs_ty};
 
 /// **What it does:** Checks for naive byte counts
 ///
@@ -91,15 +92,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
 
 fn check_arg(name: Name, arg: Name, needle: &Expr) -> bool {
     name == arg && !contains_name(name, needle)
-}
-
-fn get_pat_name(pat: &Pat) -> Option<Name> {
-    match pat.node {
-        PatKind::Binding(_, _, ref spname, _) => Some(spname.node),
-        PatKind::Path(ref qpath) => single_segment_path(qpath).map(|ps| ps.name),
-        PatKind::Box(ref p) | PatKind::Ref(ref p, _) => get_pat_name(&*p),
-        _ => None,
-    }
 }
 
 fn get_path_name(expr: &Expr) -> Option<Name> {

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -16,7 +16,7 @@ use utils::sugg;
 use utils::const_to_u64;
 
 use utils::{get_enclosing_block, get_parent_expr, higher, in_external_macro, is_integer_literal, is_refutable,
-            last_path_segment, match_trait_method, match_type, multispan_sugg, snippet, snippet_opt,
+            last_path_segment, match_trait_method, match_type, match_var, multispan_sugg, snippet, snippet_opt,
             span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then};
 use utils::paths;
 
@@ -1269,15 +1269,6 @@ fn pat_is_wild<'tcx>(pat: &'tcx PatKind, body: &'tcx Expr) -> bool {
         },
         _ => false,
     }
-}
-
-fn match_var(expr: &Expr, var: Name) -> bool {
-    if let ExprPath(QPath::Resolved(None, ref path)) = expr.node {
-        if path.segments.len() == 1 && path.segments[0].name == var {
-            return true;
-        }
-    }
-    false
 }
 
 struct UsedVisitor {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -218,6 +218,17 @@ pub fn match_trait_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool 
     }
 }
 
+/// Check if an expression references a variable of the given name.
+pub fn match_var(expr: &Expr, var: Name) -> bool {
+    if let ExprPath(QPath::Resolved(None, ref path)) = expr.node {
+        if path.segments.len() == 1 && path.segments[0].name == var {
+            return true;
+        }
+    }
+    false
+}
+
+
 pub fn last_path_segment(path: &QPath) -> &PathSegment {
     match *path {
         QPath::Resolved(_, ref path) => path.segments
@@ -389,6 +400,16 @@ pub fn get_item_name(cx: &LateContext, expr: &Expr) -> Option<Name> {
         Some(Node::NodeItem(&Item { ref name, .. })) |
         Some(Node::NodeTraitItem(&TraitItem { ref name, .. })) |
         Some(Node::NodeImplItem(&ImplItem { ref name, .. })) => Some(*name),
+        _ => None,
+    }
+}
+
+/// Get the name of a `Pat`, if any
+pub fn get_pat_name(pat: &Pat) -> Option<Name> {
+    match pat.node {
+        PatKind::Binding(_, _, ref spname, _) => Some(spname.node),
+        PatKind::Path(ref qpath) => single_segment_path(qpath).map(|ps| ps.name),
+        PatKind::Box(ref p) | PatKind::Ref(ref p, _) => get_pat_name(&*p),
         _ => None,
     }
 }

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -1,6 +1,6 @@
 #![feature(plugin)]
 #![plugin(clippy)]
-#![allow(unused)]
+#![allow(unused, many_single_char_names)]
 #![warn(ptr_arg)]
 
 fn do_vec(x: &Vec<i64>) {
@@ -34,5 +34,24 @@ struct Bar;
 impl Foo for Bar {
     type Item = Vec<u8>;
     fn do_vec(x: &Vec<i64>) {}
-    fn do_item(x: &Vec<u8>) {}  
+    fn do_item(x: &Vec<u8>) {}
+}
+
+fn cloned(x: &Vec<u8>) -> Vec<u8> {
+    let e = x.clone();
+    let f = e.clone(); // OK
+    let g = x;
+    let h = g.clone(); // Alas, we cannot reliably detect this without following data.
+    let i = (e).clone();
+    x.clone()
+}
+
+fn str_cloned(x: &String) -> String {
+    let a = x.clone();
+    let b = x.clone();
+    let c = b.clone();
+    let d = a.clone()
+             .clone()
+             .clone();
+    x.clone()
 }

--- a/tests/ui/ptr_arg.stderr
+++ b/tests/ui/ptr_arg.stderr
@@ -18,5 +18,47 @@ error: writing `&Vec<_>` instead of `&[_]` involves one more reference and canno
 27 |     fn do_vec(x: &Vec<i64>);
    |                  ^^^^^^^^^ help: change this to: `&[i64]`
 
-error: aborting due to 3 previous errors
+error: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
+  --> $DIR/ptr_arg.rs:40:14
+   |
+40 | fn cloned(x: &Vec<u8>) -> Vec<u8> {
+   |              ^^^^^^^^
+   |
+help: change this to
+   |
+40 | fn cloned(x: &[u8]) -> Vec<u8> {
+   |              ^^^^^
+help: change the `.clone()` to
+   |
+41 |     let e = x.to_owned();
+   |             ^^^^^^^^^^^^
+help: change the `.clone()` to
+   |
+46 |     x.to_owned()
+   |     ^^^^^^^^^^^^
+
+error: writing `&String` instead of `&str` involves a new object where a slice will do.
+  --> $DIR/ptr_arg.rs:49:18
+   |
+49 | fn str_cloned(x: &String) -> String {
+   |                  ^^^^^^^
+   |
+help: change this to
+   |
+49 | fn str_cloned(x: &str) -> String {
+   |                  ^^^^
+help: change the `.clone` to 
+   |
+50 |     let a = x.to_string();
+   |             ^^^^^^^^^^^^^
+help: change the `.clone` to 
+   |
+51 |     let b = x.to_string();
+   |             ^^^^^^^^^^^^^
+help: change the `.clone` to 
+   |
+56 |     x.to_string()
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This closes #1157

This change makes the `ptr_arg` lint walk the body to look for `.clone()` calls on our argument, suggesting appropriate `.to_owned()` or `.to_string()` calls instead.

This is not a 100% solution, as we do not follow reference copies. At least we document the problem for posterity