### PR TITLE
Allow empty lines in lint doc examples

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -97,12 +97,11 @@ declare_lint! {
 /// // Good (as inner attribute)
 /// #![inline(always)]
 ///
-/// fn this_is_fine_too(..) { ... }
+/// fn this_is_fine(..) { ... }
 ///
 /// // Good (as outer attribute)
 /// #[inline(always)]
-/// fn this_is_fine(..) { ... }
-///
+/// fn this_is_fine_too(..) { ... }
 /// ```
 declare_lint! {
     pub EMPTY_LINE_AFTER_OUTER_ATTR,

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -13,7 +13,6 @@ use utils::{match_def_path, opt_def_id, paths, span_help_and_lint};
 /// ```rust
 /// let bad_ref: &usize = std::mem::zeroed();
 /// ```
-
 declare_lint! {
     pub INVALID_REF,
     Warn,

--- a/util/export.py
+++ b/util/export.py
@@ -24,7 +24,7 @@ def parse_lint_def(lint):
     last_section = None
 
     for line in lint.doc:
-        if len(line.strip()) == 0:
+        if len(line.strip()) == 0 and not last_section.startswith("Example"):
             continue
 
         match = re.match(lint_subheadline, line)
@@ -39,8 +39,13 @@ def parse_lint_def(lint):
             log.warn("Skipping comment line as it was not preceded by a heading")
             log.debug("in lint `%s`, line `%s`", lint.name, line)
 
-        lint_dict['docs'][last_section] = \
-            (lint_dict['docs'].get(last_section, "") + "\n" + text).strip()
+        fragment = lint_dict['docs'].get(last_section, "")
+        if text == "\n":
+            line = fragment + text
+        else:
+            line = (fragment + "\n" + text).strip()
+
+        lint_dict['docs'][last_section] = line
 
     return lint_dict
 


### PR DESCRIPTION
This makes sure that empty lines in lint examples are preserved. (mentioned in https://github.com/rust-lang-nursery/rust-clippy/pull/2340#issuecomment-362321133)

It also fixes the documentation for the `invalid_ref` lint, which was not
shown because of an extra newline between the doc comment and lint declaration.