### PR TITLE
Miri branch: update to latest rust

### DIFF
--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -51,7 +51,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnportableVariant {
             for var in &def.variants {
                 let variant = &var.node;
                 if let Some(body_id) = variant.disr_expr {
-                    let param_env = ty::ParamEnv::empty(traits::Reveal::UserFacing);
+                    let param_env = ty::ParamEnv::empty();
                     let did = cx.tcx.hir.body_owner_def_id(body_id);
                     let substs = Substs::identity_for_item(cx.tcx.global_tcx(), did);
                     let instance = ty::Instance::new(did, substs);

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -205,7 +205,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                     let sugg = |db: &mut DiagnosticBuilder| {
                         if let ty::TypeVariants::TyAdt(ref def, ..) = ty.sty {
                             if let Some(span) = cx.tcx.hir.span_if_local(def.did) {
-                                let param_env = ty::ParamEnv::empty(traits::Reveal::UserFacing);
+                                let param_env = ty::ParamEnv::empty();
                                 if param_env.can_type_implement_copy(cx.tcx, ty, span).is_ok() {
                                     db.span_help(span, "consider marking this type as Copy");
                                 }

--- a/tests/ui/builtin-type-shadow.stderr
+++ b/tests/ui/builtin-type-shadow.stderr
@@ -19,4 +19,4 @@ error[E0308]: mismatched types
 
 error: aborting due to 2 previous errors
 
-If you want more information on this error, try using "rustc --explain E0308"
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/conf_bad_arg.stderr
+++ b/tests/ui/conf_bad_arg.stderr
@@ -8,4 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0658"
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/conf_bad_toml.stderr
+++ b/tests/ui/conf_bad_toml.stderr
@@ -8,4 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0658"
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/conf_bad_type.stderr
+++ b/tests/ui/conf_bad_type.stderr
@@ -8,4 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0658"
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/conf_french_blacklisted_name.stderr
+++ b/tests/ui/conf_french_blacklisted_name.stderr
@@ -8,4 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0658"
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/conf_path_non_string.stderr
+++ b/tests/ui/conf_path_non_string.stderr
@@ -8,4 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0658"
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/conf_unknown_key.stderr
+++ b/tests/ui/conf_unknown_key.stderr
@@ -8,4 +8,4 @@ error[E0658]: compiler plugins are experimental and possibly buggy (see issue #2
 
 error: aborting due to previous error
 
-If you want more information on this error, try using "rustc --explain E0658"
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
All tests passed locally.

`Reveal::all` is now [default behaviour](https://github.com/rust-lang/rust/commit/6d0f9319dfd4a115f64fd5e00be3749da5eda8bc).