### PR TITLE
Fix #1159: avoid comparing fixed and target sized types in lint

### DIFF
--- a/tests/ui/absurd-extreme-comparisons.rs
+++ b/tests/ui/absurd-extreme-comparisons.rs
@@ -50,3 +50,8 @@ impl PartialOrd<u32> for U {
 pub fn foo(val: U) -> bool {
     val > std::u32::MAX
 }
+
+pub fn bar(len: u64) -> bool {
+    // This is OK as we are casting from target sized to fixed size
+    len >= std::usize::MAX as u64
+}


### PR DESCRIPTION
PR to fix #1159