### PR TITLE
Don't lint comparison operators in arithmetic impls

### DIFF
--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -61,6 +61,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for SuspiciousImpl {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {
         use rustc::hir::BinOp_::*;
         if let hir::ExprBinary(binop, _, _) = expr.node {
+            match binop.node {
+                BiEq | BiLt | BiLe | BiNe | BiGe | BiGt => return,
+                _ => {},
+            }
             // Check if the binary expression is part of another bi/unary expression
             // as a child node
             let mut parent_expr = cx.tcx.hir.get_parent_node(expr.id);

--- a/tests/ui/suspicious_arithmetic_impl.rs
+++ b/tests/ui/suspicious_arithmetic_impl.rs
@@ -59,7 +59,11 @@ impl Sub for Bar {
     type Output = Bar;
 
     fn sub(self, other: Self) -> Self {
-        Bar(-(self.0 & other.0)) // OK: UnNeg part of BiExpr as parent node
+        if self.0 <= other.0 {
+            Bar(-(self.0 & other.0)) // OK: UnNeg part of BiExpr as parent node
+        } else {
+            Bar(0)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2535 

Comparison operators in arithmetic implementations are probably always intended, so don't lint them.