### PR TITLE
Check if the panic message was created by the assert-macro

### DIFF
--- a/clippy_lints/src/panic.rs
+++ b/clippy_lints/src/panic.rs
@@ -48,6 +48,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let Some(par) = string.as_str().find('{');
             if string.as_str()[par..].contains('}');
             if params[0].span.source_callee().is_none();
+            if params[0].span.lo() != params[0].span.hi();
             then {
                 span_lint(cx, PANIC_PARAMS, params[0].span,
                           "you probably are missing some parameter in your format string");


### PR DESCRIPTION
Fixes #2541 

This was caused, because the `assert!`-macro without an additional message got expanded to `panic!("assertion failed: $cond")`. If `$cond` contained `{...}` the lint would trigger, but the span of `params[0]` was empty. 

