### PR TITLE
Fix false positive in empty_line_after_outer_attr

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -262,6 +262,9 @@ fn check_attrs(cx: &LateContext, span: Span, name: &Name, attrs: &[Attribute]) {
     }
 
     for attr in attrs {
+        if attr.is_sugared_doc {
+            return;
+        }
         if attr.style == AttrStyle::Outer {
             if !is_present_in_source(cx, attr.span) {
                 return;
@@ -276,7 +279,7 @@ fn check_attrs(cx: &LateContext, span: Span, name: &Name, attrs: &[Attribute]) {
                         cx,
                         EMPTY_LINE_AFTER_OUTER_ATTR,
                         attr_to_item_span,
-                        &format!("Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?")
+                        "Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?"
                         );
 
                 }

--- a/tests/ui/empty_line_after_outer_attribute.rs
+++ b/tests/ui/empty_line_after_outer_attribute.rs
@@ -47,6 +47,11 @@ struct Foo {
 mod foo {
 }
 
+/// This doc comment should not produce a warning
+
+/** This is also a doc comment and should not produce a warning
+ */
+
 // This should not produce a warning
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]


### PR DESCRIPTION
See https://github.com/rust-lang-nursery/rust-clippy/pull/2340#issuecomment-361781622

Doc comments are syntactic sugar for #[doc] attributes, so this lint was
catching them, too.

This commit makes it so that doc comments are ignored in this lint.

I think, for normal attributes it makes sense to warn about following empty
lines, for doc comments, less. This way the user has some freedom over
the formatting.