### PR TITLE
Avoid the MATCH_SAME_ARMS warning when two arms are separated by an arm with a guard

### DIFF
--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -187,7 +187,7 @@ fn lint_match_arms(cx: &LateContext, expr: &Expr) {
 
         let eq = |&(lindex, lhs): &(usize, &Arm), &(rindex, rhs): &(usize, &Arm)| -> bool {
             let min_index = usize::min(lindex, rindex);
-            let max_index = usize::max(rindex, rindex);
+            let max_index = usize::max(lindex, rindex);
             // Arms with a guard are ignored, those can’t always be merged together
             // This is also the case for arms in-between each there is an arm with a guard
             (min_index..=max_index).all(|index| arms[index].guard.is_none()) &&

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -285,7 +285,7 @@ fn match_wild_err_arm() {
         Err(_) => println!("err")
     }
 
-    // this is a current false positive, see #1996
+    // this used to be a false positive, see #1996
     match x {
         Ok(3) => println!("ok"),
         Ok(x) if x*x == 64 => println!("ok 64"),

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -391,24 +391,6 @@ note: consider refactoring into `Ok(3) | Ok(_)`
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:292:18
-    |
-292 |         Ok(_) => println!("ok"),
-    |                  ^^^^^^^^^^^^^^
-    |
-note: same as this
-   --> $DIR/matches.rs:290:18
-    |
-290 |         Ok(3) => println!("ok"),
-    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:290:18
-    |
-290 |         Ok(3) => println!("ok"),
-    |                  ^^^^^^^^^^^^^^
-    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error: this `match` has identical arm bodies
    --> $DIR/matches.rs:298:29
     |
 298 |         (Ok(_), Some(x)) => println!("ok {}", x),

--- a/tests/ui/regex.stderr
+++ b/tests/ui/regex.stderr
@@ -112,7 +112,7 @@ error: trivial regex
 error: trivial regex
   --> $DIR/regex.rs:62:40
    |
-62 |     let trivial_backslash = Regex::new("a//.b");
+62 |     let trivial_backslash = Regex::new("a/.b");
    |                                        ^^^^^^^
    |
    = help: consider using consider using `str::contains`

--- a/tests/ui/regex.stderr
+++ b/tests/ui/regex.stderr
@@ -112,7 +112,7 @@ error: trivial regex
 error: trivial regex
   --> $DIR/regex.rs:62:40
    |
-62 |     let trivial_backslash = Regex::new("a/.b");
+62 |     let trivial_backslash = Regex::new("a//.b");
    |                                        ^^^^^^^
    |
    = help: consider using consider using `str::contains`


### PR DESCRIPTION
As detailed in #1996 it is not always possible to merge two arms with identical bodies if there is an arm with a guard in-between these two arms. This PR tweaks the lint so that no warning is raised in this case.