### PR TITLE
Lint for matching option as ref

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -499,6 +499,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         loops::WHILE_LET_LOOP,
         loops::WHILE_LET_ON_ITERATOR,
         map_clone::MAP_CLONE,
+        matches::MATCH_AS_REF,
         matches::MATCH_BOOL,
         matches::MATCH_OVERLAPPING_ARM,
         matches::MATCH_REF_PATS,

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -316,14 +316,14 @@ fn match_wild_err_arm() {
 }
 
 fn match_as_ref() {
-    let owned : Option<()> = None;
-    let borrowed = match owned {
+    let owned: Option<()> = None;
+    let borrowed: Option<&()> = match owned {
         None => None,
         Some(ref v) => Some(v),
     };
 
-    let mut mut_owned : Option<()> = None;
-    let mut mut_borrowed = match mut_owned {
+    let mut mut_owned: Option<()> = None;
+    let borrow_mut: Option<&mut ()> = match mut_owned {
         None => None,
         Some(ref mut v) => Some(v),
     };

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -315,5 +315,20 @@ fn match_wild_err_arm() {
     }
 }
 
+fn match_as_ref() {
+    let owned : Option<()> = None;
+    let borrowed = match owned {
+        None => None,
+        Some(ref v) => Some(v),
+    };
+
+    let mut mut_owned : Option<()> = None;
+    let mut mut_borrowed = match mut_owned {
+        None => None,
+        Some(ref mut v) => Some(v),
+    };
+
+}
+
 fn main() {
 }

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -427,10 +427,10 @@ note: consider refactoring into `Ok(3) | Ok(_)`
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: use as_ref() instead
-   --> $DIR/matches.rs:320:20
+   --> $DIR/matches.rs:320:33
     |
-320 |       let borrowed = match owned {
-    |  ____________________^
+320 |       let borrowed: Option<&()> = match owned {
+    |  _________________________________^
 321 | |         None => None,
 322 | |         Some(ref v) => Some(v),
 323 | |     };
@@ -438,13 +438,13 @@ error: use as_ref() instead
     |
     = note: `-D match-as-ref` implied by `-D warnings`
 
-error: use as_ref() instead
-   --> $DIR/matches.rs:326:28
+error: use as_mut() instead
+   --> $DIR/matches.rs:326:39
     |
-326 |       let mut mut_borrowed = match mut_owned {
-    |  ____________________________^
+326 |       let borrow_mut: Option<&mut ()> = match mut_owned {
+    |  _______________________________________^
 327 | |         None => None,
 328 | |         Some(ref mut v) => Some(v),
 329 | |     };
-    | |_____^ help: try this: `mut_owned.as_ref()`
+    | |_____^ help: try this: `mut_owned.as_mut()`
 

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -426,3 +426,25 @@ note: consider refactoring into `Ok(3) | Ok(_)`
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
+error: use as_ref() instead
+   --> $DIR/matches.rs:320:20
+    |
+320 |       let borrowed = match owned {
+    |  ____________________^
+321 | |         None => None,
+322 | |         Some(ref v) => Some(v),
+323 | |     };
+    | |_____^ help: try this: `owned.as_ref()`
+    |
+    = note: `-D match-as-ref` implied by `-D warnings`
+
+error: use as_ref() instead
+   --> $DIR/matches.rs:326:28
+    |
+326 |       let mut mut_borrowed = match mut_owned {
+    |  ____________________________^
+327 | |         None => None,
+328 | |         Some(ref mut v) => Some(v),
+329 | |     };
+    | |_____^ help: try this: `mut_owned.as_ref()`
+


### PR DESCRIPTION
Implements #2270

As this is my first contribution, any suggestions for improvements would be very helpful.
Especially for the `is_ref_some_arm` function, which is a bit of a mess.