### PR TITLE
Bump lazy_static: 0.2 -> 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ regex = "0.2"
 [dev-dependencies]
 compiletest_rs = "0.3"
 duct = "0.8.2"
-lazy_static = "0.2"
+lazy_static = "1.0"
 serde_derive = "1.0"
 clippy-mini-macro-test = { version = "0.1", path = "mini-macro" }
 serde = "1.0"


### PR DESCRIPTION
https://github.com/rust-lang-nursery/lazy-static.rs/compare/73236afc4733ee42db0fb6db851e14a8a5b7a386...master