### PR TITLE
Split up some single_match UI tests

### DIFF
--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -6,11 +6,6 @@
 #![allow(unused, if_let_redundant_pattern_matching)]
 #![warn(single_match_else, match_same_arms)]
 
-use std::borrow::Cow;
-
-enum Foo { Bar, Baz(u8) }
-use Foo::*;
-
 enum ExprNode {
     ExprAddrOf,
     Butterflies,
@@ -26,67 +21,6 @@ fn unwrap_addr() -> Option<&'static ExprNode> {
     match ExprNode::Butterflies {
         ExprNode::ExprAddrOf => Some(&NODE),
         _ => { let x = 5; None },
-    }
-}
-
-fn single_match(){
-    let x = Some(1u8);
-
-    match x {
-        Some(y) => { println!("{:?}", y); }
-        _ => ()
-    };
-
-    let z = (1u8,1u8);
-    match z {
-        (2...3, 7...9) => dummy(),
-        _ => {}
-    };
-
-    // Not linted (pattern guards used)
-    match x {
-        Some(y) if y == 0 => println!("{:?}", y),
-        _ => ()
-    }
-
-    // Not linted (no block with statements in the single arm)
-    match z {
-        (2...3, 7...9) => println!("{:?}", z),
-        _ => println!("nope"),
-    }
-}
-
-fn single_match_know_enum() {
-    let x = Some(1u8);
-    let y : Result<_, i8> = Ok(1i8);
-
-    match x {
-        Some(y) => dummy(),
-        None => ()
-    };
-
-    match y {
-        Ok(y) => dummy(),
-        Err(..) => ()
-    };
-
-    let c = Cow::Borrowed("");
-
-    match c {
-        Cow::Borrowed(..) => dummy(),
-        Cow::Owned(..) => (),
-    };
-
-    let z = Foo::Bar;
-    // no warning
-    match z {
-        Bar => println!("42"),
-        Baz(_) => (),
-    }
-
-    match z {
-        Baz(_) => println!("42"),
-        Bar => (),
     }
 }
 

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -1,473 +1,426 @@
 error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/matches.rs:26:5
+  --> $DIR/matches.rs:21:5
    |
-26 | /     match ExprNode::Butterflies {
-27 | |         ExprNode::ExprAddrOf => Some(&NODE),
-28 | |         _ => { let x = 5; None },
-29 | |     }
+21 | /     match ExprNode::Butterflies {
+22 | |         ExprNode::ExprAddrOf => Some(&NODE),
+23 | |         _ => { let x = 5; None },
+24 | |     }
    | |_____^ help: try this: `if let ExprNode::ExprAddrOf = ExprNode::Butterflies { Some(&NODE) } else { let x = 5; None }`
    |
    = note: `-D single-match-else` implied by `-D warnings`
 
-error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/matches.rs:35:5
-   |
-35 | /     match x {
-36 | |         Some(y) => { println!("{:?}", y); }
-37 | |         _ => ()
-38 | |     };
-   | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y); }`
-   |
-   = note: `-D single-match` implied by `-D warnings`
-
-error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/matches.rs:41:5
-   |
-41 | /     match z {
-42 | |         (2...3, 7...9) => dummy(),
-43 | |         _ => {}
-44 | |     };
-   | |_____^ help: try this: `if let (2...3, 7...9) = z { dummy() }`
-
-error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/matches.rs:63:5
-   |
-63 | /     match x {
-64 | |         Some(y) => dummy(),
-65 | |         None => ()
-66 | |     };
-   | |_____^ help: try this: `if let Some(y) = x { dummy() }`
-
-error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/matches.rs:68:5
-   |
-68 | /     match y {
-69 | |         Ok(y) => dummy(),
-70 | |         Err(..) => ()
-71 | |     };
-   | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
-
-error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/matches.rs:75:5
-   |
-75 | /     match c {
-76 | |         Cow::Borrowed(..) => dummy(),
-77 | |         Cow::Owned(..) => (),
-78 | |     };
-   | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
-
 error: this boolean expression can be simplified
-   --> $DIR/matches.rs:117:11
-    |
-117 |     match test && test {
-    |           ^^^^^^^^^^^^ help: try: `test`
-    |
-    = note: `-D nonminimal-bool` implied by `-D warnings`
+  --> $DIR/matches.rs:51:11
+   |
+51 |     match test && test {
+   |           ^^^^^^^^^^^^ help: try: `test`
+   |
+   = note: `-D nonminimal-bool` implied by `-D warnings`
 
 error: you seem to be trying to match on a boolean expression
-  --> $DIR/matches.rs:96:5
+  --> $DIR/matches.rs:30:5
    |
-96 | /     match test {
-97 | |         true => 0,
-98 | |         false => 42,
-99 | |     };
+30 | /     match test {
+31 | |         true => 0,
+32 | |         false => 42,
+33 | |     };
    | |_____^ help: consider using an if/else expression: `if test { 0 } else { 42 }`
    |
    = note: `-D match-bool` implied by `-D warnings`
 
 error: you seem to be trying to match on a boolean expression
-   --> $DIR/matches.rs:102:5
-    |
-102 | /     match option == 1 {
-103 | |         true => 1,
-104 | |         false => 0,
-105 | |     };
-    | |_____^ help: consider using an if/else expression: `if option == 1 { 1 } else { 0 }`
+  --> $DIR/matches.rs:36:5
+   |
+36 | /     match option == 1 {
+37 | |         true => 1,
+38 | |         false => 0,
+39 | |     };
+   | |_____^ help: consider using an if/else expression: `if option == 1 { 1 } else { 0 }`
 
 error: you seem to be trying to match on a boolean expression
-   --> $DIR/matches.rs:107:5
-    |
-107 | /     match test {
-108 | |         true => (),
-109 | |         false => { println!("Noooo!"); }
-110 | |     };
-    | |_____^ help: consider using an if/else expression: `if !test { println!("Noooo!"); }`
+  --> $DIR/matches.rs:41:5
+   |
+41 | /     match test {
+42 | |         true => (),
+43 | |         false => { println!("Noooo!"); }
+44 | |     };
+   | |_____^ help: consider using an if/else expression: `if !test { println!("Noooo!"); }`
 
 error: you seem to be trying to match on a boolean expression
-   --> $DIR/matches.rs:112:5
-    |
-112 | /     match test {
-113 | |         false => { println!("Noooo!"); }
-114 | |         _ => (),
-115 | |     };
-    | |_____^ help: consider using an if/else expression: `if !test { println!("Noooo!"); }`
+  --> $DIR/matches.rs:46:5
+   |
+46 | /     match test {
+47 | |         false => { println!("Noooo!"); }
+48 | |         _ => (),
+49 | |     };
+   | |_____^ help: consider using an if/else expression: `if !test { println!("Noooo!"); }`
 
 error: you seem to be trying to match on a boolean expression
-   --> $DIR/matches.rs:117:5
-    |
-117 | /     match test && test {
-118 | |         false => { println!("Noooo!"); }
-119 | |         _ => (),
-120 | |     };
-    | |_____^ help: consider using an if/else expression: `if !(test && test) { println!("Noooo!"); }`
+  --> $DIR/matches.rs:51:5
+   |
+51 | /     match test && test {
+52 | |         false => { println!("Noooo!"); }
+53 | |         _ => (),
+54 | |     };
+   | |_____^ help: consider using an if/else expression: `if !(test && test) { println!("Noooo!"); }`
 
 error: equal expressions as operands to `&&`
-   --> $DIR/matches.rs:117:11
-    |
-117 |     match test && test {
-    |           ^^^^^^^^^^^^
-    |
-    = note: `-D eq-op` implied by `-D warnings`
+  --> $DIR/matches.rs:51:11
+   |
+51 |     match test && test {
+   |           ^^^^^^^^^^^^
+   |
+   = note: `-D eq-op` implied by `-D warnings`
 
 error: you seem to be trying to match on a boolean expression
-   --> $DIR/matches.rs:122:5
-    |
-122 | /     match test {
-123 | |         false => { println!("Noooo!"); }
-124 | |         true => { println!("Yes!"); }
-125 | |     };
-    | |_____^ help: consider using an if/else expression: `if test { println!("Yes!"); } else { println!("Noooo!"); }`
+  --> $DIR/matches.rs:56:5
+   |
+56 | /     match test {
+57 | |         false => { println!("Noooo!"); }
+58 | |         true => { println!("Yes!"); }
+59 | |     };
+   | |_____^ help: consider using an if/else expression: `if test { println!("Yes!"); } else { println!("Noooo!"); }`
 
 error: you don't need to add `&` to all patterns
-   --> $DIR/matches.rs:138:9
-    |
-138 | /         match v {
-139 | |             &Some(v) => println!("{:?}", v),
-140 | |             &None => println!("none"),
-141 | |         }
-    | |_________^
-    |
-    = note: `-D match-ref-pats` implied by `-D warnings`
+  --> $DIR/matches.rs:72:9
+   |
+72 | /         match v {
+73 | |             &Some(v) => println!("{:?}", v),
+74 | |             &None => println!("none"),
+75 | |         }
+   | |_________^
+   |
+   = note: `-D match-ref-pats` implied by `-D warnings`
 help: instead of prefixing all patterns with `&`, you can dereference the expression
-    |
-138 |         match *v {
-139 |             Some(v) => println!("{:?}", v),
-140 |             None => println!("none"),
-    |
+   |
+72 |         match *v {
+73 |             Some(v) => println!("{:?}", v),
+74 |             None => println!("none"),
+   |
 
 error: you don't need to add `&` to all patterns
-   --> $DIR/matches.rs:148:5
+  --> $DIR/matches.rs:82:5
+   |
+82 | /     match tup {
+83 | |         &(v, 1) => println!("{}", v),
+84 | |         _ => println!("none"),
+85 | |     }
+   | |_____^
+help: instead of prefixing all patterns with `&`, you can dereference the expression
+   |
+82 |     match *tup {
+83 |         (v, 1) => println!("{}", v),
+   |
+
+error: you don't need to add `&` to both the expression and the patterns
+  --> $DIR/matches.rs:88:5
+   |
+88 | /     match &w {
+89 | |         &Some(v) => println!("{:?}", v),
+90 | |         &None => println!("none"),
+91 | |     }
+   | |_____^
+help: try
+   |
+88 |     match w {
+89 |         Some(v) => println!("{:?}", v),
+90 |         None => println!("none"),
+   |
+
+error: you don't need to add `&` to all patterns
+   --> $DIR/matches.rs:99:5
     |
-148 | /     match tup {
-149 | |         &(v, 1) => println!("{}", v),
-150 | |         _ => println!("none"),
-151 | |     }
+99  | /     if let &None = a {
+100 | |         println!("none");
+101 | |     }
     | |_____^
 help: instead of prefixing all patterns with `&`, you can dereference the expression
     |
-148 |     match *tup {
-149 |         (v, 1) => println!("{}", v),
+99  |     if let None = *a {
     |
 
 error: you don't need to add `&` to both the expression and the patterns
-   --> $DIR/matches.rs:154:5
+   --> $DIR/matches.rs:104:5
     |
-154 | /     match &w {
-155 | |         &Some(v) => println!("{:?}", v),
-156 | |         &None => println!("none"),
-157 | |     }
+104 | /     if let &None = &b {
+105 | |         println!("none");
+106 | |     }
     | |_____^
 help: try
     |
-154 |     match w {
-155 |         Some(v) => println!("{:?}", v),
-156 |         None => println!("none"),
-    |
-
-error: you don't need to add `&` to all patterns
-   --> $DIR/matches.rs:165:5
-    |
-165 | /     if let &None = a {
-166 | |         println!("none");
-167 | |     }
-    | |_____^
-help: instead of prefixing all patterns with `&`, you can dereference the expression
-    |
-165 |     if let None = *a {
-    |
-
-error: you don't need to add `&` to both the expression and the patterns
-   --> $DIR/matches.rs:170:5
-    |
-170 | /     if let &None = &b {
-171 | |         println!("none");
-172 | |     }
-    | |_____^
-help: try
-    |
-170 |     if let None = b {
+104 |     if let None = b {
     |
 
 error: some ranges overlap
-   --> $DIR/matches.rs:179:9
+   --> $DIR/matches.rs:113:9
     |
-179 |         0 ... 10 => println!("0 ... 10"),
+113 |         0 ... 10 => println!("0 ... 10"),
     |         ^^^^^^^^
     |
     = note: `-D match-overlapping-arm` implied by `-D warnings`
 note: overlaps with this
-   --> $DIR/matches.rs:180:9
+   --> $DIR/matches.rs:114:9
     |
-180 |         0 ... 11 => println!("0 ... 11"),
+114 |         0 ... 11 => println!("0 ... 11"),
     |         ^^^^^^^^
 
 error: some ranges overlap
-   --> $DIR/matches.rs:185:9
+   --> $DIR/matches.rs:119:9
     |
-185 |         0 ... 5 => println!("0 ... 5"),
+119 |         0 ... 5 => println!("0 ... 5"),
     |         ^^^^^^^
     |
 note: overlaps with this
-   --> $DIR/matches.rs:187:9
+   --> $DIR/matches.rs:121:9
     |
-187 |         FOO ... 11 => println!("0 ... 11"),
+121 |         FOO ... 11 => println!("0 ... 11"),
     |         ^^^^^^^^^^
 
 error: some ranges overlap
-   --> $DIR/matches.rs:193:9
+   --> $DIR/matches.rs:127:9
     |
-193 |         0 ... 5 => println!("0 ... 5"),
+127 |         0 ... 5 => println!("0 ... 5"),
     |         ^^^^^^^
     |
 note: overlaps with this
-   --> $DIR/matches.rs:192:9
+   --> $DIR/matches.rs:126:9
     |
-192 |         2 => println!("2"),
+126 |         2 => println!("2"),
     |         ^
 
 error: some ranges overlap
-   --> $DIR/matches.rs:199:9
+   --> $DIR/matches.rs:133:9
     |
-199 |         0 ... 2 => println!("0 ... 2"),
+133 |         0 ... 2 => println!("0 ... 2"),
     |         ^^^^^^^
     |
 note: overlaps with this
-   --> $DIR/matches.rs:198:9
+   --> $DIR/matches.rs:132:9
     |
-198 |         2 => println!("2"),
+132 |         2 => println!("2"),
     |         ^
 
 error: some ranges overlap
-   --> $DIR/matches.rs:222:9
+   --> $DIR/matches.rs:156:9
     |
-222 |         0 .. 11 => println!("0 .. 11"),
+156 |         0 .. 11 => println!("0 .. 11"),
     |         ^^^^^^^
     |
 note: overlaps with this
-   --> $DIR/matches.rs:223:9
+   --> $DIR/matches.rs:157:9
     |
-223 |         0 ... 11 => println!("0 ... 11"),
+157 |         0 ... 11 => println!("0 ... 11"),
     |         ^^^^^^^^
 
 error: Err(_) will match all errors, maybe not a good idea
-   --> $DIR/matches.rs:240:9
+   --> $DIR/matches.rs:174:9
     |
-240 |         Err(_) => panic!("err")
+174 |         Err(_) => panic!("err")
     |         ^^^^^^
     |
     = note: `-D match-wild-err-arm` implied by `-D warnings`
     = note: to remove this warning, match each error seperately or use unreachable macro
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:239:18
+   --> $DIR/matches.rs:173:18
     |
-239 |         Ok(_) => println!("ok"),
+173 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
     = note: `-D match-same-arms` implied by `-D warnings`
 note: same as this
-   --> $DIR/matches.rs:238:18
+   --> $DIR/matches.rs:172:18
     |
-238 |         Ok(3) => println!("ok"),
+172 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:238:18
+   --> $DIR/matches.rs:172:18
     |
-238 |         Ok(3) => println!("ok"),
+172 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: Err(_) will match all errors, maybe not a good idea
-   --> $DIR/matches.rs:246:9
+   --> $DIR/matches.rs:180:9
     |
-246 |         Err(_) => {panic!()}
+180 |         Err(_) => {panic!()}
     |         ^^^^^^
     |
     = note: to remove this warning, match each error seperately or use unreachable macro
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:245:18
+   --> $DIR/matches.rs:179:18
     |
-245 |         Ok(_) => println!("ok"),
+179 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:244:18
+   --> $DIR/matches.rs:178:18
     |
-244 |         Ok(3) => println!("ok"),
+178 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:244:18
+   --> $DIR/matches.rs:178:18
     |
-244 |         Ok(3) => println!("ok"),
+178 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: Err(_) will match all errors, maybe not a good idea
-   --> $DIR/matches.rs:252:9
+   --> $DIR/matches.rs:186:9
     |
-252 |         Err(_) => {panic!();}
+186 |         Err(_) => {panic!();}
     |         ^^^^^^
     |
     = note: to remove this warning, match each error seperately or use unreachable macro
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:251:18
+   --> $DIR/matches.rs:185:18
     |
-251 |         Ok(_) => println!("ok"),
+185 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:250:18
+   --> $DIR/matches.rs:184:18
     |
-250 |         Ok(3) => println!("ok"),
+184 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:250:18
+   --> $DIR/matches.rs:184:18
     |
-250 |         Ok(3) => println!("ok"),
+184 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:258:18
+   --> $DIR/matches.rs:192:18
     |
-258 |         Ok(_) => println!("ok"),
+192 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:257:18
+   --> $DIR/matches.rs:191:18
     |
-257 |         Ok(3) => println!("ok"),
+191 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:257:18
+   --> $DIR/matches.rs:191:18
     |
-257 |         Ok(3) => println!("ok"),
+191 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:265:18
+   --> $DIR/matches.rs:199:18
     |
-265 |         Ok(_) => println!("ok"),
+199 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:264:18
+   --> $DIR/matches.rs:198:18
     |
-264 |         Ok(3) => println!("ok"),
+198 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:264:18
+   --> $DIR/matches.rs:198:18
     |
-264 |         Ok(3) => println!("ok"),
+198 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:271:18
+   --> $DIR/matches.rs:205:18
     |
-271 |         Ok(_) => println!("ok"),
+205 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:270:18
+   --> $DIR/matches.rs:204:18
     |
-270 |         Ok(3) => println!("ok"),
+204 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:270:18
+   --> $DIR/matches.rs:204:18
     |
-270 |         Ok(3) => println!("ok"),
+204 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:277:18
+   --> $DIR/matches.rs:211:18
     |
-277 |         Ok(_) => println!("ok"),
+211 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:276:18
+   --> $DIR/matches.rs:210:18
     |
-276 |         Ok(3) => println!("ok"),
+210 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:276:18
+   --> $DIR/matches.rs:210:18
     |
-276 |         Ok(3) => println!("ok"),
+210 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:298:29
+   --> $DIR/matches.rs:232:29
     |
-298 |         (Ok(_), Some(x)) => println!("ok {}", x),
+232 |         (Ok(_), Some(x)) => println!("ok {}", x),
     |                             ^^^^^^^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:297:29
+   --> $DIR/matches.rs:231:29
     |
-297 |         (Ok(x), Some(_)) => println!("ok {}", x),
+231 |         (Ok(x), Some(_)) => println!("ok {}", x),
     |                             ^^^^^^^^^^^^^^^^^^^^
 note: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
-   --> $DIR/matches.rs:297:29
+   --> $DIR/matches.rs:231:29
     |
-297 |         (Ok(x), Some(_)) => println!("ok {}", x),
+231 |         (Ok(x), Some(_)) => println!("ok {}", x),
     |                             ^^^^^^^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-   --> $DIR/matches.rs:313:18
+   --> $DIR/matches.rs:247:18
     |
-313 |         Ok(_) => println!("ok"),
+247 |         Ok(_) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     |
 note: same as this
-   --> $DIR/matches.rs:312:18
+   --> $DIR/matches.rs:246:18
     |
-312 |         Ok(3) => println!("ok"),
+246 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
 note: consider refactoring into `Ok(3) | Ok(_)`
-   --> $DIR/matches.rs:312:18
+   --> $DIR/matches.rs:246:18
     |
-312 |         Ok(3) => println!("ok"),
+246 |         Ok(3) => println!("ok"),
     |                  ^^^^^^^^^^^^^^
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: use as_ref() instead
-   --> $DIR/matches.rs:320:33
+   --> $DIR/matches.rs:254:33
     |
-320 |       let borrowed: Option<&()> = match owned {
+254 |       let borrowed: Option<&()> = match owned {
     |  _________________________________^
-321 | |         None => None,
-322 | |         Some(ref v) => Some(v),
-323 | |     };
+255 | |         None => None,
+256 | |         Some(ref v) => Some(v),
+257 | |     };
     | |_____^ help: try this: `owned.as_ref()`
     |
     = note: `-D match-as-ref` implied by `-D warnings`
 
 error: use as_mut() instead
-   --> $DIR/matches.rs:326:39
+   --> $DIR/matches.rs:260:39
     |
-326 |       let borrow_mut: Option<&mut ()> = match mut_owned {
+260 |       let borrow_mut: Option<&mut ()> = match mut_owned {
     |  _______________________________________^
-327 | |         None => None,
-328 | |         Some(ref mut v) => Some(v),
-329 | |     };
+261 | |         None => None,
+262 | |         Some(ref mut v) => Some(v),
+263 | |     };
     | |_____^ help: try this: `mut_owned.as_mut()`
 
-error: aborting due to 38 previous errors
+error: aborting due to 33 previous errors
 

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -1,0 +1,71 @@
+#![warn(single_match)]
+
+fn dummy() {
+}
+
+fn single_match(){
+    let x = Some(1u8);
+
+    match x {
+        Some(y) => { println!("{:?}", y); }
+        _ => ()
+    };
+
+    let z = (1u8,1u8);
+    match z {
+        (2...3, 7...9) => dummy(),
+        _ => {}
+    };
+
+    // Not linted (pattern guards used)
+    match x {
+        Some(y) if y == 0 => println!("{:?}", y),
+        _ => ()
+    }
+
+    // Not linted (no block with statements in the single arm)
+    match z {
+        (2...3, 7...9) => println!("{:?}", z),
+        _ => println!("nope"),
+    }
+}
+
+enum Foo { Bar, Baz(u8) }
+use Foo::*;
+use std::borrow::Cow;
+
+fn single_match_know_enum() {
+    let x = Some(1u8);
+    let y : Result<_, i8> = Ok(1i8);
+
+    match x {
+        Some(y) => dummy(),
+        None => ()
+    };
+
+    match y {
+        Ok(y) => dummy(),
+        Err(..) => ()
+    };
+
+    let c = Cow::Borrowed("");
+
+    match c {
+        Cow::Borrowed(..) => dummy(),
+        Cow::Owned(..) => (),
+    };
+
+    let z = Foo::Bar;
+    // no warning
+    match z {
+        Bar => println!("42"),
+        Baz(_) => (),
+    }
+
+    match z {
+        Baz(_) => println!("42"),
+        Bar => (),
+    }
+}
+
+fn main() { }

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,0 +1,49 @@
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:9:5
+   |
+9  | /     match x {
+10 | |         Some(y) => { println!("{:?}", y); }
+11 | |         _ => ()
+12 | |     };
+   | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y); }`
+   |
+   = note: `-D single-match` implied by `-D warnings`
+
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:15:5
+   |
+15 | /     match z {
+16 | |         (2...3, 7...9) => dummy(),
+17 | |         _ => {}
+18 | |     };
+   | |_____^ help: try this: `if let (2...3, 7...9) = z { dummy() }`
+
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:41:5
+   |
+41 | /     match x {
+42 | |         Some(y) => dummy(),
+43 | |         None => ()
+44 | |     };
+   | |_____^ help: try this: `if let Some(y) = x { dummy() }`
+
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:46:5
+   |
+46 | /     match y {
+47 | |         Ok(y) => dummy(),
+48 | |         Err(..) => ()
+49 | |     };
+   | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
+
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:53:5
+   |
+53 | /     match c {
+54 | |         Cow::Borrowed(..) => dummy(),
+55 | |         Cow::Owned(..) => (),
+56 | |     };
+   | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This moves only the `single_match` tests over to the new file

Part of #2038 