### PR TITLE
Add PRINTLN_EMPTY_STRING lint.

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -530,6 +530,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         partialeq_ne_impl::PARTIALEQ_NE_IMPL,
         precedence::PRECEDENCE,
         print::PRINT_WITH_NEWLINE,
+        print::PRINTLN_EMPTY_STRING,
         ptr::CMP_NULL,
         ptr::MUT_FROM_REF,
         ptr::PTR_ARG,

--- a/tests/ui/println_empty_string.rs
+++ b/tests/ui/println_empty_string.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!();
+    println!("");
+}

--- a/tests/ui/println_empty_string.stderr
+++ b/tests/ui/println_empty_string.stderr
@@ -1,0 +1,8 @@
+error: using `println!("")`, consider using `println!()` instead
+ --> $DIR/println_empty_string.rs:3:5
+  |
+3 |     println!("");
+  |     ^^^^^^^^^^^^^
+  |
+  = note: `-D print-with-newline` implied by `-D warnings`
+


### PR DESCRIPTION
I have no idea of how I could properly check that there is really an empty string argument in a `println` invocation.
I think this will need the pre-expanded AST, which I can't access even in an `EarlyLintPass`.

See the `HACK` in `print.rs` for details.

Will fix #2135 when ready.