### PR TITLE
Add third variant to {pub_,}enum_variant_names examples

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -20,6 +20,7 @@ use utils::{camel_case_from, camel_case_until, in_macro};
 /// enum Cake {
 ///     BlackForestCake,
 ///     HummingbirdCake,
+///     BattenbergCake,
 /// }
 /// ```
 declare_clippy_lint! {
@@ -41,6 +42,7 @@ declare_clippy_lint! {
 /// enum Cake {
 ///     BlackForestCake,
 ///     HummingbirdCake,
+///     BattenbergCake,
 /// }
 /// ```
 declare_clippy_lint! {


### PR DESCRIPTION
The default value for `enum-variant-name-threshold` is 3, so the old examples (which only have two enum variants) don't actually trigger the lint by default.