### PR TITLE
Addresses #1955 - Suggests >= y + 1 become > y

### DIFF
--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -1,0 +1,115 @@
+//! lint on blocks unnecessarily using >= with a + 1 or - 1
+
+use rustc::lint::*;
+use syntax::ast::*;
+
+use utils::span_help_and_lint;
+
+/// **What it does:** Checks for usage of `x >= y + 1` or `x - 1 >= y` (and `<=`) in a block
+///
+///
+/// **Why is this bad?** Readability -- better to use `> y` instead of `>= y + 1`.
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// x >= y + 1
+/// ```
+///
+/// Could be written:
+///
+/// ```rust
+/// x > y
+/// ```
+declare_lint! {
+    pub INT_PLUS_ONE,
+    Allow,
+    "instead of using x >= y + 1, use x > y"
+}
+
+pub struct IntPlusOne;
+
+impl LintPass for IntPlusOne {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(INT_PLUS_ONE)
+    }
+}
+
+// cases:
+// BinOpKind::Ge
+// x >= y + 1
+// x - 1 >= y
+//
+// BinOpKind::Le
+// x + 1 <= y
+// x <= y - 1
+
+impl IntPlusOne {
+    #[allow(cast_sign_loss)]
+    fn check_lit(&self, lit: &Lit, target_value: i128) -> bool {
+        if let LitKind::Int(value, ..) = lit.node {
+            return value == (target_value as u128)
+        }
+        false
+    }
+
+    fn check_binop(&self, binop: BinOpKind, lhs: &Expr, rhs: &Expr) -> bool {
+        match (binop, &lhs.node, &rhs.node) {
+            // case where `x - 1 >= ...` or `-1 + x >= ...`
+            (BinOpKind::Ge, &ExprKind::Binary(ref lhskind, ref lhslhs, ref lhsrhs), _) => {
+                match (lhskind.node, &lhslhs.node, &lhsrhs.node) {
+                    // `-1 + x`
+                    (BinOpKind::Add, &ExprKind::Lit(ref lit), _) => self.check_lit(lit, -1),
+                    // `x - 1`
+                    (BinOpKind::Sub, _, &ExprKind::Lit(ref lit)) => self.check_lit(lit, 1),
+                    _ => false
+                }
+            },
+            // case where `... >= y + 1` or `... >= 1 + y`
+            (BinOpKind::Ge, _, &ExprKind::Binary(ref rhskind, ref rhslhs, ref rhsrhs)) if rhskind.node == BinOpKind::Add => {
+                match (&rhslhs.node, &rhsrhs.node) {
+                    // `y + 1` and `1 + y`
+                    (&ExprKind::Lit(ref lit), _)|(_, &ExprKind::Lit(ref lit)) => self.check_lit(lit, 1),
+                    _ => false
+                }
+            },
+            // case where `x + 1 <= ...` or `1 + x <= ...`
+            (BinOpKind::Le, &ExprKind::Binary(ref lhskind, ref lhslhs, ref lhsrhs), _) if lhskind.node == BinOpKind::Add => {
+                match (&lhslhs.node, &lhsrhs.node) {
+                    // `1 + x` and `x + 1`
+                    (&ExprKind::Lit(ref lit), _)|(_, &ExprKind::Lit(ref lit)) => self.check_lit(lit, 1),
+                    _ => false
+                }
+            },
+            // case where `... >= y - 1` or `... >= -1 + y`
+            (BinOpKind::Le, _, &ExprKind::Binary(ref rhskind, ref rhslhs, ref rhsrhs)) => {
+                match (rhskind.node, &rhslhs.node, &rhsrhs.node) {
+                    // `-1 + y`
+                    (BinOpKind::Add, &ExprKind::Lit(ref lit), _) => self.check_lit(lit, -1),
+                    // `y - 1`
+                    (BinOpKind::Sub, _, &ExprKind::Lit(ref lit)) => self.check_lit(lit, 1),
+                    _ => false
+                }
+            },
+            _ => false
+        }
+    }
+
+}
+
+impl EarlyLintPass for IntPlusOne {
+    fn check_expr(&mut self, cx: &EarlyContext, item: &Expr) {
+        if let ExprKind::Binary(ref kind, ref lhs, ref rhs) = item.node {
+            if self.check_binop(kind.node, lhs, rhs) {
+                span_help_and_lint(
+                    cx,
+                    INT_PLUS_ONE,
+                    item.span,
+                    "Unnecessary `>= y + 1` or `x - 1 >=`",
+                    "Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`",
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -59,7 +59,7 @@ impl IntPlusOne {
         false
     }
 
-    fn check_binop(&self, cx: &EarlyContext, block: &Expr, binop: BinOpKind, lhs: &Expr, rhs: &Expr) -> Option<(bool, Option<String>)> {
+    fn check_binop(&self, cx: &EarlyContext, block: &Expr, binop: BinOpKind, lhs: &Expr, rhs: &Expr) {
         match (binop, &lhs.node, &rhs.node) {
             // case where `x - 1 >= ...` or `-1 + x >= ...`
             (BinOpKind::Ge, &ExprKind::Binary(ref lhskind, ref lhslhs, ref lhsrhs), _) => {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -96,6 +96,7 @@ pub mod identity_op;
 pub mod if_let_redundant_pattern_matching;
 pub mod if_not_else;
 pub mod infinite_iter;
+pub mod int_plus_one;
 pub mod is_unit_expr;
 pub mod items_after_statements;
 pub mod large_enum_variant;
@@ -299,6 +300,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_early_lint_pass(box formatting::Formatting);
     reg.register_late_lint_pass(box swap::Swap);
     reg.register_early_lint_pass(box if_not_else::IfNotElse);
+    reg.register_early_lint_pass(box int_plus_one::IntPlusOne);
     reg.register_late_lint_pass(box overflow_check_conditional::OverflowCheckConditional);
     reg.register_late_lint_pass(box unused_label::UnusedLabel);
     reg.register_late_lint_pass(box new_without_default::NewWithoutDefault);
@@ -341,6 +343,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         enum_variants::PUB_ENUM_VARIANT_NAMES,
         enum_variants::STUTTER,
         if_not_else::IF_NOT_ELSE,
+        int_plus_one::INT_PLUS_ONE,
         infinite_iter::MAYBE_INFINITE_ITER,
         items_after_statements::ITEMS_AFTER_STATEMENTS,
         matches::SINGLE_MATCH_ELSE,

--- a/tests/ui/int_plus_one.rs
+++ b/tests/ui/int_plus_one.rs
@@ -1,0 +1,18 @@
+#![feature(plugin)]
+#![plugin(clippy)]
+
+#[allow(no_effect, unnecessary_operation)]
+#[warn(int_plus_one)]
+fn main() {
+    let x = 1i32;
+    let y = 0i32;
+    
+    x >= y + 1;
+    y + 1 <= x;
+
+    x - 1 >= y;
+    y <= x - 1;
+
+    x > y; // should be ok
+    y < x; // should be ok
+}

--- a/tests/ui/int_plus_one.stderr
+++ b/tests/ui/int_plus_one.stderr
@@ -5,7 +5,10 @@ error: Unnecessary `>= y + 1` or `x - 1 >=`
    |     ^^^^^^^^^^
    |
    = note: `-D int-plus-one` implied by `-D warnings`
-   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+help: change `>= y + 1` to `> y` as shown
+   |
+10 |     x > y;
+   |     ^^^^^
 
 error: Unnecessary `>= y + 1` or `x - 1 >=`
   --> $DIR/int_plus_one.rs:11:5
@@ -13,7 +16,10 @@ error: Unnecessary `>= y + 1` or `x - 1 >=`
 11 |     y + 1 <= x;
    |     ^^^^^^^^^^
    |
-   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+help: change `>= y + 1` to `> y` as shown
+   |
+11 |     y < x;
+   |     ^^^^^
 
 error: Unnecessary `>= y + 1` or `x - 1 >=`
   --> $DIR/int_plus_one.rs:13:5
@@ -21,7 +27,10 @@ error: Unnecessary `>= y + 1` or `x - 1 >=`
 13 |     x - 1 >= y;
    |     ^^^^^^^^^^
    |
-   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+help: change `>= y + 1` to `> y` as shown
+   |
+13 |     x > y;
+   |     ^^^^^
 
 error: Unnecessary `>= y + 1` or `x - 1 >=`
   --> $DIR/int_plus_one.rs:14:5
@@ -29,7 +38,10 @@ error: Unnecessary `>= y + 1` or `x - 1 >=`
 14 |     y <= x - 1;
    |     ^^^^^^^^^^
    |
-   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+help: change `>= y + 1` to `> y` as shown
+   |
+14 |     y < x;
+   |     ^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/int_plus_one.stderr
+++ b/tests/ui/int_plus_one.stderr
@@ -1,0 +1,35 @@
+error: Unnecessary `>= y + 1` or `x - 1 >=`
+  --> $DIR/int_plus_one.rs:10:5
+   |
+10 |     x >= y + 1;
+   |     ^^^^^^^^^^
+   |
+   = note: `-D int-plus-one` implied by `-D warnings`
+   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+
+error: Unnecessary `>= y + 1` or `x - 1 >=`
+  --> $DIR/int_plus_one.rs:11:5
+   |
+11 |     y + 1 <= x;
+   |     ^^^^^^^^^^
+   |
+   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+
+error: Unnecessary `>= y + 1` or `x - 1 >=`
+  --> $DIR/int_plus_one.rs:13:5
+   |
+13 |     x - 1 >= y;
+   |     ^^^^^^^^^^
+   |
+   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+
+error: Unnecessary `>= y + 1` or `x - 1 >=`
+  --> $DIR/int_plus_one.rs:14:5
+   |
+14 |     y <= x - 1;
+   |     ^^^^^^^^^^
+   |
+   = help: Consider reducing `x >= y + 1` or `x - 1 >= y` to `x > y`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This is a first pass, and as such, doesn't address a few cases (illustrated below).

This module handles the following cases:
- `... >= ... + 1` and `... >= 1 + ...`
- `... - 1 >= ...` and `-1 + ... >= ...`
- `... + 1 <= ...` and `... + 1 <= ...`
- `... <= ... - 1` and `... <= -1 + ...`

Note: this only goes 1 level deep (i.e., does not constant-fold or 
perform constant propagation) and does not currently simplify 
expressions. 

Examples of these cases include:
```rust
let x = 1;
y >= y + x; // won't catch this case or any permutation

x + 1 >= y + 2; // won't catch this case

x + 1 - 1 >= y - 1 + 1; // WILL catch this case when it likely shouldn't
```

Interested in your thoughts and suggestions. :)