### PR TITLE
Fix single_char_pattern for \n, \t, etc.

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -1763,7 +1763,11 @@ fn lint_single_char_pattern<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx hi
     }) = ConstContext::new(cx.tcx, cx.param_env.and(substs), cx.tables).eval(arg)
     {
         if r.len() == 1 {
-            let hint = snippet(cx, expr.span, "..").replace(&format!("\"{}\"", r), &format!("'{}'", r));
+            let c = r.chars().next().unwrap();
+            let snip = snippet(cx, expr.span, "..");
+            let hint = snip.replace(
+                &format!("\"{}\"", c.escape_default()),
+                &format!("'{}'", c.escape_default()));
             span_lint_and_then(
                 cx,
                 SINGLE_CHAR_PATTERN,

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -35,6 +35,8 @@ fn main() {
     x.rmatch_indices("x");
     x.trim_left_matches("x");
     x.trim_right_matches("x");
+    // Make sure we escape characters correctly.
+    x.split("\n");
 
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -102,5 +102,11 @@ error: single-character string constant used as pattern
 37 |     x.trim_right_matches("x");
    |     ---------------------^^^- help: try using a char instead: `x.trim_right_matches('x')`
 
-error: aborting due to 17 previous errors
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:39:13
+   |
+39 |     x.split("/n");
+   |     --------^^^^- help: try using a char instead: `x.split('/n')`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Single characters that are escaped weren't being searched / replaced
correctly in the hint string, so it was saying to replace, say,
`"\n"` with `"\n"` rather than `'\n'`.