### PR TITLE
Add a couple small tests to the match-same-arm lint + fix a small issue in search_same.

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -74,9 +74,8 @@ impl PartialEq for Constant {
                 }
             },
             (&Constant::Bool(l), &Constant::Bool(r)) => l == r,
-            (&Constant::Vec(ref l), &Constant::Vec(ref r)) => l == r,
+            (&Constant::Vec(ref l), &Constant::Vec(ref r)) | (&Constant::Tuple(ref l), &Constant::Tuple(ref r)) => l == r,
             (&Constant::Repeat(ref lv, ref ls), &Constant::Repeat(ref rv, ref rs)) => ls == rs && lv == rv,
-            (&Constant::Tuple(ref l), &Constant::Tuple(ref r)) => l == r,
             _ => false, // TODO: Are there inter-type equalities?
         }
     }

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -325,10 +325,13 @@ where
 
     for expr in exprs {
         match map.entry(hash(expr)) {
-            Entry::Occupied(o) => for o in o.get() {
-                if eq(o, expr) {
-                    return Some((o, expr));
+            Entry::Occupied(mut o) => {
+                for o in o.get() {
+                    if eq(o, expr) {
+                        return Some((o, expr));
+                    }
                 }
+                o.get_mut().push(expr);
             },
             Entry::Vacant(v) => {
                 v.insert(vec![expr]);

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -203,14 +203,10 @@ fn lint_match_arms(cx: &LateContext, expr: &Expr) {
                     db.span_note(i.body.span, "same as this");
 
                     // Note: this does not use `span_suggestion` on purpose: there is no clean way
-                    // to
-                    // remove the other arm. Building a span and suggest to replace it to "" makes
-                    // an
-                    // even more confusing error message. Also in order not to make up a span for
-                    // the
-                    // whole pattern, the suggestion is only shown when there is only one pattern.
-                    // The
-                    // user should know about `|` if they are already using it…
+                    // to remove the other arm. Building a span and suggest to replace it to ""
+                    // makes an even more confusing error message. Also in order not to make up a
+                    // span for the whole pattern, the suggestion is only shown when there is only
+                    // one pattern. The user should know about `|` if they are already using it…
 
                     if i.pats.len() == 1 && j.pats.len() == 1 {
                         let lhs = snippet(cx, i.pats[0].span, "<pat1>");

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -206,8 +206,7 @@ fn check_doc<'a, Events: Iterator<Item = (usize, pulldown_cmark::Event<'a>)>>(
             End(Link(_, _)) => in_link = None,
             Start(_tag) | End(_tag) => (),         // We don't care about other tags
             Html(_html) | InlineHtml(_html) => (), // HTML is weird, just ignore it
-            SoftBreak => (),
-            HardBreak => (),
+            SoftBreak | HardBreak => (),
             FootnoteReference(text) | Text(text) => {
                 if Some(&text) == in_link.as_ref() {
                     // Probably a link of the form `<http://example.com>`

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -305,6 +305,14 @@ fn match_wild_err_arm() {
         (Ok(_), Some(x)) => println!("ok {}", x),
         _ => println!("err")
     }
+
+    // because of a bug, no warning was generated for this case before #2251
+    match x {
+        Ok(_tmp) => println!("ok"),
+        Ok(3) => println!("ok"),
+        Ok(_) => println!("ok"),
+        Err(_) => {unreachable!();}
+    }
 }
 
 fn main() {

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -277,6 +277,26 @@ fn match_wild_err_arm() {
         Ok(_) => println!("ok"),
         Err(_) => {unreachable!();}
     }
+
+    // no warning because of the guard
+    match x {
+        Ok(x) if x*x == 64 => println!("ok"),
+        Ok(_) => println!("ok"),
+        Err(_) => println!("err")
+    }
+
+    match (x, Some(1i32)) {
+        (Ok(x), Some(_)) => println!("ok {}", x),
+        (Ok(_), Some(x)) => println!("ok {}", x),
+        _ => println!("err")
+    }
+
+    // no warning because of the different types for x
+    match (x, Some(1.0f64)) {
+        (Ok(x), Some(_)) => println!("ok {}", x),
+        (Ok(_), Some(x)) => println!("ok {}", x),
+        _ => println!("err")
+    }
 }
 
 fn main() {

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -285,6 +285,14 @@ fn match_wild_err_arm() {
         Err(_) => println!("err")
     }
 
+    // this is a current false positive, see #1996
+    match x {
+        Ok(3) => println!("ok"),
+        Ok(x) if x*x == 64 => println!("ok 64"),
+        Ok(_) => println!("ok"),
+        Err(_) => println!("err")
+    }
+
     match (x, Some(1i32)) {
         (Ok(x), Some(_)) => println!("ok {}", x),
         (Ok(_), Some(x)) => println!("ok {}", x),

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -391,20 +391,38 @@ note: consider refactoring into `Ok(3) | Ok(_)`
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:290:29
+   --> $DIR/matches.rs:292:18
     |
-290 |         (Ok(_), Some(x)) => println!("ok {}", x),
+292 |         Ok(_) => println!("ok"),
+    |                  ^^^^^^^^^^^^^^
+    |
+note: same as this
+   --> $DIR/matches.rs:290:18
+    |
+290 |         Ok(3) => println!("ok"),
+    |                  ^^^^^^^^^^^^^^
+note: consider refactoring into `Ok(3) | Ok(_)`
+   --> $DIR/matches.rs:290:18
+    |
+290 |         Ok(3) => println!("ok"),
+    |                  ^^^^^^^^^^^^^^
+    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: this `match` has identical arm bodies
+   --> $DIR/matches.rs:298:29
+    |
+298 |         (Ok(_), Some(x)) => println!("ok {}", x),
     |                             ^^^^^^^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:289:29
+   --> $DIR/matches.rs:297:29
     |
-289 |         (Ok(x), Some(_)) => println!("ok {}", x),
+297 |         (Ok(x), Some(_)) => println!("ok {}", x),
     |                             ^^^^^^^^^^^^^^^^^^^^
 note: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
-   --> $DIR/matches.rs:289:29
+   --> $DIR/matches.rs:297:29
     |
-289 |         (Ok(x), Some(_)) => println!("ok {}", x),
+297 |         (Ok(x), Some(_)) => println!("ok {}", x),
     |                             ^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -426,3 +426,21 @@ note: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
     |                             ^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
+error: this `match` has identical arm bodies
+   --> $DIR/matches.rs:313:18
+    |
+313 |         Ok(_) => println!("ok"),
+    |                  ^^^^^^^^^^^^^^
+    |
+note: same as this
+   --> $DIR/matches.rs:312:18
+    |
+312 |         Ok(3) => println!("ok"),
+    |                  ^^^^^^^^^^^^^^
+note: consider refactoring into `Ok(3) | Ok(_)`
+   --> $DIR/matches.rs:312:18
+    |
+312 |         Ok(3) => println!("ok"),
+    |                  ^^^^^^^^^^^^^^
+    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -390,3 +390,21 @@ note: consider refactoring into `Ok(3) | Ok(_)`
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
+error: this `match` has identical arm bodies
+   --> $DIR/matches.rs:290:29
+    |
+290 |         (Ok(_), Some(x)) => println!("ok {}", x),
+    |                             ^^^^^^^^^^^^^^^^^^^^
+    |
+note: same as this
+   --> $DIR/matches.rs:289:29
+    |
+289 |         (Ok(x), Some(_)) => println!("ok {}", x),
+    |                             ^^^^^^^^^^^^^^^^^^^^
+note: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
+   --> $DIR/matches.rs:289:29
+    |
+289 |         (Ok(x), Some(_)) => println!("ok {}", x),
+    |                             ^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+


### PR DESCRIPTION
These tests cover the case where one of the branch has a guard and where bindings in different branches have different types.