### PR TITLE
Fix rustfmt-induced missing line comments in examples

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -21,7 +21,7 @@ use url::Url;
 /// **Examples:**
 /// ```rust
 /// /// Do something with the foo_bar parameter. See also
-/// that::other::module::foo.
+/// /// that::other::module::foo.
 /// // ^ `foo_bar` and `that::other::module::foo` should be ticked.
 /// fn doit(foo_bar) { .. }
 /// ```

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -17,7 +17,7 @@ use utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};
 /// ```rust
 /// let mut lock_guard = mutex.lock();
 /// std::mem::drop(&lock_guard) // Should have been drop(lock_guard), mutex
-/// still locked
+/// // still locked
 /// operation_that_requires_mutex_to_be_unlocked();
 /// ```
 declare_clippy_lint! {

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -60,7 +60,7 @@ declare_clippy_lint! {
 /// ```rust
 /// let x:i32 = 42;   // i32 implements Copy
 /// std::mem::drop(x) // A copy of x is passed to the function, leaving the
-/// original unaffected
+/// // original unaffected
 /// ```
 declare_clippy_lint! {
     pub DROP_COPY,
@@ -87,7 +87,7 @@ declare_clippy_lint! {
 /// ```rust
 /// let x:i32 = 42;     // i32 implements Copy
 /// std::mem::forget(x) // A copy of x is passed to the function, leaving the
-/// original unaffected
+/// // original unaffected
 /// ```
 declare_clippy_lint! {
     pub FORGET_COPY,

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -16,7 +16,7 @@ use utils::{opt_def_id, sugg};
 ///
 /// **Example:**
 /// ```rust
-/// let ptr: *const T = core::intrinsics::transmute('x')`
+/// let ptr: *const T = core::intrinsics::transmute('x')
 /// ```
 declare_clippy_lint! {
     pub WRONG_TRANSMUTE,
@@ -51,7 +51,7 @@ declare_clippy_lint! {
 ///
 /// **Example:**
 /// ```rust
-/// core::intrinsics::transmute(t)` // where the result type is the same as
+/// core::intrinsics::transmute(t) // where the result type is the same as
 /// // `*t` or `&t`'s
 /// ```
 declare_clippy_lint! {

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -52,7 +52,7 @@ declare_clippy_lint! {
 /// **Example:**
 /// ```rust
 /// core::intrinsics::transmute(t)` // where the result type is the same as
-/// `*t` or `&t`'s
+/// // `*t` or `&t`'s
 /// ```
 declare_clippy_lint! {
     pub CROSSPOINTER_TRANSMUTE,


### PR DESCRIPTION
rustfmt [wrapped some comment lines](https://github.com/rust-lang-nursery/rust-clippy/commit/b25b6b3355efa33c797f4a37afb2f516531ad581), so I added some more `//`s and `///`s. I also removed some extra `` ` ``s that shouldn't have been in the example code.

It might be better to move some of these example comments to their own line—let me know if that would be better.

CI issues appear to be unrelated these changes.