### PR TITLE
Fix misaligned transmute lint.

### DIFF
--- a/tests/ui/transmute.rs
+++ b/tests/ui/transmute.rs
@@ -142,9 +142,11 @@ fn bytes_to_str(b: &[u8], mb: &mut [u8]) {
 
 #[warn(misaligned_transmute)]
 fn misaligned_transmute() {
-    let _: u32 = unsafe { std::mem::transmute([0u8; 4]) }; // err
-    let _: u32 = unsafe { std::mem::transmute(0f32) }; // ok (alignment-wise)
-    let _: [u8; 4] = unsafe { std::mem::transmute(0u32) }; // ok (alignment-wise)
+    let _: &u32 = unsafe { std::mem::transmute(&[0u8; 4]) }; // err
+    let _: *const u32 = unsafe { std::mem::transmute(&[0u8; 4] as *const [u8; 4]) }; // err
+    let _: u32 = unsafe { std::mem::transmute([0u8; 4]) }; // ok (not pointers)
+    let _: &u32 = unsafe { std::mem::transmute(&0f32) }; // ok (alignment-wise)
+    let _: &[u8; 4] = unsafe { std::mem::transmute(&0u32) }; // ok (alignment-wise)
 }
 
 fn main() { }

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -204,13 +204,22 @@ error: transmute from a `&mut [u8]` to a `&mut str`
 140 |     let _: &mut str = unsafe { std::mem::transmute(mb) };
     |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_mut(mb).unwrap()`
 
-error: transmute from `[u8; 4]` to a less-aligned type (`u32`)
-   --> $DIR/transmute.rs:145:27
+error: transmute from pointer to `[u8; 4]` to a more-strictly aligned type (`u32`)
+   --> $DIR/transmute.rs:145:28
     |
-145 |     let _: u32 = unsafe { std::mem::transmute([0u8; 4]) }; // err
-    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+145 |     let _: &u32 = unsafe { std::mem::transmute(&[0u8; 4]) }; // err
+    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D misaligned-transmute` implied by `-D warnings`
+    = note: `[u8; 4]` has 1-byte alignment; `u32` has 4-byte alignment
 
-error: aborting due to 33 previous errors
+error: transmute from pointer to `[u8; 4]` to a more-strictly aligned type (`u32`)
+   --> $DIR/transmute.rs:146:34
+    |
+146 |     let _: *const u32 = unsafe { std::mem::transmute(&[0u8; 4] as *const [u8; 4]) }; // err
+    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: `[u8; 4]` has 1-byte alignment; `u32` has 4-byte alignment
+
+error: aborting due to 34 previous errors
 


### PR DESCRIPTION
This clears up some ambiguous wording within the lint's descriptions,
and makes it so that the lint only applies to pointers. This should fix
a number of false positives (when the lint was applied to non-pointer
types) as well as false negatives (when the lint was applied to two
pointers of the same alignment, but whose pointed-to types had differing
alignments). See discussion at #2400.