### PR TITLE
Switch over to clap for arg parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ path = "src/driver.rs"
 clippy_lints = { version = "0.0.189", path = "clippy_lints" }
 # end automatic update
 cargo_metadata = "0.5"
+clap = "2.31"
 regex = "0.2"
 semver = "0.9"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use clap::{App, AppSettings, Arg};
 
 pub fn main() {
     let matches = App::new("Clippy")
+        .bin_name("cargo clippy")
         .about("Checks a package to catch common mistakes and improve your Rust code.")
         .version(env!("CARGO_PKG_VERSION"))
         .setting(AppSettings::TrailingVarArg)


### PR DESCRIPTION
It saves us from having to parse std::env::args manually, though at the
cost of mandating that --all/--manifest-path come before any other
arguments. Will make adding additional clippy-specific args easier - see #2518 

With this PR, the help message will now be:

```
$ cargo +nightly run --bin cargo-clippy -- -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/cargo-clippy -h`
cargo-clippy 0.0.189
Checks a package to catch common mistakes and improve your Rust code.

USAGE:
    cargo clippy [OPTIONS] [CMD]...

OPTIONS:
        --all                     Run over all packages in the current workspace
    -h, --help                    Prints help information
        --manifest-path <PATH>    Path to the manifest to check
    -V, --version                 Prints version information

ARGS:
    <CMD>...    Commands to pass through to cargo rustc

Other options are the same as `cargo rustc`.

To allow or deny a lint from the command line you can use `cargo clippy --`
with:

    -W --warn OPT       Set lint warnings
    -A --allow OPT      Set lint allowed
    -D --deny OPT       Set lint denied
    -F --forbid OPT     Set lint forbidden

The feature `cargo-clippy` is automatically defined for convenience. You can use
it to allow or deny lints from the code, eg.:

    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
```

I've manually tested that the four specific options get recognised correctly, and that the additional args get passed through to `cargo rustc`.

However, we can no longer provide flags that clippy knows nothing about directly - `cargo clippy --frozen` would now need to be supplied as `cargo clippy -- --frozen`. This seems to be a limitation of clap, though I don't know if it's going to be deal-breaking for this PR.