### PR TITLE
Improve needless_pass_by_value

### DIFF
--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -2,16 +2,15 @@
 
 use std::borrow::Cow;
 use rustc::hir::*;
-use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::hir::map::NodeItem;
 use rustc::lint::*;
 use rustc::ty;
-use syntax::ast::{Name, NodeId};
+use syntax::ast::NodeId;
 use syntax::codemap::Span;
 use syntax_pos::MultiSpan;
-use utils::{get_pat_name, match_qpath, match_type, match_var, paths,
-            snippet, snippet_opt, span_lint, span_lint_and_then,
+use utils::{match_qpath, match_type, paths, snippet_opt, span_lint, span_lint_and_then,
             walk_ptrs_hir_ty};
+use utils::ptr::get_spans;
 
 /// **What it does:** This lint checks for function arguments of type `&String`
 /// or `&Vec` unless the references are mutable. It will also suggest you
@@ -164,7 +163,7 @@ fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<
                 ], {
                     ty_snippet = snippet_opt(cx, parameters.types[0].span);
                 });
-                if let Ok(spans) = get_spans(cx, opt_body_id, idx, &[("clone", ".to_owned()")]) {
+                if let Some(spans) = get_spans(cx, opt_body_id, idx, &[("clone", ".to_owned()")]) {
                     span_lint_and_then(
                         cx,
                         PTR_ARG,
@@ -187,7 +186,7 @@ fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<
                     );
                 }
             } else if match_type(cx, ty, &paths::STRING) {
-                if let Ok(spans) = get_spans(cx, opt_body_id, idx, &[("clone", ".to_string()"), ("as_str", "")]) {
+                if let Some(spans) = get_spans(cx, opt_body_id, idx, &[("clone", ".to_string()"), ("as_str", "")]) {
                     span_lint_and_then(
                         cx,
                         PTR_ARG,
@@ -232,66 +231,6 @@ fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<
             });
         }
     }
-}
-
-fn get_spans(cx: &LateContext, opt_body_id: Option<BodyId>, idx: usize, replacements: &'static [(&'static str, &'static str)]) -> Result<Vec<(Span, Cow<'static, str>)>, ()> {
-    if let Some(body) = opt_body_id.map(|id| cx.tcx.hir.body(id)) {
-        get_binding_name(&body.arguments[idx]).map_or_else(|| Ok(vec![]),
-                                                |name| extract_clone_suggestions(cx, name, replacements, body))
-    } else {
-        Ok(vec![])
-    }
-}
-
-fn extract_clone_suggestions<'a, 'tcx: 'a>(cx: &LateContext<'a, 'tcx>, name: Name, replace: &'static [(&'static str, &'static str)], body: &'tcx Body) -> Result<Vec<(Span, Cow<'static, str>)>, ()> {
-    let mut visitor = PtrCloneVisitor {
-        cx,
-        name,
-        replace,
-        spans: vec![],
-        abort: false,
-    };
-    visitor.visit_body(body);
-    if visitor.abort { Err(()) } else { Ok(visitor.spans) }
-}
-
-struct PtrCloneVisitor<'a, 'tcx: 'a> {
-    cx: &'a LateContext<'a, 'tcx>,
-    name: Name,
-    replace: &'static [(&'static str, &'static str)],
-    spans: Vec<(Span, Cow<'static, str>)>,
-    abort: bool,
-}
-
-impl<'a, 'tcx: 'a> Visitor<'tcx> for PtrCloneVisitor<'a, 'tcx> {
-    fn visit_expr(&mut self, expr: &'tcx Expr) {
-        if self.abort { return; }
-        if let ExprMethodCall(ref seg, _, ref args) = expr.node {
-            if args.len() == 1 && match_var(&args[0], self.name) {
-                if seg.name == "capacity" {
-                    self.abort = true;
-                    return;
-                }
-                for &(fn_name, suffix) in self.replace {
-                    if seg.name == fn_name {
-                        self.spans.push((expr.span, snippet(self.cx, args[0].span, "_") + suffix));
-                        return;
-                    }
-                }
-            }
-            return;
-        }
-        walk_expr(self, expr);
-    }
-
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::None
-    }
-
-}
-
-fn get_binding_name(arg: &Arg) -> Option<Name> {
-    get_pat_name(&arg.pat)
 }
 
 fn get_rptr_lm(ty: &Ty) -> Option<(&Lifetime, Mutability, Span)> {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -32,6 +32,7 @@ pub mod sugg;
 pub mod inspector;
 pub mod internal_lints;
 pub mod author;
+pub mod ptr;
 pub use self::hir_utils::{SpanlessEq, SpanlessHash};
 
 pub type MethodArgs = HirVec<P<Expr>>;

--- a/clippy_lints/src/utils/ptr.rs
+++ b/clippy_lints/src/utils/ptr.rs
@@ -1,0 +1,83 @@
+use std::borrow::Cow;
+use rustc::hir::*;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::lint::LateContext;
+use syntax::ast::Name;
+use syntax::codemap::Span;
+use utils::{get_pat_name, match_var, snippet};
+
+pub fn get_spans(
+    cx: &LateContext,
+    opt_body_id: Option<BodyId>,
+    idx: usize,
+    replacements: &'static [(&'static str, &'static str)],
+) -> Option<Vec<(Span, Cow<'static, str>)>> {
+    if let Some(body) = opt_body_id.map(|id| cx.tcx.hir.body(id)) {
+        get_binding_name(&body.arguments[idx])
+            .map_or_else(|| Some(vec![]), |name| extract_clone_suggestions(cx, name, replacements, body))
+    } else {
+        Some(vec![])
+    }
+}
+
+fn extract_clone_suggestions<'a, 'tcx: 'a>(
+    cx: &LateContext<'a, 'tcx>,
+    name: Name,
+    replace: &'static [(&'static str, &'static str)],
+    body: &'tcx Body,
+) -> Option<Vec<(Span, Cow<'static, str>)>> {
+    let mut visitor = PtrCloneVisitor {
+        cx,
+        name,
+        replace,
+        spans: vec![],
+        abort: false,
+    };
+    visitor.visit_body(body);
+    if visitor.abort {
+        None
+    } else {
+        Some(visitor.spans)
+    }
+}
+
+struct PtrCloneVisitor<'a, 'tcx: 'a> {
+    cx: &'a LateContext<'a, 'tcx>,
+    name: Name,
+    replace: &'static [(&'static str, &'static str)],
+    spans: Vec<(Span, Cow<'static, str>)>,
+    abort: bool,
+}
+
+impl<'a, 'tcx: 'a> Visitor<'tcx> for PtrCloneVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx Expr) {
+        if self.abort {
+            return;
+        }
+        if let ExprMethodCall(ref seg, _, ref args) = expr.node {
+            if args.len() == 1 && match_var(&args[0], self.name) {
+                if seg.name == "capacity" {
+                    self.abort = true;
+                    return;
+                }
+                for &(fn_name, suffix) in self.replace {
+                    if seg.name == fn_name {
+                        self.spans
+                            .push((expr.span, snippet(self.cx, args[0].span, "_") + suffix));
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+        walk_expr(self, expr);
+    }
+
+    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
+        NestedVisitorMap::None
+    }
+}
+
+fn get_binding_name(arg: &Arg) -> Option<Name> {
+    get_pat_name(&arg.pat)
+}

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -72,4 +72,11 @@ impl Serialize for i32 {}
 
 fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
 
+fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
+    s.capacity();
+    let _ = t.clone();
+    u.capacity();
+    let _ = v.clone();
+}
+
 fn main() {}

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -4,6 +4,9 @@
 #![warn(needless_pass_by_value)]
 #![allow(dead_code, single_match, if_let_redundant_pattern_matching, many_single_char_names)]
 
+use std::borrow::Borrow;
+use std::convert::AsRef;
+
 // `v` should be warned
 // `w`, `x` and `y` are allowed (moved or mutated)
 fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
@@ -25,10 +28,11 @@ fn bar(x: String, y: Wrapper) {
     assert_eq!(y.0.len(), 42);
 }
 
-// U implements `Borrow<U>`, but should be warned correctly
-fn test_borrow_trait<T: std::borrow::Borrow<str>, U>(t: T, u: U) {
+// V implements `Borrow<V>`, but should be warned correctly
+fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: V) {
     println!("{}", t.borrow());
-    consume(&u);
+    println!("{}", u.as_ref());
+    consume(&v);
 }
 
 // ok
@@ -58,5 +62,14 @@ fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
     assert_eq!(x.0.len(), s.len());
     println!("{}", t);
 }
+
+trait Foo {}
+
+// `S: Serialize` can be passed by value
+trait Serialize {}
+impl<'a, T> Serialize for &'a T where T: Serialize {}
+impl Serialize for i32 {}
+
+fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
 
 fn main() {}

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -62,3 +62,45 @@ error: this argument is passed by value, but not consumed in the function body
 73 | fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
    |                                                 ^ help: consider taking a reference instead: `&T`
 
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:75:18
+   |
+75 | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
+   |                  ^^^^^^ help: consider taking a reference instead: `&String`
+
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:75:29
+   |
+75 | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
+   |                             ^^^^^^
+   |
+help: consider changing the type to
+   |
+75 | fn issue_2114(s: String, t: &str, u: Vec<i32>, v: Vec<i32>) {
+   |                             ^^^^
+help: change `t.clone()` to
+   |
+77 |     let _ = t.to_string();
+   |             ^^^^^^^^^^^^^
+
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:75:40
+   |
+75 | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
+   |                                        ^^^^^^^^ help: consider taking a reference instead: `&Vec<i32>`
+
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:75:53
+   |
+75 | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
+   |                                                     ^^^^^^^^
+   |
+help: consider changing the type to
+   |
+75 | fn issue_2114(s: String, t: String, u: Vec<i32>, v: &[i32]) {
+   |                                                     ^^^^^^
+help: change `v.clone()` to
+   |
+79 |     let _ = v.to_owned();
+   |             ^^^^^^^^^^^^
+

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -1,58 +1,64 @@
 error: this argument is passed by value, but not consumed in the function body
- --> $DIR/needless_pass_by_value.rs:9:23
-  |
-9 | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
-  |                       ^^^^^^ help: consider changing the type to: `&[T]`
-  |
-  = note: `-D needless-pass-by-value` implied by `-D warnings`
+  --> $DIR/needless_pass_by_value.rs:12:23
+   |
+12 | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
+   |                       ^^^^^^ help: consider changing the type to: `&[T]`
+   |
+   = note: `-D needless-pass-by-value` implied by `-D warnings`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:23:11
+  --> $DIR/needless_pass_by_value.rs:26:11
    |
-23 | fn bar(x: String, y: Wrapper) {
+26 | fn bar(x: String, y: Wrapper) {
    |           ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:23:22
+  --> $DIR/needless_pass_by_value.rs:26:22
    |
-23 | fn bar(x: String, y: Wrapper) {
+26 | fn bar(x: String, y: Wrapper) {
    |                      ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:29:63
+  --> $DIR/needless_pass_by_value.rs:32:71
    |
-29 | fn test_borrow_trait<T: std::borrow::Borrow<str>, U>(t: T, u: U) {
-   |                                                               ^ help: consider taking a reference instead: `&U`
+32 | fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: V) {
+   |                                                                       ^ help: consider taking a reference instead: `&V`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:40:18
+  --> $DIR/needless_pass_by_value.rs:44:18
    |
-40 | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
+44 | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider taking a reference instead
    |
-40 | fn test_match(x: &Option<Option<String>>, y: Option<Option<String>>) {
-41 |     match *x {
+44 | fn test_match(x: &Option<Option<String>>, y: Option<Option<String>>) {
+45 |     match *x {
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:53:24
+  --> $DIR/needless_pass_by_value.rs:57:24
    |
-53 | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
+57 | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                        ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:53:36
+  --> $DIR/needless_pass_by_value.rs:57:36
    |
-53 | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
+57 | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                                    ^^^^^^^
    |
 help: consider taking a reference instead
    |
-53 | fn test_destructure(x: Wrapper, y: &Wrapper, z: Wrapper) {
-54 |     let Wrapper(s) = z; // moved
-55 |     let Wrapper(ref t) = *y; // not moved
-56 |     let Wrapper(_) = *y; // still not moved
+57 | fn test_destructure(x: Wrapper, y: &Wrapper, z: Wrapper) {
+58 |     let Wrapper(s) = z; // moved
+59 |     let Wrapper(ref t) = *y; // not moved
+60 |     let Wrapper(_) = *y; // still not moved
    |
+
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:73:49
+   |
+73 | fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
+   |                                                 ^ help: consider taking a reference instead: `&T`
 


### PR DESCRIPTION
* Reducing false positives by excluding a type whose reference also fullfils the trait bound (e.g. an argument bounded by  `serde::Serialize` which has a blanket impl `impl Serialize for &S where S:Serialize`).
* Use `ptr_arg`'s logic for `String` and `Vec`. Fixes #2114.
  * Now `&String` is suggested if `.capacity()` is found.