### PR TITLE
Make dogfood test output to seperate directory

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -680,9 +680,7 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    #[allow(unused_attributes)]
-    // ^ required because `cyclomatic_complexity` attribute shows up as unused
-    #[cyclomatic_complexity = "30"]
+    #[allow(cyclomatic_complexity)]
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {
         if in_macro(expr.span) {
             return;

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -887,6 +887,7 @@ fn lint_or_fun_call(cx: &LateContext, expr: &hir::Expr, method_span: Span, name:
     }
 
     /// Check for `*or(foo())`.
+    #[allow(too_many_arguments)]
     fn check_general_case(
         cx: &LateContext,
         name: &str,

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -316,6 +316,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
         b.rules.hash(&mut self.s);
     }
 
+    #[allow(many_single_char_names)]
     pub fn hash_expr(&mut self, e: &Expr) {
         if let Some(e) = constant_simple(self.cx, e) {
             return e.hash(&mut self.s);

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -1103,7 +1103,7 @@ pub fn without_block_comments(lines: Vec<&str>) -> Vec<&str> {
 
     let mut nest_level = 0;
 
-    for line in lines.into_iter() {
+    for line in lines {
         if line.contains("/*") {
             nest_level += 1;
             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ where
     }
 
     let mut extra_envs = vec![];
-    if let Ok(_) = std::env::var("CLIPPY_DOGFOOD") {
+    if std::env::var("CLIPPY_DOGFOOD").is_ok() {
         let target_dir = std::env::var("CARGO_MANIFEST_DIR")
             .map(|m| {
                 std::path::PathBuf::from(m)
@@ -88,7 +88,7 @@ where
                     .to_string_lossy()
                     .into_owned()
             })
-            .unwrap_or("clippy_dogfood".to_string());
+            .unwrap_or_else(|_| "clippy_dogfood".to_string());
 
         extra_envs.push(("CARGO_TARGET_DIR", target_dir));
     };

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -15,6 +15,7 @@ fn dogfood() {
             .arg("cargo-clippy")
             .arg("--manifest-path")
             .arg(root_dir.join("Cargo.toml"))
+            .env("CLIPPY_DOGFOOD", "true")
             .output()
             .unwrap();
         println!("status: {}", output.status);


### PR DESCRIPTION
This commit makes `cargo clippy` output the build artifacts to a
separate directory if the `CLIPPY_DOGFOOD` env var is set. This should
prevent dogfood builds from interfering with regular builds.

This should help with issue #2595.