### PR TITLE
Fix: point to correct problem part of code

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -913,6 +913,10 @@ fn lint_or_fun_call(cx: &LateContext, expr: &hir::Expr, name: &str, args: &[hir:
             return;
         }
 
+        let start_point = self_expr.span.hi();
+        let end_point = arg.span.lo();
+        let span_replace_word = Span::new(start_point, end_point, span.ctxt());
+
         // don't lint for constant values
         let owner_def = cx.tcx.hir.get_parent_did(arg.id);
         let promotable = cx.tcx.rvalue_promotable_map(owner_def).contains(&arg.hir_id.local_id);
@@ -939,14 +943,13 @@ fn lint_or_fun_call(cx: &LateContext, expr: &hir::Expr, name: &str, args: &[hir:
             (false, false) => format!("|| {}", snippet(cx, arg.span, "..")).into(),
             (false, true) => snippet(cx, fun_span, ".."),
         };
-
         span_lint_and_sugg(
             cx,
             OR_FUN_CALL,
-            span,
+            span_replace_word ,
             &format!("use of `{}` followed by a function call", name),
             "try this",
-            format!("{}.{}_{}({})", snippet(cx, self_expr.span, "_"), name, suffix, sugg),
+            format!("{}_{}({})", name, suffix, sugg),
         );
     }
 

--- a/tests/ui/unwrap_or.rs
+++ b/tests/ui/unwrap_or.rs
@@ -1,0 +1,7 @@
+#![warn(clippy)]
+
+fn main() {
+    let some_string = Some(String::from("this string from the test"));
+    let su = some_string.clone().and(some_string).unwrap_or("Fail".to_string());
+}
+

--- a/tests/ui/unwrap_or.stderr
+++ b/tests/ui/unwrap_or.stderr
@@ -1,0 +1,10 @@
+error: use of `unwrap_or` followed by a function call
+ --> $DIR/unwrap_or.rs:5:50
+  |
+5 |     let su = some_string.clone().and(some_string).unwrap_or("Fail".to_string());
+  |                                                  ^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "Fail".to_string())`
+  |
+  = note: `-D or-fun-call` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
First pull for this project so please send feedback.

Fix span so it no longer contains the whole train-wreck of code and only
points to the problem function (for the unwrap_or lint).

https://github.com/rust-lang-nursery/rust-clippy/issues/2422