### PR TITLE
Move `set -e` to before the deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ script:
 after_success: |
   #!/bin/bash
   if [ $(uname) == Linux ]; then
-    ./.github/deploy.sh
-  # trigger rebuild of the clippy-service, to keep it up to date with clippy itself
     set -e
+    ./.github/deploy.sh
+    # trigger rebuild of the clippy-service, to keep it up to date with clippy itself
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&
        [ "$TRAVIS_REPO_SLUG" == "Manishearth/rust-clippy" ] &&
        [ "$TRAVIS_BRANCH" == "master" ] &&


### PR DESCRIPTION
I _think_ this might be why the deploy script crashing isn't causing the release to fail (see #2600). Not sure if there's an easy way to make a test-release to test that. In any case, the most recent build of 191 https://travis-ci.org/rust-lang-nursery/rust-clippy/builds/360193356 had this problem.