### PR TITLE
Move mini-macro to proc macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ compiletest_rs = "0.3"
 duct = "0.8.2"
 lazy_static = "1.0"
 serde_derive = "1.0"
-clippy-mini-macro-test = { version = "0.1", path = "mini-macro" }
+clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = "1.0"
 
 [features]

--- a/mini-macro/Cargo.toml
+++ b/mini-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy-mini-macro-test"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -14,6 +14,6 @@ repository = "https://github.com/rust-lang-nursery/rust-clippy"
 
 [lib]
 name = "clippy_mini_macro_test"
-plugin = true
+proc-macro = true
 
 [dependencies]

--- a/mini-macro/src/lib.rs
+++ b/mini-macro/src/lib.rs
@@ -1,39 +1,11 @@
-#![feature(plugin_registrar, rustc_private, quote)]
+#![feature(proc_macro)]
+extern crate proc_macro;
 
-extern crate rustc_plugin;
-extern crate syntax;
+use proc_macro::{TokenStream, quote};
 
-use rustc_plugin::Registry;
-use syntax::ast::MetaItem;
-use syntax::codemap::Span;
-use syntax::ext::base::{Annotatable, ExtCtxt, MacEager, MacResult, SyntaxExtension};
-use syntax::ext::build::AstBuilder; // trait for expr_usize
-use syntax::symbol::Symbol;
-use syntax::tokenstream::TokenTree;
-
-fn expand_macro(cx: &mut ExtCtxt, sp: Span, _: &[TokenTree]) -> Box<MacResult + 'static> {
-    let e = cx.expr_usize(sp, 42);
-    let e = cx.expr_mut_addr_of(sp, e);
-    MacEager::expr(cx.expr_mut_addr_of(sp, e))
-}
-
-fn expand_attr_macro(cx: &mut ExtCtxt, _: Span, _: &MetaItem, annotated: Annotatable) -> Vec<Annotatable> {
-    vec![
-        Annotatable::Item(
-            quote_item!(
-                cx,
-                #[allow(unused)] fn needless_take_by_value(s: String) { println!("{}", s.len()); }
-            ).unwrap()
-        ),
-        annotated,
-    ]
-}
-
-#[plugin_registrar]
-pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_macro("mini_macro", expand_macro);
-    reg.register_syntax_extension(
-        Symbol::intern("mini_macro_attr"),
-        SyntaxExtension::MultiModifier(Box::new(expand_attr_macro)),
-    );
+#[proc_macro_derive(ClippyMiniMacroTest)]
+pub fn mini_macro(_: TokenStream) -> TokenStream {
+    quote!(
+        #[allow(unused)] fn needless_take_by_value(s: String) { println!("{}", s.len()); }
+    )
 }

--- a/tests/run-pass/procedural_macro.rs
+++ b/tests/run-pass/procedural_macro.rs
@@ -1,8 +1,12 @@
-#![feature(plugin)]
-#![plugin(clippy_mini_macro_test)]
+#[macro_use]
+extern crate clippy_mini_macro_test;
 
 #[deny(warnings)]
-#[mini_macro_attr]
 fn main() {
-    let _ = mini_macro!();
+    let x = Foo;
+    println!("{:?}", x);
 }
+
+
+#[derive(ClippyMiniMacroTest, Debug)]
+struct Foo;


### PR DESCRIPTION
We can add a bang-style proc macro again once it stabilizes (we can use
the proc macro hack, but it's unnecessary for now)

fixes https://github.com/rust-lang-nursery/rust-clippy/issues/2283

r? @llogiq @oli-obk