### PR TITLE
Clarify README for new Rust users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ And, in your `main.rs` or `lib.rs`, add these lines:
 #![cfg_attr(feature="clippy", plugin(clippy))]
 ```
 
-Then build by enabling the feature: `cargo build --features "clippy"`
+Then build by enabling the feature: `cargo +nightly build --features "clippy"`.
 
 Instead of adding the `cfg_attr` attributes you can also run clippy on demand:
 `cargo rustc --features clippy -- -Z no-trans -Z extra-plugins=clippy`

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ clippy = {version = "*", optional = true}
 default = []
 ```
 
-And, in your `main.rs` or `lib.rs`:
+And, in your `main.rs` or `lib.rs`, add these lines:
 
 ```rust
 #![cfg_attr(feature="clippy", feature(plugin))]
-
 #![cfg_attr(feature="clippy", plugin(clippy))]
 ```
 


### PR DESCRIPTION
As a Rust newbie myself, I had a couple small pitfalls setting up clippy for my existing project.

I wasn't exactly sure how the attribute tabs were working, so I didn't realize that I needed both lines (one for feature(plugin) to be enabled, the other for using the plugin feature to enable clippy through a flag). To clarify, I added ", add these lines", where lines implies that both of these lines should be added to either main.rs or lib.rs. Also I removed the space between the lines to visually group them.

Additionally, I realize that in the README above it says that clippy must be run with the latest nightly, but I missed that on first read through. Would it be useful to add `+nightly` to the commands in the README? It seems better that the commands listed in the README work without any modification.

Let me know if I did anything wrong - I'm still pretty new to using Rust! Also thanks for clippy, it is an amazing tool :).