### PR TITLE
Add suggestion to useless_format

### DIFF
--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -2,7 +2,7 @@ error: useless use of `format!`
  --> $DIR/format.rs:6:5
   |
 6 |     format!("foo");
-  |     ^^^^^^^^^^^^^^^
+  |     ^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string()`
   |
   = note: `-D useless-format` implied by `-D warnings`
 


### PR DESCRIPTION
Resolves #2505

Suggests that you use `"foo".to_string()` instead of `format!("foo")`.

I am not sure if this is the right place, but I happened to notice that the `format!("{}", foo)` case doesn't actually seem to get tested for.