### PR TITLE
Move ref cow tests

### DIFF
--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -51,12 +51,3 @@ fn issue_1432() {
 
     let _ = v.iter().filter(|&a| a.is_empty());
 }
-
-#[allow(dead_code)]
-fn test_cow_with_ref(c: &Cow<[i32]>) {
-}
-
-#[allow(dead_code)]
-fn test_cow(c: Cow<[i32]>) {
-    let _c = c;
-}

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -38,13 +38,5 @@ error: this pattern creates a reference to a reference
 50 |     let _ = v.iter().filter(|&ref a| a.is_empty());
    |                               ^^^^^ help: change this to: `a`
 
-error: using a reference to `Cow` is not recommended.
-  --> $DIR/needless_borrow.rs:56:25
-   |
-56 | fn test_cow_with_ref(c: &Cow<[i32]>) {
-   |                         ^^^^^^^^^^^ help: change this to: `&[i32]`
-   |
-   = note: `-D ptr-arg` implied by `-D warnings`
-
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -1,7 +1,7 @@
-
-
 #![allow(unused, many_single_char_names)]
 #![warn(ptr_arg)]
+
+use std::borrow::Cow;
 
 fn do_vec(x: &Vec<i64>) {
     //Nothing here
@@ -67,3 +67,11 @@ fn false_positive_capacity_too(x: &String) -> String {
     x.clone()
 }
 
+#[allow(dead_code)]
+fn test_cow_with_ref(c: &Cow<[i32]>) {
+}
+
+#[allow(dead_code)]
+fn test_cow(c: Cow<[i32]>) {
+    let _c = c;
+}

--- a/tests/ui/ptr_arg.stderr
+++ b/tests/ui/ptr_arg.stderr
@@ -76,5 +76,11 @@ help: change `y.as_str()` to
 62 |     let c = y;
    |             ^
 
-error: aborting due to 6 previous errors
+error: using a reference to `Cow` is not recommended.
+  --> $DIR/ptr_arg.rs:71:25
+   |
+71 | fn test_cow_with_ref(c: &Cow<[i32]>) {
+   |                         ^^^^^^^^^^^ help: change this to: `&[i32]`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This commit moves the ref cow tests from needless_borrow.rs to ptr_arg.rs
where all the other PTR_ARG tests are.