### PR TITLE
Fix enum_glob_use false positives

### DIFF
--- a/tests/ui/enum_glob_use.rs
+++ b/tests/ui/enum_glob_use.rs
@@ -23,4 +23,10 @@ mod tests {
     use super::*;
 }
 
+#[allow(non_snake_case)]
+mod CamelCaseName {
+}
+
+use CamelCaseName::*;
+
 fn main() {}


### PR DESCRIPTION
Closes #2397.

This checks the def of the `ItemUse` path instead of checking the
capitalization of the path segements. It was noted that this def would
sometimes be `Def::Mod` instead of `Def::Enum` but it seems correct now.