### PR TITLE
Use cargo check's manifest handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ path = "src/driver.rs"
 # begin automatic update
 clippy_lints = { version = "0.0.190", path = "clippy_lints" }
 # end automatic update
-cargo_metadata = "0.5"
 regex = "0.2"
 semver = "0.9"
 
 [dev-dependencies]
+cargo_metadata = "0.5"
 compiletest_rs = "0.3.7"
 lazy_static = "1.0"
 serde_derive = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,6 @@
 #![feature(rustc_private)]
 #![allow(unknown_lints, missing_docs_in_private_items)]
 
-use std::collections::HashMap;
-use std::process;
-use std::io::{self, Write};
-
-extern crate cargo_metadata;
-
-use std::path::{Path, PathBuf};
-
 const CARGO_CLIPPY_HELP: &str = r#"Checks a package to catch common mistakes and improve your Rust code.
 
 Usage:
@@ -18,11 +10,9 @@ Usage:
 
 Common options:
     -h, --help               Print this message
-    --features               Features to compile for the package
     -V, --version            Print version info and exit
-    --all                    Run over all packages in the current workspace
 
-Other options are the same as `cargo rustc`.
+Other options are the same as `cargo check`.
 
 To allow or deny a lint from the command line you can use `cargo clippy --`
 with:
@@ -59,119 +49,8 @@ pub fn main() {
         return;
     }
 
-    let mut manifest_path_arg = std::env::args()
-        .skip(2)
-        .skip_while(|val| !val.starts_with("--manifest-path"));
-    let manifest_path_arg = manifest_path_arg.next().and_then(|val| {
-        if val == "--manifest-path" {
-            manifest_path_arg.next()
-        } else if val.starts_with("--manifest-path=") {
-            Some(val["--manifest-path=".len()..].to_owned())
-        } else {
-            None
-        }
-    });
-
-    let mut metadata = if let Ok(metadata) = cargo_metadata::metadata(manifest_path_arg.as_ref().map(AsRef::as_ref)) {
-        metadata
-    } else {
-        println!(
-            "{:?}",
-            cargo_metadata::metadata(manifest_path_arg.as_ref().map(AsRef::as_ref))
-        );
-        let _ = io::stderr().write_fmt(format_args!("error: Could not obtain cargo metadata.\n"));
-        process::exit(101);
-    };
-
-    let manifest_path = manifest_path_arg.map(|arg| {
-        PathBuf::from(arg)
-            .canonicalize()
-            .expect("manifest path could not be canonicalized")
-    });
-
-    let packages = if std::env::args().any(|a| a == "--all") {
-        metadata.packages
-    } else {
-        let package_index = {
-            if let Some(manifest_path) = manifest_path {
-                metadata.packages.iter().position(|package| {
-                    let package_manifest_path = Path::new(&package.manifest_path)
-                        .canonicalize()
-                        .expect("package manifest path could not be canonicalized");
-                    package_manifest_path == manifest_path
-                })
-            } else {
-                let package_manifest_paths: HashMap<_, _> = metadata
-                    .packages
-                    .iter()
-                    .enumerate()
-                    .map(|(i, package)| {
-                        let package_manifest_path = Path::new(&package.manifest_path)
-                            .parent()
-                            .expect("could not find parent directory of package manifest")
-                            .canonicalize()
-                            .expect("package directory cannot be canonicalized");
-                        (package_manifest_path, i)
-                    })
-                    .collect();
-
-                let current_dir = std::env::current_dir()
-                    .expect("CARGO_MANIFEST_DIR not set")
-                    .canonicalize()
-                    .expect("manifest directory cannot be canonicalized");
-
-                let mut current_path: &Path = &current_dir;
-
-                // This gets the most-recent parent (the one that takes the fewest `cd ..`s to
-                // reach).
-                loop {
-                    if let Some(&package_index) = package_manifest_paths.get(current_path) {
-                        break Some(package_index);
-                    } else {
-                        // We'll never reach the filesystem root, because to get to this point in the
-                        // code
-                        // the call to `cargo_metadata::metadata` must have succeeded. So it's okay to
-                        // unwrap the current path's parent.
-                        current_path = current_path
-                            .parent()
-                            .unwrap_or_else(|| panic!("could not find parent of path {}", current_path.display()));
-                    }
-                }
-            }
-        }.expect("could not find matching package");
-
-        vec![metadata.packages.remove(package_index)]
-    };
-
-    for package in packages {
-        let manifest_path = package.manifest_path;
-
-        for target in package.targets {
-            let args = std::env::args()
-                .skip(2)
-                .filter(|a| a != "--all" && !a.starts_with("--manifest-path="));
-
-            let args = std::iter::once(format!("--manifest-path={}", manifest_path)).chain(args);
-            if let Some(first) = target.kind.get(0) {
-                if target.kind.len() > 1 || first.ends_with("lib") {
-                    println!("lib: {}", target.name);
-                    if let Err(code) = process(std::iter::once("--lib".to_owned()).chain(args)) {
-                        std::process::exit(code);
-                    }
-                } else if ["bin", "example", "test", "bench"].contains(&&**first) {
-                    println!("{}: {}", first, target.name);
-                    if let Err(code) = process(
-                        vec![format!("--{}", first), target.name]
-                            .into_iter()
-                            .chain(args),
-                    ) {
-                        std::process::exit(code);
-                    }
-                }
-            } else {
-                panic!("badly formatted cargo metadata: target::kind is an empty array");
-            }
-        }
+    if let Err(code) = process(std::env::args().skip(2)) {
+        std::process::exit(code);
     }
 }
 


### PR DESCRIPTION
Now that we're using cargo check (#2582), we can stop needing to find out the manifest path ourselves. Instead, we can delegate to cargo check, which is perfectly capable of working out for itself what needs to be built.

Fixes #1707 (parallel building) 
Fixes #2518 (`-p` option)

Note that this PR will change the output. We will no longer output `bin: foo` before each crate. This a bit unfortunate. However, given that we're now going to be building in parallel (which is *much* faster), I think this is acceptable - we'll be no worse than cargo itself.