### PR TITLE
Don't lint range syntax with var name `start` and/or `end`

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -64,6 +64,16 @@ pub fn in_macro(span: Span) -> bool {
     })
 }
 
+/// Returns true if `expn_info` was expanded by range expressions.
+pub fn is_range_expression(span: Span) -> bool {
+    span.ctxt().outer().expn_info().map_or(false, |info| {
+        match info.callee.format {
+            ExpnFormat::CompilerDesugaring(CompilerDesugaringKind::DotFill) => true,
+            _ => false,
+        }
+    })
+}
+
 /// Returns true if the macro that expanded the crate was outside of the
 /// current crate or was a
 /// compiler plugin.

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -39,7 +39,7 @@ fn main() {
     let _ = ..=end;
     let _ = start..=end;
 
-    // TODO: the followings shoule be linted
+    // TODO: the following should be linted
     let _ = ::std::ops::RangeFrom { start: start };
     let _ = ::std::ops::RangeTo { end: end };
     let _ = ::std::ops::Range { start: start, end: end };

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -1,5 +1,6 @@
 #![warn(redundant_field_names)]
 #![allow(unused_variables)]
+#![feature(inclusive_range,inclusive_range_syntax)]
 
 mod foo {
     pub const BAR: u8 = 0;
@@ -27,4 +28,21 @@ fn main() {
         buzz: fizz, //should be ok
         foo: foo::BAR, //should be ok
     };
+
+    // Range syntax
+    let (start, end) = (0, 0);
+
+    let _ = start..;
+    let _ = ..end;
+    let _ = start..end;
+
+    let _ = ..=end;
+    let _ = start..=end;
+
+    // TODO: the followings shoule be linted
+    let _ = ::std::ops::RangeFrom { start: start };
+    let _ = ::std::ops::RangeTo { end: end };
+    let _ = ::std::ops::Range { start: start, end: end };
+    let _ = ::std::ops::RangeInclusive { start: start, end: end };
+    let _ = ::std::ops::RangeToInclusive { end: end };
 }

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -1,6 +1,8 @@
 #![warn(redundant_field_names)]
 #![allow(unused_variables)]
-#![feature(inclusive_range,inclusive_range_syntax)]
+#![feature(inclusive_range, inclusive_range_syntax)]
+
+use std::ops::{Range, RangeFrom, RangeTo, RangeInclusive, RangeToInclusive};
 
 mod foo {
     pub const BAR: u8 = 0;
@@ -29,7 +31,7 @@ fn main() {
         foo: foo::BAR, //should be ok
     };
 
-    // Range syntax
+    // Range expressions
     let (start, end) = (0, 0);
 
     let _ = start..;
@@ -39,10 +41,10 @@ fn main() {
     let _ = ..=end;
     let _ = start..=end;
 
-    // TODO: the following should be linted
-    let _ = ::std::ops::RangeFrom { start: start };
-    let _ = ::std::ops::RangeTo { end: end };
-    let _ = ::std::ops::Range { start: start, end: end };
-    let _ = ::std::ops::RangeInclusive { start: start, end: end };
-    let _ = ::std::ops::RangeToInclusive { end: end };
+    // hand-written Range family structs are linted
+    let _ = RangeFrom { start: start };
+    let _ = RangeTo { end: end };
+    let _ = Range { start: start, end: end };
+    let _ = RangeInclusive { start: start, end: end };
+    let _ = RangeToInclusive { end: end };
 }

--- a/tests/ui/redundant_field_names.stderr
+++ b/tests/ui/redundant_field_names.stderr
@@ -1,16 +1,58 @@
 error: redundant field names in struct initialization
-  --> $DIR/redundant_field_names.rs:24:9
+  --> $DIR/redundant_field_names.rs:26:9
    |
-24 |         gender: gender,
+26 |         gender: gender,
    |         ^^^^^^^^^^^^^^ help: replace it with: `gender`
    |
    = note: `-D redundant-field-names` implied by `-D warnings`
 
 error: redundant field names in struct initialization
-  --> $DIR/redundant_field_names.rs:25:9
+  --> $DIR/redundant_field_names.rs:27:9
    |
-25 |         age: age,
+27 |         age: age,
    |         ^^^^^^^^ help: replace it with: `age`
 
-error: aborting due to 2 previous errors
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:45:25
+   |
+45 |     let _ = RangeFrom { start: start };
+   |                         ^^^^^^^^^^^^ help: replace it with: `start`
+
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:46:23
+   |
+46 |     let _ = RangeTo { end: end };
+   |                       ^^^^^^^^ help: replace it with: `end`
+
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:47:21
+   |
+47 |     let _ = Range { start: start, end: end };
+   |                     ^^^^^^^^^^^^ help: replace it with: `start`
+
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:47:35
+   |
+47 |     let _ = Range { start: start, end: end };
+   |                                   ^^^^^^^^ help: replace it with: `end`
+
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:48:30
+   |
+48 |     let _ = RangeInclusive { start: start, end: end };
+   |                              ^^^^^^^^^^^^ help: replace it with: `start`
+
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:48:44
+   |
+48 |     let _ = RangeInclusive { start: start, end: end };
+   |                                            ^^^^^^^^ help: replace it with: `end`
+
+error: redundant field names in struct initialization
+  --> $DIR/redundant_field_names.rs:49:32
+   |
+49 |     let _ = RangeToInclusive { end: end };
+   |                                ^^^^^^^^ help: replace it with: `end`
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/redundant_field_names.stderr
+++ b/tests/ui/redundant_field_names.stderr
@@ -1,15 +1,15 @@
 error: redundant field names in struct initialization
-  --> $DIR/redundant_field_names.rs:23:9
+  --> $DIR/redundant_field_names.rs:24:9
    |
-23 |         gender: gender,
+24 |         gender: gender,
    |         ^^^^^^^^^^^^^^ help: replace it with: `gender`
    |
    = note: `-D redundant-field-names` implied by `-D warnings`
 
 error: redundant field names in struct initialization
-  --> $DIR/redundant_field_names.rs:24:9
+  --> $DIR/redundant_field_names.rs:25:9
    |
-24 |         age: age,
+25 |         age: age,
    |         ^^^^^^^^ help: replace it with: `age`
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
Fixes #2491.

But this PR introduces new false-negative:
does not lint hand-written `Range` struct family with var name `start` and/or `end`,
i.e. `std::ops::Range { start: start, end: end }`
But I guess it's rare to write them explicitly.