### PR TITLE
Update len_zero to handle comparisions with one

### DIFF
--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -1,6 +1,3 @@
-
-
-
 #![warn(len_without_is_empty, len_zero)]
 #![allow(dead_code, unused)]
 
@@ -12,7 +9,8 @@ impl PubOne {
     }
 }
 
-impl PubOne { // A second impl for this struct - the error span shouldn't mention this
+impl PubOne {
+    // A second impl for this struct - the error span shouldn't mention this
     pub fn irrelevant(self: &Self) -> bool {
         false
     }
@@ -39,7 +37,8 @@ impl PubAllowed {
 struct NotPubOne;
 
 impl NotPubOne {
-    pub fn len(self: &Self) -> isize { // no error, len is pub but `NotPubOne` is not exported anyway
+    pub fn len(self: &Self) -> isize {
+        // no error, len is pub but `NotPubOne` is not exported anyway
         1
     }
 }
@@ -47,7 +46,8 @@ impl NotPubOne {
 struct One;
 
 impl One {
-    fn len(self: &Self) -> isize { // no error, len is private, see #1085
+    fn len(self: &Self) -> isize {
+        // no error, len is private, see #1085
         1
     }
 }
@@ -120,7 +120,7 @@ impl HasWrongIsEmpty {
         1
     }
 
-    pub fn is_empty(self: &Self, x : u32) -> bool {
+    pub fn is_empty(self: &Self, x: u32) -> bool {
         false
     }
 }
@@ -129,11 +129,10 @@ pub trait Empty {
     fn is_empty(&self) -> bool;
 }
 
-pub trait InheritingEmpty: Empty { //must not trigger LEN_WITHOUT_IS_EMPTY
+pub trait InheritingEmpty: Empty {
+    //must not trigger LEN_WITHOUT_IS_EMPTY
     fn len(&self) -> isize;
 }
-
-
 
 fn main() {
     let x = [1, 2];
@@ -141,16 +140,17 @@ fn main() {
         println!("This should not happen!");
     }
 
-    if "".len() == 0 {
-    }
+    if "".len() == 0 {}
 
     let y = One;
-    if y.len()  == 0 { //no error because One does not have .is_empty()
+    if y.len() == 0 {
+        //no error because One does not have .is_empty()
         println!("This should not happen either!");
     }
 
-    let z : &TraitsToo = &y;
-    if z.len() > 0 { //no error, because TraitsToo has no .is_empty() method
+    let z: &TraitsToo = &y;
+    if z.len() > 0 {
+        //no error, because TraitsToo has no .is_empty() method
         println!("Nor should this!");
     }
 
@@ -164,6 +164,43 @@ fn main() {
     if has_is_empty.len() > 0 {
         println!("Or this!");
     }
+    if has_is_empty.len() < 1 {
+        println!("Or this!");
+    }
+    if has_is_empty.len() >= 1 {
+        println!("Or this!");
+    }
+    if has_is_empty.len() > 1 {
+        // no error
+        println!("This can happen.");
+    }
+    if has_is_empty.len() <= 1 {
+        // no error
+        println!("This can happen.");
+    }
+    if 0 == has_is_empty.len() {
+        println!("Or this!");
+    }
+    if 0 != has_is_empty.len() {
+        println!("Or this!");
+    }
+    if 0 < has_is_empty.len() {
+        println!("Or this!");
+    }
+    if 1 <= has_is_empty.len() {
+        println!("Or this!");
+    }
+    if 1 > has_is_empty.len() {
+        println!("Or this!");
+    }
+    if 1 < has_is_empty.len() {
+        // no error
+        println!("This can happen.");
+    }
+    if 1 >= has_is_empty.len() {
+        // no error
+        println!("This can happen.");
+    }
     assert!(!has_is_empty.is_empty());
 
     let with_is_empty: &WithIsEmpty = &Wither;
@@ -173,14 +210,14 @@ fn main() {
     assert!(!with_is_empty.is_empty());
 
     let has_wrong_is_empty = HasWrongIsEmpty;
-    if has_wrong_is_empty.len() == 0 { //no error as HasWrongIsEmpty does not have .is_empty()
+    if has_wrong_is_empty.len() == 0 {
+        //no error as HasWrongIsEmpty does not have .is_empty()
         println!("Or this!");
     }
 }
 
 fn test_slice(b: &[u8]) {
-    if b.len() != 0 {
-    }
+    if b.len() != 0 {}
 }
 
 // this used to ICE

--- a/tests/ui/len_zero.stderr
+++ b/tests/ui/len_zero.stderr
@@ -1,11 +1,11 @@
 error: item `PubOne` has a public `len` method but no corresponding `is_empty` method
-  --> $DIR/len_zero.rs:9:1
+  --> $DIR/len_zero.rs:6:1
    |
-9  | / impl PubOne {
-10 | |     pub fn len(self: &Self) -> isize {
-11 | |         1
-12 | |     }
-13 | | }
+6  | / impl PubOne {
+7  | |     pub fn len(self: &Self) -> isize {
+8  | |         1
+9  | |     }
+10 | | }
    | |_^
    |
    = note: `-D len-without-is-empty` implied by `-D warnings`
@@ -43,17 +43,17 @@ error: item `HasWrongIsEmpty` has a public `len` method but no corresponding `is
     | |_^
 
 error: length comparison to zero
-   --> $DIR/len_zero.rs:140:8
+   --> $DIR/len_zero.rs:139:8
     |
-140 |     if x.len() == 0 {
+139 |     if x.len() == 0 {
     |        ^^^^^^^^^^^^ help: using `is_empty` is more concise: `x.is_empty()`
     |
     = note: `-D len-zero` implied by `-D warnings`
 
 error: length comparison to zero
-   --> $DIR/len_zero.rs:144:8
+   --> $DIR/len_zero.rs:143:8
     |
-144 |     if "".len() == 0 {
+143 |     if "".len() == 0 {}
     |        ^^^^^^^^^^^^^ help: using `is_empty` is more concise: `"".is_empty()`
 
 error: length comparison to zero
@@ -74,25 +74,67 @@ error: length comparison to zero
 164 |     if has_is_empty.len() > 0 {
     |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!has_is_empty.is_empty()`
 
-error: length comparison to zero
+error: length comparison to one
+   --> $DIR/len_zero.rs:167:8
+    |
+167 |     if has_is_empty.len() < 1 {
+    |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `has_is_empty.is_empty()`
+
+error: length comparison to one
    --> $DIR/len_zero.rs:170:8
     |
-170 |     if with_is_empty.len() == 0 {
+170 |     if has_is_empty.len() >= 1 {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!has_is_empty.is_empty()`
+
+error: length comparison to zero
+   --> $DIR/len_zero.rs:181:8
+    |
+181 |     if 0 == has_is_empty.len() {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `has_is_empty.is_empty()`
+
+error: length comparison to zero
+   --> $DIR/len_zero.rs:184:8
+    |
+184 |     if 0 != has_is_empty.len() {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!has_is_empty.is_empty()`
+
+error: length comparison to zero
+   --> $DIR/len_zero.rs:187:8
+    |
+187 |     if 0 < has_is_empty.len() {
+    |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!has_is_empty.is_empty()`
+
+error: length comparison to one
+   --> $DIR/len_zero.rs:190:8
+    |
+190 |     if 1 <= has_is_empty.len() {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!has_is_empty.is_empty()`
+
+error: length comparison to one
+   --> $DIR/len_zero.rs:193:8
+    |
+193 |     if 1 > has_is_empty.len() {
+    |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `has_is_empty.is_empty()`
+
+error: length comparison to zero
+   --> $DIR/len_zero.rs:207:8
+    |
+207 |     if with_is_empty.len() == 0 {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `with_is_empty.is_empty()`
 
 error: length comparison to zero
-   --> $DIR/len_zero.rs:182:8
+   --> $DIR/len_zero.rs:220:8
     |
-182 |     if b.len() != 0 {
+220 |     if b.len() != 0 {}
     |        ^^^^^^^^^^^^ help: using `is_empty` is more concise: `!b.is_empty()`
 
 error: trait `DependsOnFoo` has a `len` method but no (possibly inherited) `is_empty` method
-   --> $DIR/len_zero.rs:189:1
+   --> $DIR/len_zero.rs:226:1
     |
-189 | / pub trait DependsOnFoo: Foo {
-190 | |     fn len(&mut self) -> usize;
-191 | | }
+226 | / pub trait DependsOnFoo: Foo {
+227 | |     fn len(&mut self) -> usize;
+228 | | }
     | |_^
 
-error: aborting due to 12 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
I have added test cases for comparisons with zero and one.
While implementing handling of one, incorrect handlings of zero
were also fixed.

fixes rust-lang-nursery/rust-clippy/#2554