### PR TITLE
Update configuration for leading dot filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ if let Some(y) = x { println!("{:?}", y) }
 
 ## Configuration
 
-Some lints can be configured in a `clippy.toml` file. It contains basic `variable = value` mapping eg.
+Some lints can be configured in a TOML file named with `clippy.toml` or `.clippy.toml`. It contains basic `variable = value` mapping eg.
 
 ```toml
 blacklisted-names = ["toto", "tata", "titi"]


### PR DESCRIPTION
Fix #2563 

As @pravic mentioned in #2563, `clippy` has supported leading dot filename format in

https://github.com/rust-lang-nursery/rust-clippy/blob/b835877d2ecba1b91ac74fee5b042ac0673aff14/clippy_lints/src/utils/conf.rs#L184-L187

So, just need to update the README in this PR.