### PR TITLE
Use cargo check instead of cargo rustc

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -186,10 +186,13 @@ pub fn main() {
     let clippy_enabled = env::var("CLIPPY_TESTS")
         .ok()
         .map_or(false, |val| val == "true")
-        || orig_args.iter().any(|s| s == "--emit=metadata");
+        || orig_args.iter().any(|s| s == "--emit=dep-info,metadata");
 
     if clippy_enabled {
         args.extend_from_slice(&["--cfg".to_owned(), r#"feature="cargo-clippy""#.to_owned()]);
+        if let Ok(extra_args) = env::var("CLIPPY_ARGS") {
+            args.extend(extra_args.split("__CLIPPY_HACKERY__").filter(|s| !s.is_empty()).map(str::to_owned));
+        }
     }
 
     let mut ccc = ClippyCompilerCalls::new(clippy_enabled);


### PR DESCRIPTION
fixes #2580 (since we're not running trans anymore)
fixes #2218 (running `cargo clippy` twice does not produce any warnings)
fixes #1495 (same as #2218)