### PR TITLE
Add lint to replace `const`s with `const fn`s

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -150,6 +150,7 @@ pub mod ptr;
 pub mod ranges;
 pub mod reference;
 pub mod regex;
+pub mod replace_consts;
 pub mod returns;
 pub mod serde_api;
 pub mod shadow;
@@ -361,6 +362,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box types::ImplicitHasher);
     reg.register_early_lint_pass(box const_static_lifetime::StaticConst);
     reg.register_late_lint_pass(box fallible_impl_from::FallibleImplFrom);
+    reg.register_late_lint_pass(box replace_consts::ReplaceConsts);
 
     reg.register_lint_group("clippy_restrictions", vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -399,6 +401,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         print::PRINT_STDOUT,
         print::USE_DEBUG,
         ranges::RANGE_PLUS_ONE,
+        replace_consts::REPLACE_CONSTS,
         shadow::SHADOW_REUSE,
         shadow::SHADOW_SAME,
         shadow::SHADOW_UNRELATED,

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -1,0 +1,102 @@
+use rustc::lint::*;
+use rustc::hir;
+use rustc::hir::def::Def;
+use utils::{match_def_path, span_lint_and_sugg};
+
+/// **What it does:** Checks for usage of `ATOMIC_X_INIT`, `ONCE_INIT`, and
+/// `uX/iX::MIN/MAX`.
+///
+/// **Why is this bad?** `const fn`s exist
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
+/// ```
+///
+/// Could be written:
+///
+/// ```rust
+/// static FOO: AtomicIsize = AtomicIsize::new(0);
+/// ```
+declare_lint! {
+    pub REPLACE_CONSTS,
+    Allow,
+    "Lint usages of standard library `const`s that could be replaced by `const fn`s"
+}
+
+pub struct ReplaceConsts;
+
+impl LintPass for ReplaceConsts {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(REPLACE_CONSTS)
+    }
+}
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ReplaceConsts {
+    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {
+        if_chain! {
+            if let hir::ExprPath(ref qp) = expr.node;
+            if let Def::Const(def_id) = cx.tables.qpath_def(qp, expr.hir_id);
+            then {
+                for &(const_path, repl_snip) in REPLACEMENTS {
+                    if match_def_path(cx.tcx, def_id, const_path) {
+                        span_lint_and_sugg(
+                            cx,
+                            REPLACE_CONSTS,
+                            expr.span,
+                            &format!("using `{}`", const_path.last().expect("empty path")),
+                            "try this",
+                            repl_snip.to_string(),
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+const REPLACEMENTS: &[(&[&str], &str)] = &[
+    // Once
+    (&["core", "sync",  "ONCE_INIT"], "Once::new()"),
+    // Atomic
+    (&["core", "sync", "atomic", "ATOMIC_BOOL_INIT"],  "AtomicBool::new(false)"),
+    (&["core", "sync", "atomic", "ATOMIC_ISIZE_INIT"], "AtomicIsize::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_I8_INIT"],    "AtomicI8::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_I16_INIT"],   "AtomicI16::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_I32_INIT"],   "AtomicI32::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_I64_INIT"],   "AtomicI64::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_USIZE_INIT"], "AtomicUsize::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_U8_INIT"],    "AtomicU8::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_U16_INIT"],   "AtomicU16::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_U32_INIT"],   "AtomicU32::new(0)"),
+    (&["core", "sync", "atomic", "ATOMIC_U64_INIT"],   "AtomicU64::new(0)"),
+    // Min
+    (&["core", "isize", "MIN"], "isize::min_value()"),
+    (&["core", "i8",    "MIN"], "i8::min_value()"),
+    (&["core", "i16",   "MIN"], "i16::min_value()"),
+    (&["core", "i32",   "MIN"], "i32::min_value()"),
+    (&["core", "i64",   "MIN"], "i64::min_value()"),
+    (&["core", "i128",  "MIN"], "i128::min_value()"),
+    (&["core", "usize", "MIN"], "usize::min_value()"),
+    (&["core", "u8",    "MIN"], "u8::min_value()"),
+    (&["core", "u16",   "MIN"], "u16::min_value()"),
+    (&["core", "u32",   "MIN"], "u32::min_value()"),
+    (&["core", "u64",   "MIN"], "u64::min_value()"),
+    (&["core", "u128",  "MIN"], "u128::min_value()"),
+    // Max
+    (&["core", "isize", "MAX"], "isize::max_value()"),
+    (&["core", "i8",    "MAX"], "i8::max_value()"),
+    (&["core", "i16",   "MAX"], "i16::max_value()"),
+    (&["core", "i32",   "MAX"], "i32::max_value()"),
+    (&["core", "i64",   "MAX"], "i64::max_value()"),
+    (&["core", "i128",  "MAX"], "i128::max_value()"),
+    (&["core", "usize", "MAX"], "usize::max_value()"),
+    (&["core", "u8",    "MAX"], "u8::max_value()"),
+    (&["core", "u16",   "MAX"], "u16::max_value()"),
+    (&["core", "u32",   "MAX"], "u32::max_value()"),
+    (&["core", "u64",   "MAX"], "u64::max_value()"),
+    (&["core", "u128",  "MAX"], "u128::max_value()"),
+];

--- a/tests/ui/replace_consts.rs
+++ b/tests/ui/replace_consts.rs
@@ -1,0 +1,96 @@
+#![feature(integer_atomics, i128, i128_type)]
+#![allow(blacklisted_name)]
+#![deny(replace_consts)]
+use std::sync::atomic::*;
+use std::sync::{ONCE_INIT, Once};
+
+fn bad() {
+    // Once
+    { let foo = ONCE_INIT; };
+    // Atomic
+    { let foo = ATOMIC_BOOL_INIT; };
+    { let foo = ATOMIC_ISIZE_INIT; };
+    { let foo = ATOMIC_I8_INIT; };
+    { let foo = ATOMIC_I16_INIT; };
+    { let foo = ATOMIC_I32_INIT; };
+    { let foo = ATOMIC_I64_INIT; };
+    { let foo = ATOMIC_USIZE_INIT; };
+    { let foo = ATOMIC_U8_INIT; };
+    { let foo = ATOMIC_U16_INIT; };
+    { let foo = ATOMIC_U32_INIT; };
+    { let foo = ATOMIC_U64_INIT; };
+    // Min
+    { let foo = std::isize::MIN; };
+    { let foo = std::i8::MIN; };
+    { let foo = std::i16::MIN; };
+    { let foo = std::i32::MIN; };
+    { let foo = std::i64::MIN; };
+    { let foo = std::i128::MIN; };
+    { let foo = std::usize::MIN; };
+    { let foo = std::u8::MIN; };
+    { let foo = std::u16::MIN; };
+    { let foo = std::u32::MIN; };
+    { let foo = std::u64::MIN; };
+    { let foo = std::u128::MIN; };
+    // Max
+    { let foo = std::isize::MAX; };
+    { let foo = std::i8::MAX; };
+    { let foo = std::i16::MAX; };
+    { let foo = std::i32::MAX; };
+    { let foo = std::i64::MAX; };
+    { let foo = std::i128::MAX; };
+    { let foo = std::usize::MAX; };
+    { let foo = std::u8::MAX; };
+    { let foo = std::u16::MAX; };
+    { let foo = std::u32::MAX; };
+    { let foo = std::u64::MAX; };
+    { let foo = std::u128::MAX; };
+}
+
+fn good() {
+    // Once
+    { let foo = Once::new(); };
+    // Atomic
+    { let foo = AtomicBool::new(false); };
+    { let foo = AtomicIsize::new(0); };
+    { let foo = AtomicI8::new(0); };
+    { let foo = AtomicI16::new(0); };
+    { let foo = AtomicI32::new(0); };
+    { let foo = AtomicI64::new(0); };
+    { let foo = AtomicUsize::new(0); };
+    { let foo = AtomicU8::new(0); };
+    { let foo = AtomicU16::new(0); };
+    { let foo = AtomicU32::new(0); };
+    { let foo = AtomicU64::new(0); };
+    // Min
+    { let foo = isize::min_value(); };
+    { let foo = i8::min_value(); };
+    { let foo = i16::min_value(); };
+    { let foo = i32::min_value(); };
+    { let foo = i64::min_value(); };
+    { let foo = i128::min_value(); };
+    { let foo = usize::min_value(); };
+    { let foo = u8::min_value(); };
+    { let foo = u16::min_value(); };
+    { let foo = u32::min_value(); };
+    { let foo = u64::min_value(); };
+    { let foo = u128::min_value(); };
+    // Max
+    { let foo = isize::max_value(); };
+    { let foo = i8::max_value(); };
+    { let foo = i16::max_value(); };
+    { let foo = i32::max_value(); };
+    { let foo = i64::max_value(); };
+    { let foo = i128::max_value(); };
+    { let foo = usize::max_value(); };
+    { let foo = u8::max_value(); };
+    { let foo = u16::max_value(); };
+    { let foo = u32::max_value(); };
+    { let foo = u64::max_value(); };
+    { let foo = u128::max_value(); };
+}
+
+fn main() {
+    bad();
+    good();
+}

--- a/tests/ui/replace_consts.stderr
+++ b/tests/ui/replace_consts.stderr
@@ -1,0 +1,216 @@
+error: using `ATOMIC_BOOL_INIT`
+  --> $DIR/replace_consts.rs:11:17
+   |
+11 |     { let foo = ATOMIC_BOOL_INIT; };
+   |                 ^^^^^^^^^^^^^^^^ help: try this: `AtomicBool::new(false)`
+   |
+note: lint level defined here
+  --> $DIR/replace_consts.rs:3:9
+   |
+3  | #![deny(replace_consts)]
+   |         ^^^^^^^^^^^^^^
+
+error: using `ATOMIC_ISIZE_INIT`
+  --> $DIR/replace_consts.rs:12:17
+   |
+12 |     { let foo = ATOMIC_ISIZE_INIT; };
+   |                 ^^^^^^^^^^^^^^^^^ help: try this: `AtomicIsize::new(0)`
+
+error: using `ATOMIC_I8_INIT`
+  --> $DIR/replace_consts.rs:13:17
+   |
+13 |     { let foo = ATOMIC_I8_INIT; };
+   |                 ^^^^^^^^^^^^^^ help: try this: `AtomicI8::new(0)`
+
+error: using `ATOMIC_I16_INIT`
+  --> $DIR/replace_consts.rs:14:17
+   |
+14 |     { let foo = ATOMIC_I16_INIT; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `AtomicI16::new(0)`
+
+error: using `ATOMIC_I32_INIT`
+  --> $DIR/replace_consts.rs:15:17
+   |
+15 |     { let foo = ATOMIC_I32_INIT; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `AtomicI32::new(0)`
+
+error: using `ATOMIC_I64_INIT`
+  --> $DIR/replace_consts.rs:16:17
+   |
+16 |     { let foo = ATOMIC_I64_INIT; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `AtomicI64::new(0)`
+
+error: using `ATOMIC_USIZE_INIT`
+  --> $DIR/replace_consts.rs:17:17
+   |
+17 |     { let foo = ATOMIC_USIZE_INIT; };
+   |                 ^^^^^^^^^^^^^^^^^ help: try this: `AtomicUsize::new(0)`
+
+error: using `ATOMIC_U8_INIT`
+  --> $DIR/replace_consts.rs:18:17
+   |
+18 |     { let foo = ATOMIC_U8_INIT; };
+   |                 ^^^^^^^^^^^^^^ help: try this: `AtomicU8::new(0)`
+
+error: using `ATOMIC_U16_INIT`
+  --> $DIR/replace_consts.rs:19:17
+   |
+19 |     { let foo = ATOMIC_U16_INIT; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `AtomicU16::new(0)`
+
+error: using `ATOMIC_U32_INIT`
+  --> $DIR/replace_consts.rs:20:17
+   |
+20 |     { let foo = ATOMIC_U32_INIT; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `AtomicU32::new(0)`
+
+error: using `ATOMIC_U64_INIT`
+  --> $DIR/replace_consts.rs:21:17
+   |
+21 |     { let foo = ATOMIC_U64_INIT; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `AtomicU64::new(0)`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:23:17
+   |
+23 |     { let foo = std::isize::MIN; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `isize::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:24:17
+   |
+24 |     { let foo = std::i8::MIN; };
+   |                 ^^^^^^^^^^^^ help: try this: `i8::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:25:17
+   |
+25 |     { let foo = std::i16::MIN; };
+   |                 ^^^^^^^^^^^^^ help: try this: `i16::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:26:17
+   |
+26 |     { let foo = std::i32::MIN; };
+   |                 ^^^^^^^^^^^^^ help: try this: `i32::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:27:17
+   |
+27 |     { let foo = std::i64::MIN; };
+   |                 ^^^^^^^^^^^^^ help: try this: `i64::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:28:17
+   |
+28 |     { let foo = std::i128::MIN; };
+   |                 ^^^^^^^^^^^^^^ help: try this: `i128::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:29:17
+   |
+29 |     { let foo = std::usize::MIN; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `usize::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:30:17
+   |
+30 |     { let foo = std::u8::MIN; };
+   |                 ^^^^^^^^^^^^ help: try this: `u8::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:31:17
+   |
+31 |     { let foo = std::u16::MIN; };
+   |                 ^^^^^^^^^^^^^ help: try this: `u16::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:32:17
+   |
+32 |     { let foo = std::u32::MIN; };
+   |                 ^^^^^^^^^^^^^ help: try this: `u32::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:33:17
+   |
+33 |     { let foo = std::u64::MIN; };
+   |                 ^^^^^^^^^^^^^ help: try this: `u64::min_value()`
+
+error: using `MIN`
+  --> $DIR/replace_consts.rs:34:17
+   |
+34 |     { let foo = std::u128::MIN; };
+   |                 ^^^^^^^^^^^^^^ help: try this: `u128::min_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:36:17
+   |
+36 |     { let foo = std::isize::MAX; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `isize::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:37:17
+   |
+37 |     { let foo = std::i8::MAX; };
+   |                 ^^^^^^^^^^^^ help: try this: `i8::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:38:17
+   |
+38 |     { let foo = std::i16::MAX; };
+   |                 ^^^^^^^^^^^^^ help: try this: `i16::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:39:17
+   |
+39 |     { let foo = std::i32::MAX; };
+   |                 ^^^^^^^^^^^^^ help: try this: `i32::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:40:17
+   |
+40 |     { let foo = std::i64::MAX; };
+   |                 ^^^^^^^^^^^^^ help: try this: `i64::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:41:17
+   |
+41 |     { let foo = std::i128::MAX; };
+   |                 ^^^^^^^^^^^^^^ help: try this: `i128::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:42:17
+   |
+42 |     { let foo = std::usize::MAX; };
+   |                 ^^^^^^^^^^^^^^^ help: try this: `usize::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:43:17
+   |
+43 |     { let foo = std::u8::MAX; };
+   |                 ^^^^^^^^^^^^ help: try this: `u8::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:44:17
+   |
+44 |     { let foo = std::u16::MAX; };
+   |                 ^^^^^^^^^^^^^ help: try this: `u16::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:45:17
+   |
+45 |     { let foo = std::u32::MAX; };
+   |                 ^^^^^^^^^^^^^ help: try this: `u32::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:46:17
+   |
+46 |     { let foo = std::u64::MAX; };
+   |                 ^^^^^^^^^^^^^ help: try this: `u64::max_value()`
+
+error: using `MAX`
+  --> $DIR/replace_consts.rs:47:17
+   |
+47 |     { let foo = std::u128::MAX; };
+   |                 ^^^^^^^^^^^^^^ help: try this: `u128::max_value()`
+


### PR DESCRIPTION
Fixes #2288 

I think the "Why is this bad" section in the documentation should have more, but I'm not sure what to put there.