### PR TITLE
relax `needless_range_loop` so that it reports only direct indexing

### DIFF
--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -1,0 +1,27 @@
+fn calc_idx(i: usize) -> usize {
+    (i + i + 20) % 4
+}
+
+fn main() {
+    let ns = [2, 3, 5, 7];
+
+    for i in 3..10 {
+        println!("{}", ns[i]);
+    }
+
+    for i in 3..10 {
+        println!("{}", ns[i % 4]);
+    }
+
+    for i in 3..10 {
+        println!("{}", ns[i % ns.len()]);
+    }
+
+    for i in 3..10 {
+        println!("{}", ns[calc_idx(i)]);
+    }
+
+    for i in 3..10 {
+        println!("{}", ns[calc_idx(i) % 4]);
+    }
+}

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -1,0 +1,14 @@
+error: the loop variable `i` is only used to index `ns`.
+  --> $DIR/needless_range_loop.rs:8:5
+   |
+8  | /     for i in 3..10 {
+9  | |         println!("{}", ns[i]);
+10 | |     }
+   | |_____^
+   |
+   = note: `-D needless-range-loop` implied by `-D warnings`
+help: consider using an iterator
+   |
+8  |     for <item> in ns.iter().take(10).skip(3) {
+   |         ^^^^^^
+


### PR DESCRIPTION
This change relaxes `needless_range_loop` so that it doesn't report cases when variable is indexed with some complex expression. Currently changes suggested by lint are not correct, and in some cases not desired. This "aggressive" check was there since PR #2021.
Fixes #2106 #2036
Test code and linter outputs here:
https://gist.github.com/chyvonomys/fcdc306d38c0de7cb40764fa697be593