### PR TITLE
avoid linting `ptr_arg` if `.capacity()` is called.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,8 @@ dependencies = [
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -28,22 +28,22 @@ name = "backtrace"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -61,10 +61,15 @@ name = "cargo_metadata"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -82,8 +87,8 @@ dependencies = [
  "duct 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -138,11 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "getopts"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -181,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -199,7 +199,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -289,12 +289,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -317,9 +317,9 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -364,7 +364,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -408,10 +408,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
-"checksum backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "afccc5772ba333abccdf60d55200fa3406f8c59dcf54d5f7998c9107d3799c7c"
+"checksum backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c63ea141ef8fdb10409d0f5daf30ac51f84ef43bff66f16627773d2a292cd189"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
+"checksum cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum compiletest_rs 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2741d378feb7a434dba54228c89a70b4e427fee521de67cdda3750b8a0265f5a"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
@@ -419,14 +420,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum duct 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e45aa15fe0a8a8f511e6d834626afd55e49b62e5c8802e18328a87e8a8f6065c"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
-"checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22c285d60139cf413244894189ca52debcfd70b57966feed060da76802e415a0"
-"checksum itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac17257442c2ed77dbc9fd555cf83c58b0c7f7d0e8f2ae08c0ac05c72842e1f6"
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
-"checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
+"checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
@@ -442,8 +442,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "bcb6a7637a47663ee073391a139ed07851f27ed2532c2abc88c6bf27a16cdf34"
-"checksum serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "812ff66056fd9a9a5b7c119714243b0862cf98340e7d4b5ee05a932c40d5ea6c"
+"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
+"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
 "checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
 "checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
 "checksum shared_child 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "099b38928dbe4a0a01fcd8c233183072f14a7d126a34bed05880869be66e14cc"

--- a/clippy_lints/src/literal_digit_grouping.rs
+++ b/clippy_lints/src/literal_digit_grouping.rs
@@ -279,12 +279,19 @@ impl LiteralDigitGrouping {
                         let fractional_part = &parts[1].chars().rev().collect::<String>();
                         let _ = Self::do_lint(fractional_part)
                             .map(|fractional_group_size| {
-                                let consistent = Self::parts_consistent(integral_group_size, fractional_group_size, parts[0].len(), parts[1].len());
+                                let consistent = Self::parts_consistent(integral_group_size,
+                                                                        fractional_group_size,
+                                                                        parts[0].len(),
+                                                                        parts[1].len());
                                 if !consistent {
-                                    WarningType::InconsistentDigitGrouping.display(&digit_info.grouping_hint(), cx, &lit.span);
+                                    WarningType::InconsistentDigitGrouping.display(&digit_info.grouping_hint(),
+                                                                                   cx,
+                                                                                   &lit.span);
                                 }
                             })
-                            .map_err(|warning_type| warning_type.display(&digit_info.grouping_hint(), cx, &lit.span));
+                            .map_err(|warning_type| warning_type.display(&digit_info.grouping_hint(),
+                                                                         cx,
+                                                                         &lit.span));
                     }
                 })
                 .map_err(|warning_type| warning_type.display(&digit_info.grouping_hint(), cx, &lit.span));
@@ -332,7 +339,8 @@ impl LiteralDigitGrouping {
                 .windows(2)
                 .all(|ps| ps[1] - ps[0] == group_size + 1)
                 // number of digits to the left of the last group cannot be bigger than group size.
-                && (digits.len() - underscore_positions.last().expect("there's at least one element") <= group_size + 1);
+                && (digits.len() - underscore_positions.last()
+                                                       .expect("there's at least one element") <= group_size + 1);
 
             if !consistent {
                 return Err(WarningType::InconsistentDigitGrouping);

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -15,16 +15,7 @@
 // *rustc*'s
 // [`missing_doc`].
 //
-// [`missing_doc`]:
-// https://github.
-// com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.
-//
-//
-//
-//
-//
-//
-// rs#L246
+// [`missing_doc`]: https://github.com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.rs#L246
 //
 
 use rustc::hir;

--- a/clippy_lints/src/print.rs
+++ b/clippy_lints/src/print.rs
@@ -124,7 +124,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             else if args.len() == 2 && match_def_path(cx.tcx, fun_id, &paths::FMT_ARGUMENTV1_NEW) {
                 if let ExprPath(ref qpath) = args[1].node {
                     if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, args[1].hir_id)) {
-                        if match_def_path(cx.tcx, def_id, &paths::DEBUG_FMT_METHOD) && !is_in_debug_impl(cx, expr) && is_expn_of(expr.span, "panic").is_none() {
+                        if match_def_path(cx.tcx, def_id, &paths::DEBUG_FMT_METHOD)
+                                && !is_in_debug_impl(cx, expr) && is_expn_of(expr.span, "panic").is_none() {
                             span_lint(cx, USE_DEBUG, args[0].span, "use of `Debug`-based formatting");
                         }
                     }

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -1,5 +1,6 @@
 //! Checks for usage of  `&Vec[_]` and `&String`.
 
+use std::borrow::Cow;
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::hir::map::NodeItem;
@@ -163,44 +164,48 @@ fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<
                 ], {
                     ty_snippet = snippet_opt(cx, parameters.types[0].span);
                 });
-                let spans = get_spans(cx, opt_body_id, idx, "to_owned");
-                span_lint_and_then(
-                    cx,
-                    PTR_ARG,
-                    arg.span,
-                    "writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used \
-                     with non-Vec-based slices.",
-                    |db| {
-                        if let Some(ref snippet) = ty_snippet {
+                if let Ok(spans) = get_spans(cx, opt_body_id, idx, &[("clone", ".to_owned()")]) {
+                    span_lint_and_then(
+                        cx,
+                        PTR_ARG,
+                        arg.span,
+                        "writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used \
+                         with non-Vec-based slices.",
+                        |db| {
+                            if let Some(ref snippet) = ty_snippet {
+                                db.span_suggestion(arg.span,
+                                                   "change this to",
+                                                   format!("&[{}]", snippet));
+                            }
+                            for (clonespan, suggestion) in spans {
+                                db.span_suggestion(clonespan,
+                                                   &snippet_opt(cx, clonespan).map_or("change the call to".into(),
+                                                        |x| Cow::Owned(format!("change `{}` to", x))),
+                                                   suggestion.into());
+                            }
+                        }
+                    );
+                }
+            } else if match_type(cx, ty, &paths::STRING) {
+                if let Ok(spans) = get_spans(cx, opt_body_id, idx, &[("clone", ".to_string()"), ("as_str", "")]) {
+                    span_lint_and_then(
+                        cx,
+                        PTR_ARG,
+                        arg.span,
+                        "writing `&String` instead of `&str` involves a new object where a slice will do.",
+                        |db| {
                             db.span_suggestion(arg.span,
                                                "change this to",
-                                               format!("&[{}]", snippet));
+                                               "&str".into());
+                            for (clonespan, suggestion) in spans {
+                                db.span_suggestion_short(clonespan,
+                                                   &snippet_opt(cx, clonespan).map_or("change the call to".into(),
+                                                        |x| Cow::Owned(format!("change `{}` to", x))),
+                                                   suggestion.into());
+                            }
                         }
-                        for (clonespan, suggestion) in spans {
-                            db.span_suggestion(clonespan,
-                                               "change the `.clone()` to",
-                                               suggestion);
-                        }
-                    }
-                );
-            } else if match_type(cx, ty, &paths::STRING) {
-                let spans = get_spans(cx, opt_body_id, idx, "to_string");
-                span_lint_and_then(
-                    cx,
-                    PTR_ARG,
-                    arg.span,
-                    "writing `&String` instead of `&str` involves a new object where a slice will do.",
-                    |db| {
-                        db.span_suggestion(arg.span,
-                                           "change this to",
-                                           "&str".into());
-                        for (clonespan, suggestion) in spans {
-                            db.span_suggestion_short(clonespan,
-                                               "change the `.clone` to ",
-                                               suggestion);
-                        }
-                    }
-                );
+                    );
+                }
             }
         }
     }
@@ -229,38 +234,50 @@ fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<
     }
 }
 
-fn get_spans(cx: &LateContext, opt_body_id: Option<BodyId>, idx: usize, fn_name: &'static str) -> Vec<(Span, String)> {
+fn get_spans(cx: &LateContext, opt_body_id: Option<BodyId>, idx: usize, replacements: &'static [(&'static str, &'static str)]) -> Result<Vec<(Span, Cow<'static, str>)>, ()> {
     if let Some(body) = opt_body_id.map(|id| cx.tcx.hir.body(id)) {
-        get_binding_name(&body.arguments[idx]).map_or_else(Vec::new,
-                                                |name| extract_clone_suggestions(cx, name, fn_name, body))
+        get_binding_name(&body.arguments[idx]).map_or_else(|| Ok(vec![]),
+                                                |name| extract_clone_suggestions(cx, name, replacements, body))
     } else {
-        vec![]
+        Ok(vec![])
     }
 }
 
-fn extract_clone_suggestions<'a, 'tcx: 'a>(cx: &LateContext<'a, 'tcx>, name: Name, fn_name: &'static str, body: &'tcx Body) -> Vec<(Span, String)> {
+fn extract_clone_suggestions<'a, 'tcx: 'a>(cx: &LateContext<'a, 'tcx>, name: Name, replace: &'static [(&'static str, &'static str)], body: &'tcx Body) -> Result<Vec<(Span, Cow<'static, str>)>, ()> {
     let mut visitor = PtrCloneVisitor {
         cx,
         name,
-        fn_name,
-        spans: vec![]
+        replace,
+        spans: vec![],
+        abort: false,
     };
     visitor.visit_body(body);
-    visitor.spans
+    if visitor.abort { Err(()) } else { Ok(visitor.spans) }
 }
 
 struct PtrCloneVisitor<'a, 'tcx: 'a> {
     cx: &'a LateContext<'a, 'tcx>,
     name: Name,
-    fn_name: &'static str,
-    spans: Vec<(Span, String)>,
+    replace: &'static [(&'static str, &'static str)],
+    spans: Vec<(Span, Cow<'static, str>)>,
+    abort: bool,
 }
 
 impl<'a, 'tcx: 'a> Visitor<'tcx> for PtrCloneVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx Expr) {
+        if self.abort { return; }
         if let ExprMethodCall(ref seg, _, ref args) = expr.node {
-            if args.len() == 1 && match_var(&args[0], self.name) && seg.name == "clone" {
-                self.spans.push((expr.span, format!("{}.{}()", snippet(self.cx, args[0].span, "_"), self.fn_name)));
+            if args.len() == 1 && match_var(&args[0], self.name) {
+                if seg.name == "capacity" {
+                    self.abort = true;
+                    return;
+                }
+                for &(fn_name, suffix) in self.replace {
+                    if seg.name == fn_name {
+                        self.spans.push((expr.span, snippet(self.cx, args[0].span, "_") + suffix));
+                        return;
+                    }
+                }
             }
             return;
         }

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -82,7 +82,8 @@ macro_rules! define_Conf {
             #[serde(rename_all="kebab-case")]
             #[serde(deny_unknown_fields)]
             pub struct Conf {
-                $(#[$doc] #[serde(default=$rust_name_str)] #[serde(with=$rust_name_str)] pub $rust_name: define_Conf!(TY $($ty)+),)+
+                $(#[$doc] #[serde(default=$rust_name_str)] #[serde(with=$rust_name_str)]
+                          pub $rust_name: define_Conf!(TY $($ty)+),)+
                 #[allow(dead_code)]
                 #[serde(default)]
                 third_party: Option<::toml::Value>,
@@ -91,10 +92,12 @@ macro_rules! define_Conf {
                 mod $rust_name {
                     use serde;
                     use serde::Deserialize;
-                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<define_Conf!(TY $($ty)+), D::Error> {
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D)
+                    -> Result<define_Conf!(TY $($ty)+), D::Error> {
                         type T = define_Conf!(TY $($ty)+);
                         Ok(T::deserialize(deserializer).unwrap_or_else(|e| {
-                            ::utils::conf::ERRORS.lock().expect("no threading here").push(::utils::conf::Error::Toml(e.to_string()));
+                            ::utils::conf::ERRORS.lock().expect("no threading here")
+                                                        .push(::utils::conf::Error::Toml(e.to_string()));
                             super::$rust_name()
                         }))
                     }

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -55,3 +55,15 @@ fn str_cloned(x: &String) -> String {
              .clone();
     x.clone()
 }
+
+fn false_positive_capacity(x: &Vec<u8>, y: &String) {
+    let a = x.capacity();
+    let b = y.clone();
+    let c = y.as_str();
+}
+
+fn false_positive_capacity_too(x: &String) -> String {
+    if x.capacity() > 1024 { panic!("Too large!"); }
+    x.clone()
+}
+

--- a/tests/ui/ptr_arg.stderr
+++ b/tests/ui/ptr_arg.stderr
@@ -28,11 +28,11 @@ help: change this to
    |
 40 | fn cloned(x: &[u8]) -> Vec<u8> {
    |              ^^^^^
-help: change the `.clone()` to
+help: change `x.clone()` to
    |
 41 |     let e = x.to_owned();
    |             ^^^^^^^^^^^^
-help: change the `.clone()` to
+help: change `x.clone()` to
    |
 46 |     x.to_owned()
    |     ^^^^^^^^^^^^
@@ -47,18 +47,37 @@ help: change this to
    |
 49 | fn str_cloned(x: &str) -> String {
    |                  ^^^^
-help: change the `.clone` to 
+help: change `x.clone()` to
    |
 50 |     let a = x.to_string();
    |             ^^^^^^^^^^^^^
-help: change the `.clone` to 
+help: change `x.clone()` to
    |
 51 |     let b = x.to_string();
    |             ^^^^^^^^^^^^^
-help: change the `.clone` to 
+help: change `x.clone()` to
    |
 56 |     x.to_string()
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: writing `&String` instead of `&str` involves a new object where a slice will do.
+  --> $DIR/ptr_arg.rs:59:44
+   |
+59 | fn false_positive_capacity(x: &Vec<u8>, y: &String) {
+   |                                            ^^^^^^^
+   |
+help: change this to
+   |
+59 | fn false_positive_capacity(x: &Vec<u8>, y: &str) {
+   |                                            ^^^^
+help: change `y.clone()` to
+   |
+61 |     let b = y.to_string();
+   |             ^^^^^^^^^^^^^
+help: change `y.as_str()` to
+   |
+62 |     let c = y;
+   |             ^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
 Also suggest removing `.as_str()` where applicable.

This fixes #2070.

Also fixes a few formatting mishaps.