### PR TITLE
Fix check of immutable condition in closure

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -2150,8 +2150,20 @@ fn check_infinite_loop<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, cond: &'tcx Expr, b
         return;
     }
 
+    if mut_var_visitor.ids.is_empty() {
+        span_lint(
+            cx,
+            WHILE_IMMUTABLE_CONDITION,
+            cond.span,
+            "all variables in condition are immutable. This either leads to an infinite or to a never running loop.",
+        );
+        return;
+    }
+
+
     let mut delegate = MutVarsDelegate {
         used_mutably: mut_var_visitor.ids,
+        skip: false,
     };
     let def_id = def_id::DefId::local(block.hir_id.owner);
     let region_scope_tree = &cx.tcx.region_scope_tree(def_id);
@@ -2194,7 +2206,10 @@ impl<'a, 'tcx> VarCollectorVisitor<'a, 'tcx> {
 impl<'a, 'tcx> Visitor<'tcx> for VarCollectorVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, ex: &'tcx Expr) {
         match ex.node {
-            ExprPath(_) => self.insert_def_id(ex),
+            ExprPath(_) => if let Some(node_id) = check_for_mutability(self.cx, ex) {
+                self.ids.insert(node_id, false);
+            },
+
             // If there is any fuction/method call… we just stop analysis
             ExprCall(..) | ExprMethodCall(..) => self.skip = true,
 
@@ -2211,6 +2226,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarCollectorVisitor<'a, 'tcx> {
 
 struct MutVarsDelegate {
     used_mutably: HashMap<NodeId, bool>,
+    skip: bool,
 }
 
 impl<'tcx> MutVarsDelegate {
@@ -2220,6 +2236,7 @@ impl<'tcx> MutVarsDelegate {
                 if let Some(used) = self.used_mutably.get_mut(&id) {
                     *used = true;
                 },
+            Categorization::Upvar(_) => skip = true,
             Categorization::Deref(ref cmt, _) => self.update(&cmt.cat, sp),
             _ => {}
         }

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -1,9 +1,13 @@
+
+
+
 fn fn_val(i: i32) -> i32 { unimplemented!() }
 fn fn_constref(i: &i32) -> i32 { unimplemented!() }
 fn fn_mutref(i: &mut i32) { unimplemented!() }
 fn fooi() -> i32 { unimplemented!() }
 fn foob() -> bool { unimplemented!() }
 
+#[allow(many_single_char_names)]
 fn immutable_condition() {
     // Should warn when all vars mentionned are immutable
     let y = 0;
@@ -43,6 +47,14 @@ fn immutable_condition() {
         println!("OK - Fn call results may vary");
     }
 
+    let mut a = 0;
+    let mut c = move || {
+        while a < 5 {
+            a += 1;
+            println!("OK - a is mutable");
+        }
+    };
+    c();
 }
 
 fn unused_var() {

--- a/tests/ui/infinite_loop.stderr
+++ b/tests/ui/infinite_loop.stderr
@@ -1,57 +1,57 @@
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:10:11
+  --> $DIR/infinite_loop.rs:14:11
    |
-10 |     while y < 10 {
+14 |     while y < 10 {
    |           ^^^^^^
    |
    = note: `-D while-immutable-condition` implied by `-D warnings`
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:15:11
+  --> $DIR/infinite_loop.rs:19:11
    |
-15 |     while y < 10 && x < 3 {
+19 |     while y < 10 && x < 3 {
    |           ^^^^^^^^^^^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:22:11
+  --> $DIR/infinite_loop.rs:26:11
    |
-22 |     while !cond {
+26 |     while !cond {
    |           ^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:52:11
+  --> $DIR/infinite_loop.rs:64:11
    |
-52 |     while i < 3 {
+64 |     while i < 3 {
    |           ^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:57:11
+  --> $DIR/infinite_loop.rs:69:11
    |
-57 |     while i < 3 && j > 0 {
+69 |     while i < 3 && j > 0 {
    |           ^^^^^^^^^^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:61:11
+  --> $DIR/infinite_loop.rs:73:11
    |
-61 |     while i < 3 {
+73 |     while i < 3 {
    |           ^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:76:11
+  --> $DIR/infinite_loop.rs:88:11
    |
-76 |     while i < 3 {
+88 |     while i < 3 {
    |           ^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-  --> $DIR/infinite_loop.rs:81:11
+  --> $DIR/infinite_loop.rs:93:11
    |
-81 |     while i < 3 {
+93 |     while i < 3 {
    |           ^^^^^
 
 error: Variable in the condition are not mutated in the loop body. This either leads to an infinite or to a never running loop.
-   --> $DIR/infinite_loop.rs:144:15
+   --> $DIR/infinite_loop.rs:156:15
     |
-144 |         while self.count < n {
+156 |         while self.count < n {
     |               ^^^^^^^^^^^^^^
 
 error: aborting due to 9 previous errors


### PR DESCRIPTION
(Fixes #2562)

This fixes the check for an immutable condition in a closure, which was easily done, by adding a check for an `Upvar`.

The problem I'm now facing is, that it still does not detect if the variable in the condition is mutated in the body. I don't know if this can be fixed, without rewriting the check for that.

Currently we check if some variable in the condition gets mutated, by comparing the `NodeId`s. This is (I think) not really possible for the closure case:
While we get the `NodeId` from `Def::Upvar(NodeId, usize, NodeId)` ([Documentation](https://manishearth.github.io/rust-internals-docs/rustc/hir/def/enum.Def.html#variant.Upvar)), the `Categorization::Upvar(mem_categorization::Upvar)` ([Documentation](https://manishearth.github.io/rust-internals-docs/rustc/middle/mem_categorization/enum.Categorization.html#variant.Upvar)) only gives us the `HirId`.

I'm out of ideas how to do this nicely, without rewriting the check.
Any thoughts or hints on this @oli-obk?