### PR TITLE
Don't lint accidental "prefixes" on enum variants

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -159,7 +159,8 @@ fn check_variant(
     }
     for var in &def.variants {
         let name = var2str(var);
-        if partial_match(item_name, &name) == item_name_chars {
+        if partial_match(item_name, &name) == item_name_chars &&
+           name.chars().nth(item_name_chars).map_or(false, |c| !c.is_lowercase()) {
             span_lint(cx, lint, var.span, "Variant name starts with the enum's name");
         }
         if partial_rmatch(item_name, &name) == item_name_chars {

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -102,4 +102,18 @@ mod allowed {
     }
 }
 
+// should not lint
+enum Pat {
+    Foo,
+    Bar,
+    Path,
+}
+
+// should not lint
+enum N {
+    Pos,
+    Neg,
+    Float,
+}
+
 fn main() {}


### PR DESCRIPTION
fixes  #1241