### PR TITLE
 Extend needless_pass_by_value to methods 

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -134,7 +134,7 @@ fn check_collapsible_no_if_let(cx: &EarlyContext, expr: &ast::Expr, check: &ast:
                 db.span_suggestion(expr.span,
                                    "try",
                                    format!("if {} {}",
-                                           lhs.and(rhs),
+                                           lhs.and(&rhs),
                                            snippet_block(cx, content.span, "..")));
             });
         }

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -45,6 +45,7 @@ impl LintPass for IntPlusOne {
 // x + 1 <= y
 // x <= y - 1
 
+#[derive(Copy, Clone)]
 enum Side {
     LHS,
     RHS,

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -6,7 +6,7 @@
 use rustc::hir;
 use rustc::lint::{EarlyContext, LateContext, LintContext};
 use rustc_errors;
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 use std::fmt::Display;
 use std;
 use syntax::codemap::{CharPos, Span};
@@ -136,8 +136,8 @@ impl<'a> Sugg<'a> {
     }
 
     /// Convenience method to create the `<lhs> && <rhs>` suggestion.
-    pub fn and(self, rhs: Self) -> Sugg<'static> {
-        make_binop(ast::BinOpKind::And, &self, &rhs)
+    pub fn and<R: Borrow<Self>>(self, rhs: R) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::And, &self, rhs.borrow())
     }
 
     /// Convenience method to create the `<lhs> as <rhs>` suggestion.
@@ -162,10 +162,10 @@ impl<'a> Sugg<'a> {
 
     /// Convenience method to create the `<lhs>..<rhs>` or `<lhs>...<rhs>`
     /// suggestion.
-    pub fn range(self, end: Self, limit: ast::RangeLimits) -> Sugg<'static> {
+    pub fn range<E: Borrow<Self>>(self, end: E, limit: ast::RangeLimits) -> Sugg<'static> {
         match limit {
-            ast::RangeLimits::HalfOpen => make_assoc(AssocOp::DotDot, &self, &end),
-            ast::RangeLimits::Closed => make_assoc(AssocOp::DotDotEq, &self, &end),
+            ast::RangeLimits::HalfOpen => make_assoc(AssocOp::DotDot, &self, end.borrow()),
+            ast::RangeLimits::Closed => make_assoc(AssocOp::DotDotEq, &self, end.borrow()),
         }
     }
 

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -6,7 +6,7 @@
 use rustc::hir;
 use rustc::lint::{EarlyContext, LateContext, LintContext};
 use rustc_errors;
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::fmt::Display;
 use std;
 use syntax::codemap::{CharPos, Span};
@@ -136,8 +136,8 @@ impl<'a> Sugg<'a> {
     }
 
     /// Convenience method to create the `<lhs> && <rhs>` suggestion.
-    pub fn and<R: Borrow<Self>>(self, rhs: R) -> Sugg<'static> {
-        make_binop(ast::BinOpKind::And, &self, rhs.borrow())
+    pub fn and(self, rhs: &Self) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::And, &self, rhs)
     }
 
     /// Convenience method to create the `<lhs> as <rhs>` suggestion.
@@ -162,10 +162,10 @@ impl<'a> Sugg<'a> {
 
     /// Convenience method to create the `<lhs>..<rhs>` or `<lhs>...<rhs>`
     /// suggestion.
-    pub fn range<E: Borrow<Self>>(self, end: E, limit: ast::RangeLimits) -> Sugg<'static> {
+    pub fn range(self, end: &Self, limit: ast::RangeLimits) -> Sugg<'static> {
         match limit {
-            ast::RangeLimits::HalfOpen => make_assoc(AssocOp::DotDot, &self, end.borrow()),
-            ast::RangeLimits::Closed => make_assoc(AssocOp::DotDotEq, &self, end.borrow()),
+            ast::RangeLimits::HalfOpen => make_assoc(AssocOp::DotDot, &self, end),
+            ast::RangeLimits::Closed => make_assoc(AssocOp::DotDotEq, &self, end),
         }
     }
 

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -1,9 +1,9 @@
 
 #![feature(const_fn)]
 
-
 #![warn(clippy, clippy_pedantic)]
-#![allow(blacklisted_name, unused, print_stdout, non_ascii_literal, new_without_default, new_without_default_derive, missing_docs_in_private_items)]
+#![allow(blacklisted_name, unused, print_stdout, non_ascii_literal, new_without_default,
+    new_without_default_derive, missing_docs_in_private_items, needless_pass_by_value)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -65,7 +65,7 @@ fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
 
 trait Foo {}
 
-// `S: Serialize` can be passed by value
+// `S: Serialize` is allowed to be passed by value, since a caller can pass `&S` instead
 trait Serialize {}
 impl<'a, T> Serialize for &'a T where T: Serialize {}
 impl Serialize for i32 {}
@@ -77,6 +77,29 @@ fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
     let _ = t.clone();
     u.capacity();
     let _ = v.clone();
+}
+
+struct S<T, U>(T, U);
+
+impl<T: Serialize, U> S<T, U> {
+    fn foo(
+        self, // taking `self` by value is always allowed
+        s: String,
+        t: String,
+    ) -> usize {
+        s.len() + t.capacity()
+    }
+
+    fn bar(
+        _t: T, // Ok, since `&T: Serialize` too
+    ) {
+    }
+
+    fn baz(
+        &self,
+        _u: U,
+    ) {
+    }
 }
 
 fn main() {}

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -98,6 +98,7 @@ impl<T: Serialize, U> S<T, U> {
     fn baz(
         &self,
         _u: U,
+        _s: Self,
     ) {
     }
 }

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -122,3 +122,9 @@ error: this argument is passed by value, but not consumed in the function body
 100 |         _u: U,
     |             ^ help: consider taking a reference instead: `&U`
 
+error: this argument is passed by value, but not consumed in the function body
+   --> $DIR/needless_pass_by_value.rs:101:13
+    |
+101 |         _s: Self,
+    |             ^^^^ help: consider taking a reference instead: `&Self`
+

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -104,3 +104,21 @@ help: change `v.clone()` to
 79 |     let _ = v.to_owned();
    |             ^^^^^^^^^^^^
 
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:87:12
+   |
+87 |         s: String,
+   |            ^^^^^^ help: consider changing the type to: `&str`
+
+error: this argument is passed by value, but not consumed in the function body
+  --> $DIR/needless_pass_by_value.rs:88:12
+   |
+88 |         t: String,
+   |            ^^^^^^ help: consider taking a reference instead: `&String`
+
+error: this argument is passed by value, but not consumed in the function body
+   --> $DIR/needless_pass_by_value.rs:100:13
+    |
+100 |         _u: U,
+    |             ^ help: consider taking a reference instead: `&U`
+


### PR DESCRIPTION
I don't remember why I didn't include them initially.