### PR TITLE
Handle methods with an obvious negation in the non-minimal bool lint

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -44,11 +44,10 @@ declare_lint! {
     "boolean expressions that contain terminals which can be eliminated"
 }
 
-const METHODS_WITH_NEGATION: [(&str, &str); 4] = [
+// For each pairs, both orders are considered.
+const METHODS_WITH_NEGATION: [(&str, &str); 2] = [
     ("is_some", "is_none"),
-    ("is_none", "is_some"),
     ("is_err", "is_ok"),
-    ("is_ok", "is_err"),
 ];
 
 #[derive(Copy, Clone)]
@@ -407,21 +406,23 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
     fn handle_method_call_in_not(&mut self, e: &'tcx Expr, inner: &'tcx Expr) {
         if let ExprMethodCall(ref path, _, ref args) = inner.node {
             if args.len() == 1 {
-                METHODS_WITH_NEGATION.iter().for_each(|&(method, negation_method)| {
-                    if method == path.name.as_str() {
-                        span_lint_and_then(
-                            self.cx,
-                            NONMINIMAL_BOOL,
-                            e.span,
-                            "this boolean expression can be simplified",
-                            |db| {
-                                db.span_suggestion(
-                                    e.span,
-                                    "try",
-                                    negation_method.to_owned()
-                                );
-                            }
-                        )
+                METHODS_WITH_NEGATION.iter().for_each(|&(method1, method2)| {
+                    for &(method, negation_method) in &[(method1, method2), (method2, method1)] {
+                        if method == path.name.as_str() {
+                            span_lint_and_then(
+                                self.cx,
+                                NONMINIMAL_BOOL,
+                                e.span,
+                                "this boolean expression can be simplified",
+                                |db| {
+                                    db.span_suggestion(
+                                        e.span,
+                                        "try",
+                                        negation_method.to_owned()
+                                    );
+                                }
+                            )
+                        }
                     }
                 })
             }

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -405,24 +405,26 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
     }
 
     fn handle_method_call_in_not(&mut self, e: &'tcx Expr, inner: &'tcx Expr) {
-        if let ExprMethodCall(ref path, _, _) = inner.node {
-            METHODS_WITH_NEGATION.iter().for_each(|&(method, negation_method)| {
-                if method == path.name.as_str() {
-                    span_lint_and_then(
-                        self.cx,
-                        NONMINIMAL_BOOL,
-                        e.span,
-                        "this boolean expression can be simplified",
-                        |db| {
-                            db.span_suggestion(
-                                e.span,
-                                "try",
-                                negation_method.to_owned()
-                            );
-                        }
-                    )
-                }
-            })
+        if let ExprMethodCall(ref path, _, ref args) = inner.node {
+            if args.len() == 1 {
+                METHODS_WITH_NEGATION.iter().for_each(|&(method, negation_method)| {
+                    if method == path.name.as_str() {
+                        span_lint_and_then(
+                            self.cx,
+                            NONMINIMAL_BOOL,
+                            e.span,
+                            "this boolean expression can be simplified",
+                            |db| {
+                                db.span_suggestion(
+                                    e.span,
+                                    "try",
+                                    negation_method.to_owned()
+                                );
+                            }
+                        )
+                    }
+                })
+            }
         }
     }
 }

--- a/tests/ui/booleans.rs
+++ b/tests/ui/booleans.rs
@@ -38,3 +38,17 @@ fn equality_stuff() {
     let _ = a > b && a == b;
     let _ = a != b || !(a != b || c == d);
 }
+
+#[allow(unused, many_single_char_names)]
+fn methods_with_negation() {
+    let a: Option<i32> = unimplemented!();
+    let b: Result<i32, i32> = unimplemented!();
+    let _ = a.is_some();
+    let _ = !a.is_some();
+    let _ = a.is_none();
+    let _ = !a.is_none();
+    let _ = b.is_err();
+    let _ = !b.is_err();
+    let _ = b.is_ok();
+    let _ = !b.is_ok();
+}

--- a/tests/ui/booleans.rs
+++ b/tests/ui/booleans.rs
@@ -51,4 +51,6 @@ fn methods_with_negation() {
     let _ = !b.is_err();
     let _ = b.is_ok();
     let _ = !b.is_ok();
+    let c = false;
+    let _ = !(a.is_some() && !c);
 }

--- a/tests/ui/booleans.stderr
+++ b/tests/ui/booleans.stderr
@@ -131,26 +131,8 @@ help: try
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: this boolean expression can be simplified
-  --> $DIR/booleans.rs:47:13
+  --> $DIR/booleans.rs:55:13
    |
-47 |     let _ = !a.is_some();
-   |             ^^^^^^^^^^^^ help: try: `is_none`
-
-error: this boolean expression can be simplified
-  --> $DIR/booleans.rs:49:13
-   |
-49 |     let _ = !a.is_none();
-   |             ^^^^^^^^^^^^ help: try: `is_some`
-
-error: this boolean expression can be simplified
-  --> $DIR/booleans.rs:51:13
-   |
-51 |     let _ = !b.is_err();
-   |             ^^^^^^^^^^^ help: try: `is_ok`
-
-error: this boolean expression can be simplified
-  --> $DIR/booleans.rs:53:13
-   |
-53 |     let _ = !b.is_ok();
-   |             ^^^^^^^^^^ help: try: `is_err`
+55 |     let _ = !(a.is_some() && !c);
+   |             ^^^^^^^^^^^^^^^^^^^^ help: try: `c || a.is_none()`
 

--- a/tests/ui/booleans.stderr
+++ b/tests/ui/booleans.stderr
@@ -131,6 +131,30 @@ help: try
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:47:13
+   |
+47 |     let _ = !a.is_some();
+   |             ^^^^^^^^^^^^ help: try: `a.is_none()`
+
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:49:13
+   |
+49 |     let _ = !a.is_none();
+   |             ^^^^^^^^^^^^ help: try: `a.is_some()`
+
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:51:13
+   |
+51 |     let _ = !b.is_err();
+   |             ^^^^^^^^^^^ help: try: `b.is_ok()`
+
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:53:13
+   |
+53 |     let _ = !b.is_ok();
+   |             ^^^^^^^^^^ help: try: `b.is_err()`
+
+error: this boolean expression can be simplified
   --> $DIR/booleans.rs:55:13
    |
 55 |     let _ = !(a.is_some() && !c);

--- a/tests/ui/booleans.stderr
+++ b/tests/ui/booleans.stderr
@@ -130,3 +130,27 @@ help: try
 39 |     let _ = !(a == b && c == d);
    |             ^^^^^^^^^^^^^^^^^^^
 
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:47:13
+   |
+47 |     let _ = !a.is_some();
+   |             ^^^^^^^^^^^^ help: try: `is_none`
+
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:49:13
+   |
+49 |     let _ = !a.is_none();
+   |             ^^^^^^^^^^^^ help: try: `is_some`
+
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:51:13
+   |
+51 |     let _ = !b.is_err();
+   |             ^^^^^^^^^^^ help: try: `is_ok`
+
+error: this boolean expression can be simplified
+  --> $DIR/booleans.rs:53:13
+   |
+53 |     let _ = !b.is_ok();
+   |             ^^^^^^^^^^ help: try: `is_err`
+

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -6,15 +6,3 @@ error: useless use of `format!`
   |
   = note: `-D useless-format` implied by `-D warnings`
 
-error: useless use of `format!`
- --> $DIR/format.rs:8:5
-  |
-8 |     format!("{}", "foo");
-  |     ^^^^^^^^^^^^^^^^^^^^^
-
-error: useless use of `format!`
-  --> $DIR/format.rs:15:5
-   |
-15 |     format!("{}", arg);
-   |     ^^^^^^^^^^^^^^^^^^^
-

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -23,7 +23,7 @@ error: the loop variable `i` is only used to index `ms`.
 help: consider using an iterator
    |
 29 |     for <item> in &mut ms {
-   |         ^^^^^^
+   |
 
 error: the loop variable `i` is only used to index `ms`.
   --> $DIR/needless_range_loop.rs:35:5
@@ -37,5 +37,5 @@ error: the loop variable `i` is only used to index `ms`.
 help: consider using an iterator
    |
 35 |     for <item> in &mut ms {
-   |         ^^^^^^
+   |
 

--- a/tests/ui/print_with_newline.stderr
+++ b/tests/ui/print_with_newline.stderr
@@ -6,21 +6,3 @@ error: using `print!()` with a format string that ends in a newline, consider us
   |
   = note: `-D print-with-newline` implied by `-D warnings`
 
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
- --> $DIR/print_with_newline.rs:7:5
-  |
-7 |     print!("Hello {}/n", "world");
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
- --> $DIR/print_with_newline.rs:8:5
-  |
-8 |     print!("Hello {} {}/n/n", "world", "#2");
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
- --> $DIR/print_with_newline.rs:9:5
-  |
-9 |     print!("{}/n", 1265);
-  |     ^^^^^^^^^^^^^^^^^^^^^
-


### PR DESCRIPTION
As suggested in #1930 warn on negations of `is_some`, `is_none`, `is_ok`, or `is_err`.

This is done using a const array to store methods with obvious negations. Not sure if this is the idiomatic way to do it, at least it should be reasonably efficient as there are only four elements involved.