### PR TITLE
WIP: Fix Appveyor CI build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+
+# The output comparison during tests is done using LF line feeds.
+# Ensure the newlines for the reference files are LF even on Windows.
+/tests/**/*.stderr text eol=lf
+/tests/**/*.stdout text eol=lf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,17 @@ environment:
     global:
         PROJECT_NAME: rust-clippy
     matrix:
-        - TARGET: i686-pc-windows-gnu
-          MSYS2_BITS: 32
+        # Compiler plugins are broken in Nightly rust on windows-gnu so these
+        # CI targets are disabled for now.
+        #
+        # rust-lang/rust issue #47029
+
+        # - TARGET: i686-pc-windows-gnu
+        #   MSYS2_BITS: 32
         - TARGET: i686-pc-windows-msvc
           MSYS2_BITS: 32
-        - TARGET: x86_64-pc-windows-gnu
-          MSYS2_BITS: 64
+        # - TARGET: x86_64-pc-windows-gnu
+        #   MSYS2_BITS: 64
         - TARGET: x86_64-pc-windows-msvc
           MSYS2_BITS: 64
 

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -69,8 +69,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutexAtomic {
                         atomic_name
                     );
                     match mutex_param.sty {
-                        ty::TyUint(t) if t != ast::UintTy::Us => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
-                        ty::TyInt(t) if t != ast::IntTy::Is => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
+                        ty::TyUint(t) if t != ast::UintTy::Usize => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
+                        ty::TyInt(t) if t != ast::IntTy::Isize => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
                         _ => span_lint(cx, MUTEX_ATOMIC, expr.span, &msg),
                     };
                 }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -541,7 +541,7 @@ declare_lint! {
 fn int_ty_to_nbits(typ: Ty, tcx: TyCtxt) -> u64 {
     match typ.sty {
         ty::TyInt(i) => match i {
-            IntTy::Is => tcx.data_layout.pointer_size.bits(),
+            IntTy::Isize => tcx.data_layout.pointer_size.bits(),
             IntTy::I8 => 8,
             IntTy::I16 => 16,
             IntTy::I32 => 32,
@@ -549,7 +549,7 @@ fn int_ty_to_nbits(typ: Ty, tcx: TyCtxt) -> u64 {
             IntTy::I128 => 128,
         },
         ty::TyUint(i) => match i {
-            UintTy::Us => tcx.data_layout.pointer_size.bits(),
+            UintTy::Usize => tcx.data_layout.pointer_size.bits(),
             UintTy::U8 => 8,
             UintTy::U16 => 16,
             UintTy::U32 => 32,
@@ -562,7 +562,7 @@ fn int_ty_to_nbits(typ: Ty, tcx: TyCtxt) -> u64 {
 
 fn is_isize_or_usize(typ: Ty) -> bool {
     match typ.sty {
-        ty::TyInt(IntTy::Is) | ty::TyUint(UintTy::Us) => true,
+        ty::TyInt(IntTy::Isize) | ty::TyUint(UintTy::Usize) => true,
         _ => false,
     }
 }
@@ -1151,15 +1151,15 @@ fn detect_extreme_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -
 
     let which = match (&ty.sty, cv.val) {
         (&ty::TyBool, Bool(false)) |
-        (&ty::TyInt(IntTy::Is), Integral(Isize(Is32(::std::i32::MIN)))) |
-        (&ty::TyInt(IntTy::Is), Integral(Isize(Is64(::std::i64::MIN)))) |
+        (&ty::TyInt(IntTy::Isize), Integral(Isize(Is32(::std::i32::MIN)))) |
+        (&ty::TyInt(IntTy::Isize), Integral(Isize(Is64(::std::i64::MIN)))) |
         (&ty::TyInt(IntTy::I8), Integral(I8(::std::i8::MIN))) |
         (&ty::TyInt(IntTy::I16), Integral(I16(::std::i16::MIN))) |
         (&ty::TyInt(IntTy::I32), Integral(I32(::std::i32::MIN))) |
         (&ty::TyInt(IntTy::I64), Integral(I64(::std::i64::MIN))) |
         (&ty::TyInt(IntTy::I128), Integral(I128(::std::i128::MIN))) |
-        (&ty::TyUint(UintTy::Us), Integral(Usize(Us32(::std::u32::MIN)))) |
-        (&ty::TyUint(UintTy::Us), Integral(Usize(Us64(::std::u64::MIN)))) |
+        (&ty::TyUint(UintTy::Usize), Integral(Usize(Us32(::std::u32::MIN)))) |
+        (&ty::TyUint(UintTy::Usize), Integral(Usize(Us64(::std::u64::MIN)))) |
         (&ty::TyUint(UintTy::U8), Integral(U8(::std::u8::MIN))) |
         (&ty::TyUint(UintTy::U16), Integral(U16(::std::u16::MIN))) |
         (&ty::TyUint(UintTy::U32), Integral(U32(::std::u32::MIN))) |
@@ -1167,15 +1167,15 @@ fn detect_extreme_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -
         (&ty::TyUint(UintTy::U128), Integral(U128(::std::u128::MIN))) => Minimum,
 
         (&ty::TyBool, Bool(true)) |
-        (&ty::TyInt(IntTy::Is), Integral(Isize(Is32(::std::i32::MAX)))) |
-        (&ty::TyInt(IntTy::Is), Integral(Isize(Is64(::std::i64::MAX)))) |
+        (&ty::TyInt(IntTy::Isize), Integral(Isize(Is32(::std::i32::MAX)))) |
+        (&ty::TyInt(IntTy::Isize), Integral(Isize(Is64(::std::i64::MAX)))) |
         (&ty::TyInt(IntTy::I8), Integral(I8(::std::i8::MAX))) |
         (&ty::TyInt(IntTy::I16), Integral(I16(::std::i16::MAX))) |
         (&ty::TyInt(IntTy::I32), Integral(I32(::std::i32::MAX))) |
         (&ty::TyInt(IntTy::I64), Integral(I64(::std::i64::MAX))) |
         (&ty::TyInt(IntTy::I128), Integral(I128(::std::i128::MAX))) |
-        (&ty::TyUint(UintTy::Us), Integral(Usize(Us32(::std::u32::MAX)))) |
-        (&ty::TyUint(UintTy::Us), Integral(Usize(Us64(::std::u64::MAX)))) |
+        (&ty::TyUint(UintTy::Usize), Integral(Usize(Us32(::std::u32::MAX)))) |
+        (&ty::TyUint(UintTy::Usize), Integral(Usize(Us64(::std::u64::MAX)))) |
         (&ty::TyUint(UintTy::U8), Integral(U8(::std::u8::MAX))) |
         (&ty::TyUint(UintTy::U16), Integral(U16(::std::u16::MAX))) |
         (&ty::TyUint(UintTy::U32), Integral(U32(::std::u32::MAX))) |
@@ -1329,7 +1329,7 @@ fn numeric_cast_precast_bounds<'a>(cx: &LateContext, expr: &'a Expr) -> Option<(
                     FullInt::S(i128::from(i64::max_value())),
                 ),
                 IntTy::I128 => (FullInt::S(i128::min_value() as i128), FullInt::S(i128::max_value() as i128)),
-                IntTy::Is => (FullInt::S(isize::min_value() as i128), FullInt::S(isize::max_value() as i128)),
+                IntTy::Isize => (FullInt::S(isize::min_value() as i128), FullInt::S(isize::max_value() as i128)),
             }),
             ty::TyUint(uint_ty) => Some(match uint_ty {
                 UintTy::U8 => (FullInt::U(u128::from(u8::min_value())), FullInt::U(u128::from(u8::max_value()))),
@@ -1346,7 +1346,7 @@ fn numeric_cast_precast_bounds<'a>(cx: &LateContext, expr: &'a Expr) -> Option<(
                     FullInt::U(u128::from(u64::max_value())),
                 ),
                 UintTy::U128 => (FullInt::U(u128::min_value() as u128), FullInt::U(u128::max_value() as u128)),
-                UintTy::Us => (FullInt::U(usize::min_value() as u128), FullInt::U(usize::max_value() as u128)),
+                UintTy::Usize => (FullInt::U(usize::min_value() as u128), FullInt::U(usize::max_value() as u128)),
             }),
             _ => None,
         }


### PR DESCRIPTION
### Tasks

- [x] Temporarily disable `windows-gnu` targets.
- [x] Ensure `stderr`/`stdout` reference files use the expected line endings.
- [ ] Fix the line ending -related difference in clippy reports.

### Summary

First of all, the `windows-gnu` targets cannot currently build compiler plugins rust-lang/rust#47029. These targets are disabled temporarily.

The big failure seems to be in how git checkout will convert the newlines in the stderr reference files into CRLF. This is countered by forcing LF line endings through `.gitattributes`.

There is still one final issue that I have yet to fix. For some reason the CRLF difference (I believe) affects the Clippy output in specific scenarios. This results in extra newlines in the stderr output.

A selected example from the `needless_continue.rs` below. The `// [...]` comments are added.

Windows, pasted Playground:
```rust
           if (zero!(i % 2) || nonzero!(i % 5)) && i % 3 != 0 {
               continue;
           }

           println!("Blabber");
           println!("Jabber");
           ...
```

Linux, [gist Playground](https://play.rust-lang.org/?gist=f39c0da0603f17f6b9b475c8873f6c2a&version=stable)
```rust
   = help: Consider dropping the else clause, and moving out the code in the else block, like so:
           if (zero!(i % 2) || nonzero!(i % 5)) && i % 3 != 0 {
               continue;
           }
           println!("Blabber");
           println!("Jabber");
           ...
```

Note the issue can be replicated in playground when pasting code there in Windows. Looking at the JSON payload this does include `\r\n` linebreaks in the HTTP request.

I would _love_ some pointers on where to look for that last issue.

----------

The branch also builds on top of the #2333 to make it compile on the new Nightly to begin with.