### PR TITLE
Split TyImplTrait into Universal and Existential

### DIFF
--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -325,7 +325,8 @@ impl<'a, 'tcx> Visitor<'tcx> for RefVisitor<'a, 'tcx> {
             TyPath(ref path) => {
                 self.collect_anonymous_lifetimes(path, ty);
             },
-            TyImplTrait(ref param_bounds) => for bound in param_bounds {
+            TyImplTraitExistential(ref param_bounds) |
+                TyImplTraitUniversal(_, ref param_bounds) => for bound in param_bounds {
                 if let RegionTyParamBound(_) = *bound {
                     self.record(&None);
                 }


### PR DESCRIPTION
rust-lang/rust#45918 has landed, it broke clippy due to changing the `hir::Ty_` enum. This change replaces the old enum variant with the two new ones.