### PR TITLE
Fix ICE comparing `ExprRange` equality

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -229,7 +229,18 @@ pub fn constant_simple(lcx: &LateContext, e: &Expr) -> Option<Constant> {
     constant(lcx, e).and_then(|(cst, res)| if res { None } else { Some(cst) })
 }
 
-struct ConstEvalLateContext<'a, 'tcx: 'a> {
+/// Creates a ConstEvalLateContext from the given LateContext and TypeckTables
+pub fn constant_context<'c, 'cc>(lcx: &LateContext<'c, 'cc>, tables: &'cc ty::TypeckTables<'cc>) -> ConstEvalLateContext<'c, 'cc> {
+    ConstEvalLateContext {
+        tcx: lcx.tcx,
+        tables,
+        param_env: lcx.param_env,
+        needed_resolution: false,
+        substs: lcx.tcx.intern_substs(&[]),
+    }
+}
+
+pub struct ConstEvalLateContext<'a, 'tcx: 'a> {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     tables: &'a ty::TypeckTables<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
@@ -239,7 +250,7 @@ struct ConstEvalLateContext<'a, 'tcx: 'a> {
 
 impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
     /// simple constant folding: Insert an expression, get a constant or none.
-    fn expr(&mut self, e: &Expr) -> Option<Constant> {
+    pub fn expr(&mut self, e: &Expr) -> Option<Constant> {
         match e.node {
             ExprPath(ref qpath) => self.fetch_path(qpath, e.hir_id),
             ExprBlock(ref block) => self.block(block),

--- a/tests/ui/copies.rs
+++ b/tests/ui/copies.rs
@@ -396,3 +396,18 @@ fn ifs_same_cond() {
 }
 
 fn main() {}
+
+// Issue #2423. This was causing an ICE
+fn func() {
+    if true {
+        f(&[0; 62]);
+        f(&[0; 4]);
+        f(&[0; 3]);
+    } else {
+        f(&[0; 62]);
+        f(&[0; 6]);
+        f(&[0; 6]);
+    }
+}
+
+fn f(val: &[u8]) {}


### PR DESCRIPTION
This should fix: https://github.com/rust-lang-nursery/rust-clippy/issues/2423

`eq_expr` on hir::utils was throwing an ICE due to an invalid `LateContext` being used. I've added a method to be able to create a `ConstEvalLateContext` with a custom `TypeckTables`. 
There was a comment on the issue pointing that it should be create also from a specific `param_env`, but it seems that is not need on this specific case. I've took a look and I didn't find any way of extracting the `param_env`.