### PR TITLE
Partly fix incorrect useless_attribute suggestion

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -427,6 +427,14 @@ pub fn snippet_block<'a, 'b, T: LintContext<'b>>(cx: &T, span: Span, default: &'
     trim_multiline(snip, true)
 }
 
+/// Returns a new Span that covers the full last line of the given Span
+pub fn last_line_of_span<'a, T: LintContext<'a>>(cx: &T, span: Span) -> Span {
+    let file_map_and_line = cx.sess().codemap().lookup_line(span.lo()).unwrap();
+    let line_no = file_map_and_line.line;
+    let line_start = &file_map_and_line.fm.lines.clone().into_inner()[line_no];
+    Span::new(*line_start, span.hi(), span.ctxt())
+}
+
 /// Like `snippet_block`, but add braces if the expr is not an `ExprBlock`.
 /// Also takes an `Option<String>` which can be put inside the braces.
 pub fn expr_block<'a, 'b, T: LintContext<'b>>(

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -3,6 +3,9 @@
 #![warn(useless_attribute)]
 
 #[allow(dead_code, unused_extern_crates)]
+#[cfg_attr(feature = "cargo-clippy", allow(dead_code, unused_extern_crates))]
+#[cfg_attr(feature = "cargo-clippy",
+           allow(dead_code, unused_extern_crates))]
 extern crate clippy_lints;
 
 // don't lint on unused_import for `use` items

--- a/tests/ui/useless_attribute.stderr
+++ b/tests/ui/useless_attribute.stderr
@@ -6,5 +6,11 @@ error: useless lint attribute
   |
   = note: `-D useless-attribute` implied by `-D warnings`
 
-error: aborting due to previous error
+error: useless lint attribute
+ --> $DIR/useless_attribute.rs:6:1
+  |
+6 | #[cfg_attr(feature = "cargo-clippy", allow(dead_code, unused_extern_crates))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![cfg_attr(feature = "cargo-clippy", allow(dead_code, unused_extern_crates))`
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This fixes an incorrect suggestion from the `useless_attribute` lint
when using `cfg_attr`.

Additionally, it will not show a suggestion anymore, if the attribute
begins on a previous line, because it is much harder to construct the suggestion
span of multi-line `cfg_attr` attributes as they don't appear in the AST.

Reported in #1522 