### PR TITLE
Remove unused variable and a minor refactoring

### DIFF
--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -36,7 +36,7 @@ impl LintPass for RedundantFieldNames {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantFieldNames {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
-        if let ExprStruct(ref path, ref fields, _) = expr.node {
+        if let ExprStruct(_, ref fields, _) = expr.node {
             for field in fields {
                 let name = field.name.node;
 


### PR DESCRIPTION
Sorry. I have left an unused variable in #2507.
e13dcd2 removes it.

8e40676 is a minor refactoring.
It moves `is_range_expression()` call outside of blocks.