### PR TITLE
Fix #2494 add suggestion for unreadable_literal

### DIFF
--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -4,7 +4,7 @@
 use rustc::lint::*;
 use syntax::ast::*;
 use syntax_pos;
-use utils::{in_external_macro, snippet_opt, span_help_and_lint};
+use utils::{in_external_macro, snippet_opt, span_lint_and_sugg};
 
 /// **What it does:** Warns if a long integral or floating-point constant does
 /// not contain underscores.
@@ -222,33 +222,37 @@ enum WarningType {
 impl WarningType {
     pub fn display(&self, grouping_hint: &str, cx: &EarlyContext, span: &syntax_pos::Span) {
         match *self {
-            WarningType::UnreadableLiteral => span_help_and_lint(
+            WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,
                 UNREADABLE_LITERAL,
                 *span,
                 "long literal lacking separators",
-                &format!("consider: {}", grouping_hint),
+                "consider",
+                grouping_hint.to_owned(),
             ),
-            WarningType::LargeDigitGroups => span_help_and_lint(
+            WarningType::LargeDigitGroups => span_lint_and_sugg(
                 cx,
                 LARGE_DIGIT_GROUPS,
                 *span,
                 "digit groups should be smaller",
-                &format!("consider: {}", grouping_hint),
+                "consider",
+                grouping_hint.to_owned(),
             ),
-            WarningType::InconsistentDigitGrouping => span_help_and_lint(
+            WarningType::InconsistentDigitGrouping => span_lint_and_sugg(
                 cx,
                 INCONSISTENT_DIGIT_GROUPING,
                 *span,
                 "digits grouped inconsistently by underscores",
-                &format!("consider: {}", grouping_hint),
+                "consider",
+                grouping_hint.to_owned(),
             ),
-            WarningType::DecimalRepresentation => span_help_and_lint(
+            WarningType::DecimalRepresentation => span_lint_and_sugg(
                 cx,
                 DECIMAL_LITERAL_REPRESENTATION,
                 *span,
                 "integer literal has a better hexadecimal representation",
-                &format!("consider: {}", grouping_hint),
+                "consider",
+                grouping_hint.to_owned(),
             ),
         };
     }

--- a/tests/ui/builtin-type-shadow.stderr
+++ b/tests/ui/builtin-type-shadow.stderr
@@ -19,3 +19,4 @@ error[E0308]: mismatched types
 
 error: aborting due to 2 previous errors
 
+If you want more information on this error, try using "rustc --explain E0308"

--- a/tests/ui/conf_bad_arg.stderr
+++ b/tests/ui/conf_bad_arg.stderr
@@ -8,3 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
+If you want more information on this error, try using "rustc --explain E0658"

--- a/tests/ui/conf_bad_toml.stderr
+++ b/tests/ui/conf_bad_toml.stderr
@@ -8,3 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
+If you want more information on this error, try using "rustc --explain E0658"

--- a/tests/ui/conf_bad_type.stderr
+++ b/tests/ui/conf_bad_type.stderr
@@ -8,3 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
+If you want more information on this error, try using "rustc --explain E0658"

--- a/tests/ui/conf_french_blacklisted_name.stderr
+++ b/tests/ui/conf_french_blacklisted_name.stderr
@@ -8,3 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
+If you want more information on this error, try using "rustc --explain E0658"

--- a/tests/ui/conf_path_non_string.stderr
+++ b/tests/ui/conf_path_non_string.stderr
@@ -8,3 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
+If you want more information on this error, try using "rustc --explain E0658"

--- a/tests/ui/conf_unknown_key.stderr
+++ b/tests/ui/conf_unknown_key.stderr
@@ -8,3 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
+If you want more information on this error, try using "rustc --explain E0658"

--- a/tests/ui/decimal_literal_representation.stderr
+++ b/tests/ui/decimal_literal_representation.stderr
@@ -2,42 +2,33 @@ error: integer literal has a better hexadecimal representation
   --> $DIR/decimal_literal_representation.rs:18:9
    |
 18 |         32_773,        // 0x8005
-   |         ^^^^^^
+   |         ^^^^^^ help: consider: `0x8005`
    |
    = note: `-D decimal-literal-representation` implied by `-D warnings`
-   = help: consider: 0x8005
 
 error: integer literal has a better hexadecimal representation
   --> $DIR/decimal_literal_representation.rs:19:9
    |
 19 |         65_280,        // 0xFF00
-   |         ^^^^^^
-   |
-   = help: consider: 0xFF00
+   |         ^^^^^^ help: consider: `0xFF00`
 
 error: integer literal has a better hexadecimal representation
   --> $DIR/decimal_literal_representation.rs:20:9
    |
 20 |         2_131_750_927, // 0x7F0F_F00F
-   |         ^^^^^^^^^^^^^
-   |
-   = help: consider: 0x7F0F_F00F
+   |         ^^^^^^^^^^^^^ help: consider: `0x7F0F_F00F`
 
 error: integer literal has a better hexadecimal representation
   --> $DIR/decimal_literal_representation.rs:21:9
    |
 21 |         2_147_483_647, // 0x7FFF_FFFF
-   |         ^^^^^^^^^^^^^
-   |
-   = help: consider: 0x7FFF_FFFF
+   |         ^^^^^^^^^^^^^ help: consider: `0x7FFF_FFFF`
 
 error: integer literal has a better hexadecimal representation
   --> $DIR/decimal_literal_representation.rs:22:9
    |
 22 |         4_042_322_160, // 0xF0F0_F0F0
-   |         ^^^^^^^^^^^^^
-   |
-   = help: consider: 0xF0F0_F0F0
+   |         ^^^^^^^^^^^^^ help: consider: `0xF0F0_F0F0`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/inconsistent_digit_grouping.stderr
+++ b/tests/ui/inconsistent_digit_grouping.stderr
@@ -2,42 +2,33 @@ error: digits grouped inconsistently by underscores
  --> $DIR/inconsistent_digit_grouping.rs:7:16
   |
 7 |     let bad = (1_23_456, 1_234_5678, 1234_567, 1_234.5678_f32, 1.234_5678_f32);
-  |                ^^^^^^^^
+  |                ^^^^^^^^ help: consider: `123_456`
   |
   = note: `-D inconsistent-digit-grouping` implied by `-D warnings`
-  = help: consider: 123_456
 
 error: digits grouped inconsistently by underscores
  --> $DIR/inconsistent_digit_grouping.rs:7:26
   |
 7 |     let bad = (1_23_456, 1_234_5678, 1234_567, 1_234.5678_f32, 1.234_5678_f32);
-  |                          ^^^^^^^^^^
-  |
-  = help: consider: 12_345_678
+  |                          ^^^^^^^^^^ help: consider: `12_345_678`
 
 error: digits grouped inconsistently by underscores
  --> $DIR/inconsistent_digit_grouping.rs:7:38
   |
 7 |     let bad = (1_23_456, 1_234_5678, 1234_567, 1_234.5678_f32, 1.234_5678_f32);
-  |                                      ^^^^^^^^
-  |
-  = help: consider: 1_234_567
+  |                                      ^^^^^^^^ help: consider: `1_234_567`
 
 error: digits grouped inconsistently by underscores
  --> $DIR/inconsistent_digit_grouping.rs:7:48
   |
 7 |     let bad = (1_23_456, 1_234_5678, 1234_567, 1_234.5678_f32, 1.234_5678_f32);
-  |                                                ^^^^^^^^^^^^^^
-  |
-  = help: consider: 1_234.567_8_f32
+  |                                                ^^^^^^^^^^^^^^ help: consider: `1_234.567_8_f32`
 
 error: digits grouped inconsistently by underscores
  --> $DIR/inconsistent_digit_grouping.rs:7:64
   |
 7 |     let bad = (1_23_456, 1_234_5678, 1234_567, 1_234.5678_f32, 1.234_5678_f32);
-  |                                                                ^^^^^^^^^^^^^^
-  |
-  = help: consider: 1.234_567_8_f32
+  |                                                                ^^^^^^^^^^^^^^ help: consider: `1.234_567_8_f32`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/large_digit_groups.stderr
+++ b/tests/ui/large_digit_groups.stderr
@@ -2,50 +2,39 @@ error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:16
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                ^^^^^^^^^^^^^
+  |                ^^^^^^^^^^^^^ help: consider: `0b11_0110_i64`
   |
   = note: `-D large-digit-groups` implied by `-D warnings`
-  = help: consider: 0b11_0110_i64
 
 error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:31
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                               ^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: consider: 0x123_4567_8901_usize
+  |                               ^^^^^^^^^^^^^^^^^^^^^ help: consider: `0x123_4567_8901_usize`
 
 error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:54
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                                                      ^^^^^^^^^^^
-  |
-  = help: consider: 123_456_f32
+  |                                                      ^^^^^^^^^^^ help: consider: `123_456_f32`
 
 error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:67
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                                                                   ^^^^^^^^^^^^^^
-  |
-  = help: consider: 123_456.12_f32
+  |                                                                   ^^^^^^^^^^^^^^ help: consider: `123_456.12_f32`
 
 error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:83
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                                                                                   ^^^^^^^^^^^^^^^^^
-  |
-  = help: consider: 123_456.123_45_f32
+  |                                                                                   ^^^^^^^^^^^^^^^^^ help: consider: `123_456.123_45_f32`
 
 error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:102
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                                                                                                      ^^^^^^^^^^^^^^^^^^^
-  |
-  = help: consider: 123_456.123_456_f32
+  |                                                                                                      ^^^^^^^^^^^^^^^^^^^ help: consider: `123_456.123_456_f32`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/unreadable_literal.stderr
+++ b/tests/ui/unreadable_literal.stderr
@@ -2,34 +2,27 @@ error: long literal lacking separators
  --> $DIR/unreadable_literal.rs:7:16
   |
 7 |     let bad = (0b10110_i64, 0x12345678901_usize, 12345_f32, 1.23456_f32);
-  |                ^^^^^^^^^^^
+  |                ^^^^^^^^^^^ help: consider: `0b1_0110_i64`
   |
   = note: `-D unreadable-literal` implied by `-D warnings`
-  = help: consider: 0b1_0110_i64
 
 error: long literal lacking separators
  --> $DIR/unreadable_literal.rs:7:29
   |
 7 |     let bad = (0b10110_i64, 0x12345678901_usize, 12345_f32, 1.23456_f32);
-  |                             ^^^^^^^^^^^^^^^^^^^
-  |
-  = help: consider: 0x123_4567_8901_usize
+  |                             ^^^^^^^^^^^^^^^^^^^ help: consider: `0x123_4567_8901_usize`
 
 error: long literal lacking separators
  --> $DIR/unreadable_literal.rs:7:50
   |
 7 |     let bad = (0b10110_i64, 0x12345678901_usize, 12345_f32, 1.23456_f32);
-  |                                                  ^^^^^^^^^
-  |
-  = help: consider: 12_345_f32
+  |                                                  ^^^^^^^^^ help: consider: `12_345_f32`
 
 error: long literal lacking separators
  --> $DIR/unreadable_literal.rs:7:61
   |
 7 |     let bad = (0b10110_i64, 0x12345678901_usize, 12345_f32, 1.23456_f32);
-  |                                                             ^^^^^^^^^^^
-  |
-  = help: consider: 1.234_56_f32
+  |                                                             ^^^^^^^^^^^ help: consider: `1.234_56_f32`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This particularly helps IDEs as they'll be able to provide fix tips.
![suggest](https://user-images.githubusercontent.com/2331607/36852509-b4d4e5bc-1d63-11e8-8e89-397791190d7d.png)

Also added the following to a bunch of tests, presumably a new compiler message.
> If you want more information on this error, try using "rustc --explain E0658"

