### PR TITLE
Fix false positive in needless_pass_by_value trait methods

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -87,7 +87,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
 
         // Exclude non-inherent impls
         if let Some(NodeItem(item)) = cx.tcx.hir.find(cx.tcx.hir.get_parent_node(node_id)) {
-            if matches!(item.node, ItemImpl(_, _, _, _, Some(_), _, _) | ItemAutoImpl(..)) {
+            if matches!(item.node, ItemImpl(_, _, _, _, Some(_), _, _) | ItemAutoImpl(..) |
+                ItemTrait(..))
+            {
                 return;
             }
         }

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -144,7 +144,6 @@ impl LintPass for StringLitAsBytes {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        use std::ascii::AsciiExt;
         use syntax::ast::LitKind;
         use utils::{in_macro, snippet};
 

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -103,4 +103,11 @@ impl<T: Serialize, U> S<T, U> {
     }
 }
 
+trait FalsePositive {
+    fn visit_str(s: &str);
+    fn visit_string(s: String) {
+        Self::visit_str(&s);
+    }
+}
+
 fn main() {}

--- a/tests/ui/unicode.stderr
+++ b/tests/ui/unicode.stderr
@@ -2,7 +2,7 @@ error: zero-width space detected
  --> $DIR/unicode.rs:6:12
   |
 6 |     print!("Here >​< is a ZWS, and ​another");
-  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D zero-width-space` implied by `-D warnings`
   = help: Consider replacing the string with:
@@ -12,7 +12,7 @@ error: non-nfc unicode sequence detected
   --> $DIR/unicode.rs:12:12
    |
 12 |     print!("̀àh?");
-   |            ^^^^^^^
+   |            ^^^^^
    |
    = note: `-D unicode-not-nfc` implied by `-D warnings`
    = help: Consider replacing the string with:


### PR DESCRIPTION
Fixes #2208 (and rustup to `1.23.0-nightly (3b82e4c74 2017-11-05)`)