### PR TITLE
Re-enable dogfood test on Windows

### DIFF
--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -3,9 +3,6 @@ fn dogfood() {
     if option_env!("RUSTC_TEST_SUITE").is_some() {
         return;
     }
-    if cfg!(windows) {
-        return;
-    }
     let root_dir = std::env::current_dir().unwrap();
     for d in &[".", "clippy_lints"] {
         std::env::set_current_dir(root_dir.join(d)).unwrap();


### PR DESCRIPTION
This should work now that dogfood uses a separate output directory.