### PR TITLE
Ignore identifier 'OpenStreetMap' for DOC_MARKDOWN lint

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -157,7 +157,7 @@ define_Conf! {
         "JavaScript",
         "NaN",
         "OAuth",
-        "OpenGL", "OpenSSH", "OpenSSL",
+        "OpenGL", "OpenSSH", "OpenSSL", "OpenStreetMap",
         "TrueType",
         "iOS", "macOS",
         "TeX", "LaTeX", "BibTeX", "BibLaTeX",


### PR DESCRIPTION
A small change, but I would be very delighted. :)