### PR TITLE
Configuration option for VERBOSE_BIT_MASK threshold

### DIFF
--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -90,7 +90,17 @@ declare_lint! {
 }
 
 #[derive(Copy, Clone)]
-pub struct BitMask;
+pub struct BitMask {
+    verbose_bit_mask_threshold: u64,
+}
+
+impl BitMask {
+    pub fn new(verbose_bit_mask_threshold: u64) -> Self {
+        Self {
+            verbose_bit_mask_threshold: verbose_bit_mask_threshold,
+        }
+    }
+}
 
 impl LintPass for BitMask {
     fn get_lints(&self) -> LintArray {
@@ -119,6 +129,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BitMask {
             let Expr_::ExprLit(ref lit1) = right.node,
             let LitKind::Int(0, _) = lit1.node,
             n.leading_zeros() == n.count_zeros(),
+            n > u128::from(self.verbose_bit_mask_threshold),
         ], {
             span_lint_and_then(cx,
                                VERBOSE_BIT_MASK,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -231,7 +231,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_early_lint_pass(box enum_variants::EnumVariantNames::new(conf.enum_variant_name_threshold));
     reg.register_late_lint_pass(box enum_glob_use::EnumGlobUse);
     reg.register_late_lint_pass(box enum_clike::UnportableVariant);
-    reg.register_late_lint_pass(box bit_mask::BitMask);
+    reg.register_late_lint_pass(box bit_mask::BitMask::new(conf.verbose_bit_mask_threshold));
     reg.register_late_lint_pass(box ptr::PointerPass);
     reg.register_late_lint_pass(box needless_bool::NeedlessBool);
     reg.register_late_lint_pass(box needless_bool::BoolComparison);

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -172,7 +172,7 @@ define_Conf! {
     (enum_variant_name_threshold, "enum_variant_name_threshold", 3 => u64),
     /// Lint: LARGE_ENUM_VARIANT. The maximum size of a emum's variant to avoid box suggestion
     (enum_variant_size_threshold, "enum_variant_size_threshold", 200 => u64),
-    /// Lint: VERBOSE_BIT_MASK. The maximum size of a bit mask, that won't be checked on verbosity
+    /// Lint: VERBOSE_BIT_MASK. The maximum allowed size of a bit mask before suggesting to use 'trailing_zeros'
     (verbose_bit_mask_threshold, "verbose_bit_mask_threshold", 1 => u64),
 }
 

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -172,6 +172,8 @@ define_Conf! {
     (enum_variant_name_threshold, "enum_variant_name_threshold", 3 => u64),
     /// Lint: LARGE_ENUM_VARIANT. The maximum size of a emum's variant to avoid box suggestion
     (enum_variant_size_threshold, "enum_variant_size_threshold", 200 => u64),
+    /// Lint: VERBOSE_BIT_MASK. The maximum size of a bit mask, that won't be checked on verbosity
+    (verbose_bit_mask_threshold, "verbose_bit_mask_threshold", 1 => u64),
 }
 
 /// Search for the configuration file.

--- a/tests/ui/bit_masks.stderr
+++ b/tests/ui/bit_masks.stderr
@@ -6,20 +6,6 @@ error: &-masking with zero
    |
    = note: `-D bad-bit-mask` implied by `-D warnings`
 
-error: bit mask could be simplified with a call to `trailing_zeros`
-  --> $DIR/bit_masks.rs:12:5
-   |
-12 |     x & 0 == 0;
-   |     ^^^^^^^^^^ help: try: `x.trailing_zeros() >= 0`
-   |
-   = note: `-D verbose-bit-mask` implied by `-D warnings`
-
-error: bit mask could be simplified with a call to `trailing_zeros`
-  --> $DIR/bit_masks.rs:14:5
-   |
-14 |     x & 1 == 0; //ok, compared with zero
-   |     ^^^^^^^^^^ help: try: `x.trailing_zeros() >= 1`
-
 error: incompatible bit mask: `_ & 2` can never be equal to `1`
   --> $DIR/bit_masks.rs:15:5
    |
@@ -106,5 +92,5 @@ error: ineffective bit mask: `x | 1` compared to `8`, is the same as x compared 
 55 |     x | 1 >= 8;
    |     ^^^^^^^^^^
 
-error: aborting due to 17 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui/conf_unknown_key.stderr
+++ b/tests/ui/conf_unknown_key.stderr
@@ -1,4 +1,4 @@
-error: error reading Clippy's configuration file: unknown field `foobar`, expected one of `blacklisted-names`, `cyclomatic-complexity-threshold`, `doc-valid-idents`, `too-many-arguments-threshold`, `type-complexity-threshold`, `single-char-binding-names-threshold`, `too-large-for-stack`, `enum-variant-name-threshold`, `enum-variant-size-threshold`, `third-party`
+error: error reading Clippy's configuration file: unknown field `foobar`, expected one of `blacklisted-names`, `cyclomatic-complexity-threshold`, `doc-valid-idents`, `too-many-arguments-threshold`, `type-complexity-threshold`, `single-char-binding-names-threshold`, `too-large-for-stack`, `enum-variant-name-threshold`, `enum-variant-size-threshold`, `verbose-bit-mask-threshold`, `third-party`
 
 error: aborting due to previous error
 

--- a/tests/ui/trailing_zeros.rs
+++ b/tests/ui/trailing_zeros.rs
@@ -7,4 +7,5 @@ fn main() {
     let _ = #[clippy(author)] (x & 0b1111 == 0);  // suggest trailing_zeros
     let _ = x & 0b1_1111 == 0; // suggest trailing_zeros
     let _ = x & 0b1_1010 == 0; // do not lint
+    let _ = x & 1 == 0; // do not lint
 }


### PR DESCRIPTION
To fix issue #2078 . By default option is 1. u64, because I didn't figure out how to deserialize
u128 from config. 