### PR TITLE
Implicit hasher lint

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -333,6 +333,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box infinite_iter::Pass);
     reg.register_late_lint_pass(box invalid_ref::InvalidRef);
     reg.register_late_lint_pass(box identity_conversion::IdentityConversion::default());
+    reg.register_late_lint_pass(box types::ImplicitHasher);
 
     reg.register_lint_group("clippy_restrictions", vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -555,6 +556,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         types::BOX_VEC,
         types::CAST_LOSSLESS,
         types::CHAR_LIT_AS_U8,
+        types::IMPLICIT_HASHER,
         types::LET_UNIT_VALUE,
         types::LINKEDLIST,
         types::TYPE_COMPLEXITY,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -13,6 +13,7 @@
 
 #[macro_use]
 extern crate rustc;
+extern crate rustc_typeck;
 extern crate syntax;
 extern crate syntax_pos;
 

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1453,8 +1453,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidUpcastComparisons {
     }
 }
 
-/// **What it does:** Checks for public `impl` or `fn` missing generalization over
-/// different hashers and implicitly defaulting to the default hashing
+/// **What it does:** Checks for public `impl` or `fn` missing generalization
+/// over different hashers and implicitly defaulting to the default hashing
 /// algorithm (SipHash).
 ///
 /// **Why is this bad?** `HashMap` or `HashSet` with custom hashers cannot be
@@ -1505,26 +1505,29 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
                 &generics_snip[1..generics_snip.len() - 1]
             };
 
-            db.span_suggestion(
-                generics_suggestion_span,
-                "consider adding a type parameter",
-                format!(
-                    "<{}{}S: ::std::hash::BuildHasher{}>",
-                    generics_snip,
-                    if generics_snip.is_empty() { "" } else { ", " },
-                    if vis.suggestions.is_empty() {
-                        ""
-                    } else {
-                        // request users to add `Default` bound so that generic constructors can be used
-                        " + Default"
-                    },
-                ),
-            );
-
-            db.span_suggestion(
-                target.span(),
-                "...and change the type to",
-                format!("{}<{}, S>", target.type_name(), target.type_arguments(),),
+            multispan_sugg(
+                db,
+                "consider adding a type parameter".to_string(),
+                vec![
+                    (
+                        generics_suggestion_span,
+                        format!(
+                            "<{}{}S: ::std::hash::BuildHasher{}>",
+                            generics_snip,
+                            if generics_snip.is_empty() { "" } else { ", " },
+                            if vis.suggestions.is_empty() {
+                                ""
+                            } else {
+                                // request users to add `Default` bound so that generic constructors can be used
+                                " + Default"
+                            },
+                        ),
+                    ),
+                    (
+                        target.span(),
+                        format!("{}<{}, S>", target.type_name(), target.type_arguments(),),
+                    ),
+                ],
             );
 
             if !vis.suggestions.is_empty() {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -664,7 +664,10 @@ pub fn span_lint_and_sugg<'a, 'tcx: 'a, T: LintContext<'tcx>>(
 /// appear once per
 /// replacement. In human-readable format though, it only appears once before
 /// the whole suggestion.
-pub fn multispan_sugg(db: &mut DiagnosticBuilder, help_msg: String, sugg: Vec<(Span, String)>) {
+pub fn multispan_sugg<I>(db: &mut DiagnosticBuilder, help_msg: String, sugg: I)
+where
+    I: IntoIterator<Item=(Span, String)>,
+{
     let sugg = rustc_errors::CodeSuggestion {
         substitution_parts: sugg.into_iter()
             .map(|(span, sub)| {

--- a/tests/ui/implicit_hasher.rs
+++ b/tests/ui/implicit_hasher.rs
@@ -1,0 +1,68 @@
+#![allow(unused)]
+//#![feature(plugin)]#![plugin(clippy)]
+use std::collections::{HashMap, HashSet};
+use std::cmp::Eq;
+use std::hash::{Hash, BuildHasher};
+
+trait Foo<T>: Sized {
+    fn make() -> (Self, Self);
+}
+
+impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V> {
+    fn make() -> (Self, Self) {
+        // OK, don't suggest to modify these
+        let _: HashMap<i32, i32> = HashMap::new();
+        let _: HashSet<i32> = HashSet::new();
+
+        (HashMap::new(), HashMap::with_capacity(10))
+    }
+}
+impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V>,) {
+    fn make() -> (Self, Self) {
+        ((HashMap::new(),), (HashMap::with_capacity(10),))
+    }
+}
+impl Foo<i16> for HashMap<String, String> {
+    fn make() -> (Self, Self) {
+        (HashMap::new(), HashMap::with_capacity(10))
+    }
+}
+
+impl<K: Hash + Eq, V, S: BuildHasher + Default> Foo<i32> for HashMap<K, V, S> {
+    fn make() -> (Self, Self) {
+        (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
+    }
+}
+impl<S: BuildHasher + Default> Foo<i64> for HashMap<String, String, S> {
+    fn make() -> (Self, Self) {
+        (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
+    }
+}
+
+
+impl<T: Hash + Eq> Foo<i8> for HashSet<T> {
+    fn make() -> (Self, Self) {
+        (HashSet::new(), HashSet::with_capacity(10))
+    }
+}
+impl Foo<i16> for HashSet<String> {
+    fn make() -> (Self, Self) {
+        (HashSet::new(), HashSet::with_capacity(10))
+    }
+}
+
+impl<T: Hash + Eq, S: BuildHasher + Default> Foo<i32> for HashSet<T, S> {
+    fn make() -> (Self, Self) {
+        (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default::default()))
+    }
+}
+impl<S: BuildHasher + Default> Foo<i64> for HashSet<String, S> {
+    fn make() -> (Self, Self) {
+        (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default::default()))
+    }
+}
+
+pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+}
+
+fn main() {}

--- a/tests/ui/implicit_hasher.rs
+++ b/tests/ui/implicit_hasher.rs
@@ -65,4 +65,22 @@ impl<S: BuildHasher + Default> Foo<i64> for HashSet<String, S> {
 pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
 }
 
+macro_rules! gen {
+    (impl) => {
+        impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V> {
+            fn make() -> (Self, Self) {
+                (HashMap::new(), HashMap::with_capacity(10))
+            }
+        }
+    };
+
+    (fn $name:ident) => {
+        pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+        }
+    }
+}
+
+gen!(impl);
+gen!(fn bar);
+
 fn main() {}

--- a/tests/ui/implicit_hasher.rs
+++ b/tests/ui/implicit_hasher.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::cmp::Eq;
 use std::hash::{Hash, BuildHasher};
 
-trait Foo<T>: Sized {
+pub trait Foo<T>: Sized {
     fn make() -> (Self, Self);
 }
 

--- a/tests/ui/implicit_hasher.stderr
+++ b/tests/ui/implicit_hasher.stderr
@@ -1,0 +1,154 @@
+error: impl for `HashMap` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:11:35
+   |
+11 | impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V> {
+   |                                   ^^^^^^^^^^^^^
+   |
+   = note: `-D implicit-hasher` implied by `-D warnings`
+help: consider adding a type parameter
+   |
+11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashMap<K, V> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+11 | impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V, S> {
+   |                                   ^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+14 |         let _: HashMap<i32, i32> = HashMap::default();
+   |                                    ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+15 |         let _: HashSet<i32> = HashSet::default();
+   |                               ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+17 |         (HashMap::default(), HashMap::with_capacity(10))
+   |          ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+17 |         (HashMap::new(), HashMap::with_capacity_and_hasher(10, Default::default()))
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: impl for `HashMap` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:20:36
+   |
+20 | impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V>,) {
+   |                                    ^^^^^^^^^^^^^
+   |
+help: consider adding a type parameter
+   |
+20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for (HashMap<K, V>,) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+20 | impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V, S>,) {
+   |                                    ^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+22 |         ((HashMap::default(),), (HashMap::with_capacity(10),))
+   |           ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+22 |         ((HashMap::new(),), (HashMap::with_capacity_and_hasher(10, Default::default()),))
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: impl for `HashMap` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:25:19
+   |
+25 | impl Foo<i16> for HashMap<String, String> {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider adding a type parameter
+   |
+25 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashMap<String, String> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+25 | impl Foo<i16> for HashMap<String, String, S> {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+27 |         (HashMap::default(), HashMap::with_capacity(10))
+   |          ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+27 |         (HashMap::new(), HashMap::with_capacity_and_hasher(10, Default::default()))
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: impl for `HashSet` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:43:32
+   |
+43 | impl<T: Hash + Eq> Foo<i8> for HashSet<T> {
+   |                                ^^^^^^^^^^
+   |
+help: consider adding a type parameter
+   |
+43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashSet<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+43 | impl<T: Hash + Eq> Foo<i8> for HashSet<T, S> {
+   |                                ^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+45 |         (HashSet::default(), HashSet::with_capacity(10))
+   |          ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+45 |         (HashSet::new(), HashSet::with_capacity_and_hasher(10, Default::default()))
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: impl for `HashSet` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:48:19
+   |
+48 | impl Foo<i16> for HashSet<String> {
+   |                   ^^^^^^^^^^^^^^^
+   |
+help: consider adding a type parameter
+   |
+48 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashSet<String> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+48 | impl Foo<i16> for HashSet<String, S> {
+   |                   ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+50 |         (HashSet::default(), HashSet::with_capacity(10))
+   |          ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor here
+   |
+50 |         (HashSet::new(), HashSet::with_capacity_and_hasher(10, Default::default()))
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: parameter of type `HashMap` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:65:23
+   |
+65 | pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |                       ^^^^^^^^^^^^^^^^^
+   |
+help: consider adding a type parameter
+   |
+65 | pub fn foo<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+65 | pub fn foo(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {
+   |                       ^^^^^^^^^^^^^^^^^^^^
+
+error: parameter of type `HashSet` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:65:53
+   |
+65 | pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |                                                     ^^^^^^^^^^^^
+   |
+help: consider adding a type parameter
+   |
+65 | pub fn foo<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+65 | pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
+   |                                                     ^^^^^^^^^^^^^^^
+

--- a/tests/ui/implicit_hasher.stderr
+++ b/tests/ui/implicit_hasher.stderr
@@ -7,28 +7,12 @@ error: impl for `HashMap` should be generarized over different hashers
    = note: `-D implicit-hasher` implied by `-D warnings`
 help: consider adding a type parameter
    |
-11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashMap<K, V> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher> Foo<i8> for HashMap<K, V> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 11 | impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V, S> {
    |                                   ^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-14 |         let _: HashMap<i32, i32> = HashMap::default();
-   |                                    ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-15 |         let _: HashSet<i32> = HashSet::default();
-   |                               ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-17 |         (HashMap::default(), HashMap::with_capacity(10))
-   |          ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-17 |         (HashMap::new(), HashMap::with_capacity_and_hasher(10, Default::default()))
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:20:36
@@ -38,20 +22,12 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for (HashMap<K, V>,) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher> Foo<i8> for (HashMap<K, V>,) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 20 | impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V, S>,) {
    |                                    ^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-22 |         ((HashMap::default(),), (HashMap::with_capacity(10),))
-   |           ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-22 |         ((HashMap::new(),), (HashMap::with_capacity_and_hasher(10, Default::default()),))
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:25:19
@@ -61,20 +37,12 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-25 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashMap<String, String> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+25 | impl<S: ::std::hash::BuildHasher> Foo<i16> for HashMap<String, String> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 25 | impl Foo<i16> for HashMap<String, String, S> {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-27 |         (HashMap::default(), HashMap::with_capacity(10))
-   |          ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-27 |         (HashMap::new(), HashMap::with_capacity_and_hasher(10, Default::default()))
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashSet` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:43:32
@@ -84,20 +52,12 @@ error: impl for `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashSet<T> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher> Foo<i8> for HashSet<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 43 | impl<T: Hash + Eq> Foo<i8> for HashSet<T, S> {
    |                                ^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-45 |         (HashSet::default(), HashSet::with_capacity(10))
-   |          ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-45 |         (HashSet::new(), HashSet::with_capacity_and_hasher(10, Default::default()))
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashSet` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:48:19
@@ -107,20 +67,12 @@ error: impl for `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-48 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashSet<String> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+48 | impl<S: ::std::hash::BuildHasher> Foo<i16> for HashSet<String> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 48 | impl Foo<i16> for HashSet<String, S> {
    |                   ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-50 |         (HashSet::default(), HashSet::with_capacity(10))
-   |          ^^^^^^^^^^^^^^^^^^
-help: ...and use generic constructor here
-   |
-50 |         (HashSet::new(), HashSet::with_capacity_and_hasher(10, Default::default()))
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: parameter of type `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:65:23
@@ -151,4 +103,58 @@ help: ...and change the type to
    |
 65 | pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
    |                                                     ^^^^^^^^^^^^^^^
+
+error: impl for `HashMap` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:70:43
+   |
+70 |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V> {
+   |                                           ^^^^^^^^^^^^^
+...
+83 | gen!(impl);
+   | ----------- in this macro invocation
+   |
+help: consider adding a type parameter
+   |
+70 |         impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher> Foo<u8> for HashMap<K, V> {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+70 |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V, S> {
+   |                                           ^^^^^^^^^^^^^^^^
+
+error: parameter of type `HashMap` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:78:33
+   |
+78 |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |                                 ^^^^^^^^^^^^^^^^^
+...
+84 | gen!(fn bar);
+   | ------------- in this macro invocation
+   |
+help: consider adding a type parameter
+   |
+78 |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+78 |         pub fn $name(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {
+   |                                 ^^^^^^^^^^^^^^^^^^^^
+
+error: parameter of type `HashSet` should be generarized over different hashers
+  --> $DIR/implicit_hasher.rs:78:63
+   |
+78 |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |                                                               ^^^^^^^^^^^^
+...
+84 | gen!(fn bar);
+   | ------------- in this macro invocation
+   |
+help: consider adding a type parameter
+   |
+78 |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and change the type to
+   |
+78 |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
+   |                                                               ^^^^^^^^^^^^^^^
 

--- a/tests/ui/implicit_hasher.stderr
+++ b/tests/ui/implicit_hasher.stderr
@@ -7,12 +7,16 @@ error: impl for `HashMap` should be generarized over different hashers
    = note: `-D implicit-hasher` implied by `-D warnings`
 help: consider adding a type parameter
    |
-11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher> Foo<i8> for HashMap<K, V> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashMap<K, V> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 11 | impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V, S> {
    |                                   ^^^^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+17 |         (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
+   |          ^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:20:36
@@ -22,12 +26,16 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher> Foo<i8> for (HashMap<K, V>,) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for (HashMap<K, V>,) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 20 | impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V, S>,) {
    |                                    ^^^^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+22 |         ((HashMap::default(),), (HashMap::with_capacity_and_hasher(10, Default::default()),))
+   |           ^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:25:19
@@ -37,12 +45,16 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-25 | impl<S: ::std::hash::BuildHasher> Foo<i16> for HashMap<String, String> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+25 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashMap<String, String> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 25 | impl Foo<i16> for HashMap<String, String, S> {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+27 |         (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
+   |          ^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashSet` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:43:32
@@ -52,12 +64,16 @@ error: impl for `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher> Foo<i8> for HashSet<T> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashSet<T> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 43 | impl<T: Hash + Eq> Foo<i8> for HashSet<T, S> {
    |                                ^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+45 |         (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default::default()))
+   |          ^^^^^^^^^^^^^^^^^^
 
 error: impl for `HashSet` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:48:19
@@ -67,12 +83,16 @@ error: impl for `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-48 | impl<S: ::std::hash::BuildHasher> Foo<i16> for HashSet<String> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+48 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashSet<String> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 48 | impl Foo<i16> for HashSet<String, S> {
    |                   ^^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+50 |         (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default::default()))
+   |          ^^^^^^^^^^^^^^^^^^
 
 error: parameter of type `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:65:23
@@ -115,12 +135,16 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-70 |         impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher> Foo<u8> for HashMap<K, V> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+70 |         impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<u8> for HashMap<K, V> {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and change the type to
    |
 70 |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V, S> {
    |                                           ^^^^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+72 |                 (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
+   |                  ^^^^^^^^^^^^^^^^^^
 
 error: parameter of type `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:78:33

--- a/tests/ui/implicit_hasher.stderr
+++ b/tests/ui/implicit_hasher.stderr
@@ -7,12 +7,8 @@ error: impl for `HashMap` should be generarized over different hashers
    = note: `-D implicit-hasher` implied by `-D warnings`
 help: consider adding a type parameter
    |
-11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashMap<K, V> {
+11 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashMap<K, V, S> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-11 | impl<K: Hash + Eq, V> Foo<i8> for HashMap<K, V, S> {
-   |                                   ^^^^^^^^^^^^^^^^
 help: ...and use generic constructor
    |
 17 |         (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
@@ -26,12 +22,8 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for (HashMap<K, V>,) {
+20 | impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<i8> for (HashMap<K, V, S>,) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-20 | impl<K: Hash + Eq, V> Foo<i8> for (HashMap<K, V, S>,) {
-   |                                    ^^^^^^^^^^^^^^^^
 help: ...and use generic constructor
    |
 22 |         ((HashMap::default(),), (HashMap::with_capacity_and_hasher(10, Default::default()),))
@@ -45,12 +37,8 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-25 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashMap<String, String> {
+25 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashMap<String, String, S> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-25 | impl Foo<i16> for HashMap<String, String, S> {
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: ...and use generic constructor
    |
 27 |         (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
@@ -64,12 +52,8 @@ error: impl for `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashSet<T> {
+43 | impl<T: Hash + Eq, S: ::std::hash::BuildHasher + Default> Foo<i8> for HashSet<T, S> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-43 | impl<T: Hash + Eq> Foo<i8> for HashSet<T, S> {
-   |                                ^^^^^^^^^^^^^
 help: ...and use generic constructor
    |
 45 |         (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default::default()))
@@ -83,12 +67,8 @@ error: impl for `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-48 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashSet<String> {
+48 | impl<S: ::std::hash::BuildHasher + Default> Foo<i16> for HashSet<String, S> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-48 | impl Foo<i16> for HashSet<String, S> {
-   |                   ^^^^^^^^^^^^^^^^^^
 help: ...and use generic constructor
    |
 50 |         (HashSet::default(), HashSet::with_capacity_and_hasher(10, Default::default()))
@@ -102,12 +82,8 @@ error: parameter of type `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-65 | pub fn foo<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+65 | pub fn foo<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-65 | pub fn foo(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {
-   |                       ^^^^^^^^^^^^^^^^^^^^
 
 error: parameter of type `HashSet` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:65:53
@@ -117,12 +93,8 @@ error: parameter of type `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-65 | pub fn foo<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+65 | pub fn foo<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-65 | pub fn foo(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
-   |                                                     ^^^^^^^^^^^^^^^
 
 error: impl for `HashMap` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:70:43
@@ -135,12 +107,8 @@ error: impl for `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-70 |         impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<u8> for HashMap<K, V> {
+70 |         impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<u8> for HashMap<K, V, S> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-70 |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V, S> {
-   |                                           ^^^^^^^^^^^^^^^^
 help: ...and use generic constructor
    |
 72 |                 (HashMap::default(), HashMap::with_capacity_and_hasher(10, Default::default()))
@@ -157,12 +125,8 @@ error: parameter of type `HashMap` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-78 |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+78 |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-78 |         pub fn $name(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {
-   |                                 ^^^^^^^^^^^^^^^^^^^^
 
 error: parameter of type `HashSet` should be generarized over different hashers
   --> $DIR/implicit_hasher.rs:78:63
@@ -175,10 +139,6 @@ error: parameter of type `HashSet` should be generarized over different hashers
    |
 help: consider adding a type parameter
    |
-78 |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>) {
+78 |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: ...and change the type to
-   |
-78 |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {
-   |                                                               ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fixes #2101.

* Looks for `HashMap<K, V>` (without 3rd arg.) and `HashSet<T>` (without 2nd arg.) in `impl Trait for <here>` and function arguments.
* Suggests to add hasher argument and trait bound `BuildHasher`. Plus `Default` if non-generic constructor found.
* Looks for non-generic constructors (which can be used only with the default hasher) like `HashMap::new` or `HashMap::with_capacity`, and suggests to replace them with generic alternatives.
