### PR TITLE
lints/doc_markdown: add two more entries

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -154,7 +154,7 @@ define_Conf! {
         "JavaScript",
         "NaN",
         "OAuth",
-        "OpenGL",
+        "OpenGL", "OpenSSH", "OpenSSL",
         "TrueType",
         "iOS", "macOS",
         "TeX", "LaTeX", "BibTex", "BibLaTex",


### PR DESCRIPTION
This adds two more entries to the `doc_markdown` whitelist. I suspect `OpenSSH` and `OpenSSL` are widespread and common enough to justify being here instead of in every clippy configuration file.