### PR TITLE
Fix #2265, ignore eq_op lint in macro invocation

### DIFF
--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -1,6 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
-use utils::{implements_trait, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq};
+use utils::{in_macro, implements_trait, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq};
 
 /// **What it does:** Checks for equal operands to comparison, logical and
 /// bitwise, difference and division binary operators (`==`, `>`, etc., `&&`,
@@ -53,7 +53,7 @@ impl LintPass for EqOp {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprBinary(ref op, ref left, ref right) = e.node {
-            if is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) {
+            if !in_macro(e.span) && is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) {
                 span_lint(
                     cx,
                     EQ_OP,

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -53,7 +53,7 @@ impl LintPass for EqOp {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprBinary(ref op, ref left, ref right) = e.node {
-            if !in_macro(e.span) && is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) {
+            if is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) && !in_macro(e.span) {
                 span_lint(
                     cx,
                     EQ_OP,

--- a/tests/ui/eq_op.rs
+++ b/tests/ui/eq_op.rs
@@ -87,4 +87,20 @@ fn main() {
     let x = Y(1);
     let y = Y(2);
     let z = x & &y;
+
+    check_ignore_macro();
+}
+
+macro_rules! check_if_named_foo {
+    ($expression:expr) => (
+        if stringify!($expression) == "foo" {
+            println!("foo!");
+        } else {
+            println!("not foo.");
+        }
+    )
+}
+
+fn check_ignore_macro() {
+    check_if_named_foo!(foo);
 }


### PR DESCRIPTION
Added an in_macro check when checking eq_op. It's at the end of the expression since code not being inside a macro seems to be the norm.

Did I modify the test correctly? Basically I'm making sure that the test case doesn't create any warnings, but I didn't see any examples of that elsewhere in the file.