### PR TITLE
Lint multiline attributes properly

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -271,18 +271,18 @@ fn check_attrs(cx: &LateContext, span: Span, name: &Name, attrs: &[Attribute]) {
                 return;
             }
 
-            let attr_to_item_span = Span::new(attr.span.lo(), span.lo(), span.ctxt());
+            let begin_of_attr_to_item = Span::new(attr.span.lo(), span.lo(), span.ctxt());
+            let end_of_attr_to_item = Span::new(attr.span.hi(), span.lo(), span.ctxt());
 
-            if let Some(snippet) = snippet_opt(cx, attr_to_item_span) {
+            if let Some(snippet) = snippet_opt(cx, end_of_attr_to_item) {
                 let lines = snippet.split('\n').collect::<Vec<_>>();
-                if lines.iter().filter(|l| l.trim().is_empty()).count() > 1 {
+                if lines.iter().filter(|l| l.trim().is_empty()).count() > 2 {
                     span_lint(
                         cx,
                         EMPTY_LINE_AFTER_OUTER_ATTR,
-                        attr_to_item_span,
+                        begin_of_attr_to_item,
                         "Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?"
-                        );
-
+                    );
                 }
             }
         }

--- a/tests/ui/empty_line_after_outer_attribute.rs
+++ b/tests/ui/empty_line_after_outer_attribute.rs
@@ -58,4 +58,13 @@ mod foo {
 #[allow(missing_docs)]
 fn three_attributes() { assert!(true) }
 
+// This should not produce a warning
+#[doc = "
+Returns the escaped value of the textual representation of
+
+"]
+pub fn function() -> bool {
+    true
+}
+
 fn main() { }


### PR DESCRIPTION
This makes it so that the `empty_line_after_outer_attribute` lint only
checks for newlines between the end of the attribute and the beginning
of the following item.

We need to check for the empty line count being bigger than 2 because
now the snippet of valid code contains only `\n` and splitting it
produces `["", ""]`
Invalid code would contain more than 2 empty strings.

Closes #2428 