### PR TITLE
Fix latest nightly breakage

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1798,7 +1798,7 @@ fn is_ref_iterable_type(cx: &LateContext, e: &Expr) -> bool {
 fn is_iterable_array(ty: Ty) -> bool {
     // IntoIterator is currently only implemented for array sizes <= 32 in rustc
     match ty.sty {
-        ty::TyArray(_, n) => (0..=32).contains(n.val.to_raw_bits().expect("array length")),
+        ty::TyArray(_, n) => (0..=32).contains(&n.val.to_raw_bits().expect("array length")),
         _ => false,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ extern crate clippy_lints;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    if let Ok(lint_store) = reg.sess.lint_store.try_borrow() {
+    reg.sess.lint_store.with_read_lock(|lint_store| {
         for (lint, _, _) in lint_store.get_lint_groups() {
             if lint == "clippy" {
                 reg.sess
@@ -21,7 +21,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
                 return;
             }
         }
-    }
+    });
 
     clippy_lints::register_plugins(reg);
 }


### PR DESCRIPTION
Was caused partly by https://github.com/rust-lang/rust/pull/49882 

`lint_store` is now wrapped in an `RwLock` instead of a `RefCell`

I'm not sure if there are better ways to use the RwLock API, though. But it seems to work.

fixes #2682