### PR TITLE
Make decimal_literal_representation a restriction lint

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -382,6 +382,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         else_if_without_else::ELSE_IF_WITHOUT_ELSE,
         methods::CLONE_ON_REF_PTR,
         misc::FLOAT_CMP_CONST,
+        literal_representation::DECIMAL_LITERAL_REPRESENTATION,
     ]);
 
     reg.register_lint_group("clippy_pedantic", vec![
@@ -496,7 +497,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         let_if_seq::USELESS_LET_IF_SEQ,
         lifetimes::NEEDLESS_LIFETIMES,
         lifetimes::UNUSED_LIFETIMES,
-        literal_representation::DECIMAL_LITERAL_REPRESENTATION,
         literal_representation::INCONSISTENT_DIGIT_GROUPING,
         literal_representation::LARGE_DIGIT_GROUPS,
         literal_representation::UNREADABLE_LITERAL,

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -74,9 +74,8 @@ declare_lint! {
 /// `255` => `0xFF`
 /// `65_535` => `0xFFFF`
 /// `4_042_322_160` => `0xF0F0_F0F0`
-declare_lint! {
+declare_restriction_lint! {
     pub DECIMAL_LITERAL_REPRESENTATION,
-    Warn,
     "using decimal representation when hexadecimal would be better"
 }
 

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -178,7 +178,7 @@ define_Conf! {
     /// Lint: VERBOSE_BIT_MASK. The maximum allowed size of a bit mask before suggesting to use 'trailing_zeros'
     (verbose_bit_mask_threshold, "verbose_bit_mask_threshold", 1 => u64),
     /// Lint: DECIMAL_LITERAL_REPRESENTATION. The lower bound for linting decimal literals
-    (literal_representation_threshold, "literal_representation_threshold", 4096 => u64),
+    (literal_representation_threshold, "literal_representation_threshold", 16384 => u64),
 }
 
 /// Search for the configuration file.

--- a/tests/ui/decimal_literal_representation.rs
+++ b/tests/ui/decimal_literal_representation.rs
@@ -4,11 +4,17 @@
 #[warn(decimal_literal_representation)]
 #[allow(unused_variables)]
 fn main() {
-    // Hex:      7F,  80, 100, 1FF,  800,  FFA,   F0F3,     7F0F_F00D
-    let good = (127, 128, 256, 511, 2048, 4090, 61_683, 2_131_750_925);
+    let good = (        // Hex:
+        127,            // 0x7F
+        256,            // 0x100
+        511,            // 0x1FF
+        2048,           // 0x800
+        4090,           // 0xFFA
+        16_371,         // 0x3FF3
+        61_683,         // 0xF0F3
+        2_131_750_925,  // 0x7F0F_F00D
+    );
     let bad = (        // Hex:
-        4096,          // 0x1000
-        16_371,        // 0x3FF3
         32_773,        // 0x8005
         65_280,        // 0xFF00
         2_131_750_927, // 0x7F0F_F00F

--- a/tests/ui/decimal_literal_representation.stderr
+++ b/tests/ui/decimal_literal_representation.stderr
@@ -1,59 +1,43 @@
 error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:10:9
+  --> $DIR/decimal_literal_representation.rs:18:9
    |
-10 |         4096,          // 0x1000
-   |         ^^^^
+18 |         32_773,        // 0x8005
+   |         ^^^^^^
    |
    = note: `-D decimal-literal-representation` implied by `-D warnings`
-   = help: consider: 0x1000
-
-error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:11:9
-   |
-11 |         16_371,        // 0x3FF3
-   |         ^^^^^^
-   |
-   = help: consider: 0x3FF3
-
-error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:12:9
-   |
-12 |         32_773,        // 0x8005
-   |         ^^^^^^
-   |
    = help: consider: 0x8005
 
 error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:13:9
+  --> $DIR/decimal_literal_representation.rs:19:9
    |
-13 |         65_280,        // 0xFF00
+19 |         65_280,        // 0xFF00
    |         ^^^^^^
    |
    = help: consider: 0xFF00
 
 error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:14:9
+  --> $DIR/decimal_literal_representation.rs:20:9
    |
-14 |         2_131_750_927, // 0x7F0F_F00F
+20 |         2_131_750_927, // 0x7F0F_F00F
    |         ^^^^^^^^^^^^^
    |
    = help: consider: 0x7F0F_F00F
 
 error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:15:9
+  --> $DIR/decimal_literal_representation.rs:21:9
    |
-15 |         2_147_483_647, // 0x7FFF_FFFF
+21 |         2_147_483_647, // 0x7FFF_FFFF
    |         ^^^^^^^^^^^^^
    |
    = help: consider: 0x7FFF_FFFF
 
 error: integer literal has a better hexadecimal representation
-  --> $DIR/decimal_literal_representation.rs:16:9
+  --> $DIR/decimal_literal_representation.rs:22:9
    |
-16 |         4_042_322_160, // 0xF0F0_F0F0
+22 |         4_042_322_160, // 0xF0F0_F0F0
    |         ^^^^^^^^^^^^^
    |
    = help: consider: 0xF0F0_F0F0
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Also set the default limit to `16384 = 0x4000`.

Addresses #2421 