### PR TITLE
Updated clippy to account for changes from rust-lang/rust#44766

### DIFF
--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LifetimePass {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx ImplItem) {
         if let ImplItemKind::Method(ref sig, id) = item.node {
-            check_fn_inner(cx, &sig.decl, Some(id), &sig.generics, item.span);
+            check_fn_inner(cx, &sig.decl, Some(id), &item.generics, item.span);
         }
     }
 
@@ -76,7 +76,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LifetimePass {
                 TraitMethod::Required(_) => None,
                 TraitMethod::Provided(id) => Some(id),
             };
-            check_fn_inner(cx, &sig.decl, body, &sig.generics, item.span);
+            check_fn_inner(cx, &sig.decl, body, &item.generics, item.span);
         }
     }
 }

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -719,7 +719,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                 if name == method_name &&
                    sig.decl.inputs.len() == n_args &&
                    out_type.matches(&sig.decl.output) &&
-                   self_kind.matches(first_arg_ty, first_arg, self_ty, false, &sig.generics) {
+                   self_kind.matches(first_arg_ty, first_arg, self_ty, false, &implitem.generics) {
                     span_lint(cx, SHOULD_IMPLEMENT_TRAIT, implitem.span, &format!(
                         "defining a method called `{}` on this type; consider implementing \
                          the `{}` trait or choosing a less ambiguous name", name, trait_name));
@@ -733,7 +733,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             for &(ref conv, self_kinds) in &CONVENTIONS {
                 if_let_chain! {[
                     conv.check(&name.as_str()),
-                    !self_kinds.iter().any(|k| k.matches(first_arg_ty, first_arg, self_ty, is_copy, &sig.generics)),
+                    !self_kinds.iter().any(|k| k.matches(first_arg_ty, first_arg, self_ty, is_copy, &implitem.generics)),
                 ], {
                     let lint = if item.vis == hir::Visibility::Public {
                         WRONG_PUB_SELF_CONVENTION

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -108,12 +108,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                 // can't be implemented by default
                 return;
             }
-            if !sig.generics.ty_params.is_empty() {
-                // when the result of `new()` depends on a type parameter we should not require
-                // an
-                // impl of `Default`
-                return;
-            }
+            //TODO: There is no sig.generics anymore and I don't know how to fix this.
+            //if !sig.generics.ty_params.is_empty() {
+            //    // when the result of `new()` depends on a type parameter we should not require
+            //    // an
+            //    // impl of `Default`
+            //    return;
+            //}
             if decl.inputs.is_empty() && name == "new" && cx.access_levels.is_reachable(id) {
                 let self_ty = cx.tcx
                     .type_of(cx.tcx.hir.local_def_id(cx.tcx.hir.get_parent(id)));


### PR DESCRIPTION
In rust-lang/rust#44766, I make some changes to the ast and the hir which break some clippy code. Please **DO NOT** merge these changes until that PR is merged. This PR shouldn't even pass CI until those changes land in the compiler, but I thought I would mention it anyway just in case. 

Some of the breaking changes were easy to fix, but there is one particular lint that I don't know how to fix. There's a TODO comment and commented out code in this PR to show where the problem is. I would appreciate some advice about how to go about fixing this.

The problem is that there is no more `sig.generics`. As part of my rustc PR, I lifted the generics property from each individual method signature to the trait/impl item itself. This is in preparation for implementing generic associated types. When I fixed [rustfmt](https://github.com/rust-lang-nursery/rustfmt/pull/2043), I was able to resolve this by adding a parameter to the function that needed to check generics so that the generics could be passed in from above. I tried doing that here but ran into some problems along the way. Do you think the right thing to do is to add a generics parameter to `check_fn`?