### PR TITLE
Use compiletest version v0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ cargo_metadata = "0.2"
 regex = "0.2"
 
 [dev-dependencies]
-compiletest_rs = "0.3.6"
+compiletest_rs = "0.3.7"
 duct = "0.8.2"
 lazy_static = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
`cargo test` is currently not working due to a compile fail of compiltest-rs v0.3.6.

This is already fixed in version 0.3.7 of compiletest-rs. (See https://github.com/laumann/compiletest-rs/commit/5c48e0152093ed8b33cc84d0e79a53b9439fd34b). 