### PR TITLE
Minor refactoring (walk_ptrs_ty_depth)

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -1034,7 +1034,7 @@ fn lint_clone_on_copy(cx: &LateContext, expr: &hir::Expr, arg: &hir::Expr, arg_t
 }
 
 fn lint_clone_on_ref_ptr(cx: &LateContext, expr: &hir::Expr, arg: &hir::Expr) {
-    let (obj_ty, _) = walk_ptrs_ty_depth(cx.tables.expr_ty(arg));
+    let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(arg));
 
     if let ty::TyAdt(_, subst) = obj_ty.sty {
         let caller_type = if match_type(cx, obj_ty, &paths::RC) {
@@ -1063,7 +1063,7 @@ fn lint_string_extend(cx: &LateContext, expr: &hir::Expr, args: &[hir::Expr]) {
     let arg = &args[1];
     if let Some(arglists) = method_chain_args(arg, &["chars"]) {
         let target = &arglists[0][0];
-        let (self_ty, _) = walk_ptrs_ty_depth(cx.tables.expr_ty(target));
+        let self_ty = walk_ptrs_ty(cx.tables.expr_ty(target));
         let ref_str = if self_ty.sty == ty::TyStr {
             ""
         } else if match_type(cx, self_ty, &paths::STRING) {
@@ -1089,7 +1089,7 @@ fn lint_string_extend(cx: &LateContext, expr: &hir::Expr, args: &[hir::Expr]) {
 }
 
 fn lint_extend(cx: &LateContext, expr: &hir::Expr, args: &[hir::Expr]) {
-    let (obj_ty, _) = walk_ptrs_ty_depth(cx.tables.expr_ty(&args[0]));
+    let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(&args[0]));
     if match_type(cx, obj_ty, &paths::STRING) {
         lint_string_extend(cx, expr, args);
     }
@@ -1327,7 +1327,7 @@ fn derefs_to_slice(cx: &LateContext, expr: &hir::Expr, ty: Ty) -> Option<sugg::S
 
 /// lint use of `unwrap()` for `Option`s and `Result`s
 fn lint_unwrap(cx: &LateContext, expr: &hir::Expr, unwrap_args: &[hir::Expr]) {
-    let (obj_ty, _) = walk_ptrs_ty_depth(cx.tables.expr_ty(&unwrap_args[0]));
+    let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(&unwrap_args[0]));
 
     let mess = if match_type(cx, obj_ty, &paths::OPTION) {
         Some((OPTION_UNWRAP_USED, "an Option", "None"))

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -2,7 +2,7 @@ use rustc::hir::{Expr, ExprLit, ExprMethodCall};
 use rustc::lint::*;
 use syntax::ast::LitKind;
 use syntax::codemap::{Span, Spanned};
-use utils::{match_type, paths, span_lint, walk_ptrs_ty_depth};
+use utils::{match_type, paths, span_lint, walk_ptrs_ty};
 
 /// **What it does:** Checks for duplicate open options as well as combinations
 /// that make no sense.
@@ -22,7 +22,6 @@ declare_lint! {
     "nonsensical combination of options for opening a file"
 }
 
-
 #[derive(Copy, Clone)]
 pub struct NonSensical;
 
@@ -35,7 +34,7 @@ impl LintPass for NonSensical {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonSensical {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprMethodCall(ref path, _, ref arguments) = e.node {
-            let (obj_ty, _) = walk_ptrs_ty_depth(cx.tables.expr_ty(&arguments[0]));
+            let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(&arguments[0]));
             if path.name == "open" && match_type(cx, obj_ty, &paths::OPEN_OPTIONS) {
                 let mut options = Vec::new();
                 get_open_options(cx, &arguments[0], &mut options);
@@ -63,7 +62,7 @@ enum OpenOption {
 
 fn get_open_options(cx: &LateContext, argument: &Expr, options: &mut Vec<(OpenOption, Argument)>) {
     if let ExprMethodCall(ref path, _, ref arguments) = argument.node {
-        let (obj_ty, _) = walk_ptrs_ty_depth(cx.tables.expr_ty(&arguments[0]));
+        let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(&arguments[0]));
 
         // Only proceed if this is a call on some object of type std::fs::OpenOptions
         if match_type(cx, obj_ty, &paths::OPEN_OPTIONS) && arguments.len() >= 2 {


### PR DESCRIPTION
Replace `walk_ptrs_ty_depth` with `walk_ptrs_ty` when the depth value is
ignored.