### PR TITLE
immutable while condition

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -521,6 +521,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         loops::UNUSED_COLLECT,
         loops::WHILE_LET_LOOP,
         loops::WHILE_LET_ON_ITERATOR,
+        loops::WHILE_IMMUTABLE_CONDITION,
         map_clone::MAP_CLONE,
         matches::MATCH_AS_REF,
         matches::MATCH_BOOL,

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -77,8 +77,8 @@ fn used_immutable() {
     }
 
     while i < 3 {
-        fn_mutref(&mut i);
         println!("OK - passed by mutable reference");
+        fn_mutref(&mut i)
     }
 }
 

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -1,7 +1,8 @@
 fn fn_val(i: i32) -> i32 { unimplemented!() }
 fn fn_constref(i: &i32) -> i32 { unimplemented!() }
 fn fn_mutref(i: &mut i32) { unimplemented!() }
-fn foo() -> i32 { unimplemented!() }
+fn fooi() -> i32 { unimplemented!() }
+fn foob() -> bool { unimplemented!() }
 
 fn immutable_condition() {
     // Should warn when all vars mentionned are immutable
@@ -12,6 +13,8 @@ fn immutable_condition() {
 
     let x = 0;
     while y < 10 && x < 3 {
+        let mut k = 1;
+        k += 2;
         println!("KO - x and y immutable");
     }
 
@@ -32,7 +35,11 @@ fn immutable_condition() {
         println!("OK - mut_cond is mutable");
     }
 
-    while foo() < x {
+    while fooi() < x {
+        println!("OK - Fn call results may vary");
+    }
+
+    while foob() {
         println!("OK - Fn call results may vary");
     }
 
@@ -79,6 +86,11 @@ fn used_immutable() {
     while i < 3 {
         println!("OK - passed by mutable reference");
         fn_mutref(&mut i)
+    }
+
+    while i < 3 {
+        fn_mutref(&mut i);
+        println!("OK - passed by mutable reference");
     }
 }
 

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -1,0 +1,89 @@
+fn fn_val(i: i32) -> i32 { unimplemented!() }
+fn fn_constref(i: &i32) -> i32 { unimplemented!() }
+fn fn_mutref(i: &mut i32) { unimplemented!() }
+fn foo() -> i32 { unimplemented!() }
+
+fn immutable_condition() {
+    // Should warn when all vars mentionned are immutable
+    let y = 0;
+    while y < 10 {
+        println!("KO - y is immutable");
+    }
+
+    let x = 0;
+    while y < 10 && x < 3 {
+        println!("KO - x and y immutable");
+    }
+
+    let cond = false;
+    while !cond {
+        println!("KO - cond immutable");
+    }
+
+    let mut i = 0;
+    while y < 10 && i < 3 {
+        i += 1;
+        println!("OK - i is mutable");
+    }
+
+    let mut mut_cond = false;
+    while !mut_cond || cond {
+        mut_cond = true;
+        println!("OK - mut_cond is mutable");
+    }
+
+    while foo() < x {
+        println!("OK - Fn call results may vary");
+    }
+
+}
+
+fn unused_var() {
+    // Should warn when a (mutable) var is not used in while body
+    let (mut i, mut j) = (0, 0);
+
+    while i < 3 {
+        j = 3;
+        println!("KO - i not mentionned");
+    }
+
+    while i < 3 && j > 0 {
+        println!("KO - i and j not mentionned");
+    }
+
+    while i < 3 {
+        let mut i = 5;
+        fn_mutref(&mut i);
+        println!("KO - shadowed");
+    }
+
+    while i < 3 && j > 0 {
+        i = 5;
+        println!("OK - i in cond and mentionned");
+    }
+}
+
+fn used_immutable() {
+    let mut i = 0;
+
+    while i < 3 {
+        fn_constref(&i);
+        println!("KO - const reference");
+    }
+
+    while i < 3 {
+        fn_val(i);
+        println!("KO - passed by value");
+    }
+
+    while i < 3 {
+        fn_mutref(&mut i);
+        println!("OK - passed by mutable reference");
+    }
+}
+
+fn main() {
+    immutable_condition();
+    unused_var();
+    used_immutable();
+}

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -94,8 +94,22 @@ fn used_immutable() {
     }
 }
 
+use std::cell::Cell;
+
+fn maybe_i_mutate(i: &Cell<bool>) { unimplemented!() }
+
+fn internally_mutable() {
+    let b = Cell::new(true);
+
+    while b.get() {       // b cannot be silently coerced to `bool`
+        maybe_i_mutate(&b);
+        println!("OK - Method call within condition");
+    }
+}
+
 fn main() {
     immutable_condition();
     unused_var();
     used_immutable();
+    internally_mutable();
 }

--- a/tests/ui/infinite_loop.stderr
+++ b/tests/ui/infinite_loop.stderr
@@ -1,0 +1,22 @@
+error: all variables in condition are immutable. This might lead to infinite loops.
+ --> $DIR/infinite_loop.rs:9:11
+  |
+9 |     while y < 10 {
+  |           ^^^^^^
+  |
+  = note: `-D while-immutable-condition` implied by `-D warnings`
+
+error: all variables in condition are immutable. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:14:11
+   |
+14 |     while y < 10 && x < 3 {
+   |           ^^^^^^^^^^^^^^^
+
+error: all variables in condition are immutable. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:19:11
+   |
+19 |     while !cond {
+   |           ^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/infinite_loop.stderr
+++ b/tests/ui/infinite_loop.stderr
@@ -1,22 +1,67 @@
 error: all variables in condition are immutable. This might lead to infinite loops.
- --> $DIR/infinite_loop.rs:9:11
-  |
-9 |     while y < 10 {
-  |           ^^^^^^
-  |
-  = note: `-D while-immutable-condition` implied by `-D warnings`
+  --> $DIR/infinite_loop.rs:10:11
+   |
+10 |     while y < 10 {
+   |           ^^^^^^
+   |
+   = note: `-D while-immutable-condition` implied by `-D warnings`
 
 error: all variables in condition are immutable. This might lead to infinite loops.
-  --> $DIR/infinite_loop.rs:14:11
+  --> $DIR/infinite_loop.rs:15:11
    |
-14 |     while y < 10 && x < 3 {
+15 |     while y < 10 && x < 3 {
    |           ^^^^^^^^^^^^^^^
 
 error: all variables in condition are immutable. This might lead to infinite loops.
-  --> $DIR/infinite_loop.rs:19:11
+  --> $DIR/infinite_loop.rs:22:11
    |
-19 |     while !cond {
+22 |     while !cond {
    |           ^^^^^
 
-error: aborting due to 3 previous errors
+error: Variable in the condition are not mutated in the loop body. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:52:5
+   |
+52 | /     while i < 3 {
+53 | |         j = 3;
+54 | |         println!("KO - i not mentionned");
+55 | |     }
+   | |_____^
+
+error: Variable in the condition are not mutated in the loop body. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:57:5
+   |
+57 | /     while i < 3 && j > 0 {
+58 | |         println!("KO - i and j not mentionned");
+59 | |     }
+   | |_____^
+
+error: Variable in the condition are not mutated in the loop body. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:61:5
+   |
+61 | /     while i < 3 {
+62 | |         let mut i = 5;
+63 | |         fn_mutref(&mut i);
+64 | |         println!("KO - shadowed");
+65 | |     }
+   | |_____^
+
+error: Variable in the condition are not mutated in the loop body. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:76:5
+   |
+76 | /     while i < 3 {
+77 | |         fn_constref(&i);
+78 | |         println!("KO - const reference");
+79 | |     }
+   | |_____^
+
+error: Variable in the condition are not mutated in the loop body. This might lead to infinite loops.
+  --> $DIR/infinite_loop.rs:81:5
+   |
+81 | /     while i < 3 {
+82 | |         fn_val(i);
+83 | |         println!("KO - passed by value");
+84 | |     }
+   | |_____^
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/never_loop.rs
+++ b/tests/ui/never_loop.rs
@@ -1,6 +1,6 @@
 
 
-#![allow(single_match, unused_assignments, unused_variables)]
+#![allow(single_match, unused_assignments, unused_variables, while_immutable_condition)]
 
 fn test1() {
     let mut x = 0;


### PR DESCRIPTION
This PR aims at implementing lint suggested in [#40(comment)](https://github.com/rust-lang-nursery/rust-clippy/issues/40#issuecomment-251462183).

Current status, lints when:
- [x] All variables in the body are immutable
- [x] Variables in the condition do not appear in the body
- [x] Variables only used by const ref or by value. Special case to handle:
     - [x] Shadowing
     - ~~[ ] Inner mutability (cell, refcell, mutex, sync::atomic, anything else?)~~

Is there any additional step or edge case to be handled?