### PR TITLE
Fix false positive in empty_line_after_outer_attribute

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -267,7 +267,7 @@ fn check_attrs(cx: &LateContext, span: Span, name: &Name, attrs: &[Attribute]) {
             return;
         }
         if attr.style == AttrStyle::Outer {
-            if !is_present_in_source(cx, attr.span) {
+            if attr.tokens.is_empty() || !is_present_in_source(cx, attr.span) {
                 return;
             }
 

--- a/tests/ui/empty_line_after_outer_attribute.rs
+++ b/tests/ui/empty_line_after_outer_attribute.rs
@@ -67,4 +67,16 @@ pub fn function() -> bool {
     true
 }
 
+// This should not produce a warning
+#[derive(Clone, Copy)]
+pub enum FooFighter {
+    Bar1,
+
+    Bar2,
+
+    Bar3,
+
+    Bar4
+}
+
 fn main() { }


### PR DESCRIPTION
`empty_line_after_outer_attribute` produced a false positive warning when
deriving `Copy` and/or `Clone` for an item.

It looks like the second point in [this comment][that_comment] is related,
as the attribute that causes the false positive has a path of
`rustc_copy_clone_marker`.

Checking for an empty `TokenStream` on the attribute gets around these attributes.

Fixes #2475, #2517

[that_comment]: https://github.com/rust-lang/rust/issues/35900#issuecomment-245978831