### PR TITLE
Fix crates.io site name

### DIFF
--- a/clippy_lints/README.md
+++ b/clippy_lints/README.md
@@ -1,3 +1,3 @@
 This crate contains Clippy lints. For the main crate, check
-[*cargo.io*](https://crates.io/crates/clippy) or
+[*crates.io*](https://crates.io/crates/clippy) or
 [GitHub](https://github.com/rust-lang-nursery/rust-clippy).


### PR DESCRIPTION
Pretty straightforward (cargo.io -> crates.io)