### PR TITLE
Add rustc version check to build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ helper.txt
 *.iml
 .vscode
 .idea
+
+# Used by the Clippy build script
+min_version.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,9 @@ clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = "1.0"
 derive-new = "0.5"
 
+[build-dependencies]
+rustc_version = "0.2.2"
+ansi_term = "0.11"
+
 [features]
 debugging = []

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,99 @@
+//! This build script ensures that clippy is not compiled with an
+//! incompatible version of rust. It will panic with a descriptive
+//! error message instead.
+//!
+//! We specifially want to ensure that clippy is only built with a
+//! rustc version that is newer or equal to the one specified in the
+//! `min_version.txt` file.
+//!
+//! `min_version.txt` is in the repo but also in the `.gitignore` to
+//! make sure that it is not updated manually by accident. Only CI
+//! should update that file.
+//!
+//! This build script was originally taken from the Rocket web framework:
+//! https://github.com/SergioBenitez/Rocket
+
+extern crate rustc_version;
+extern crate ansi_term;
+
 use std::env;
+use rustc_version::{version_meta, version_meta_for, Channel, Version, VersionMeta};
+use ansi_term::Colour::Red;
 
 fn main() {
+    let string = include_str!("min_version.txt");
+    let min_version_meta = version_meta_for(string)
+        .expect("Could not parse version string in min_version.txt");
+    let current_version_meta = version_meta()
+        .expect("Could not retrieve current rustc version information from ENV");
+
+    let min_version = min_version_meta.clone().semver;
+    let min_date_str = min_version_meta.clone().commit_date
+        .expect("min_version.txt does not contain a rustc commit date");
+
+    let current_version = current_version_meta.clone().semver;
+    let current_date_str = current_version_meta.clone().commit_date
+        .expect("current rustc version information does not contain a rustc commit date");
+
+    let print_version_err = |version: &Version, date: &str| {
+        eprintln!("> {} {}. {} {}.\n",
+                  "Installed rustc version is:",
+                  format!("{} ({})", version, date),
+                  "Minimum required rustc version:",
+                  format!("{} ({})", min_version, min_date_str));
+    };
+
+    if !correct_channel(&current_version_meta) {
+        eprintln!("\n{} {}",
+                  Red.bold().paint("error:"),
+                  "clippy requires a nightly version of Rust.");
+        print_version_err(&current_version, &*current_date_str);
+        eprintln!("{}{}{}",
+                  "See the README (",
+                  "https://github.com/rust-lang-nursery/rust-clippy#usage",
+                  ") for more information.");
+        panic!("Aborting compilation due to incompatible compiler.")
+    }
+
+    let current_date = str_to_ymd(&current_date_str).unwrap();
+    let min_date = str_to_ymd(&min_date_str).unwrap();
+
+    if current_date < min_date {
+        eprintln!("\n{} {}",
+                  Red.bold().paint("error:"),
+                  "clippy does not support this version of rustc nightly.");
+        eprintln!("> {}{}{}",
+                  "Use `",
+                  "rustup update",
+                  "` or your preferred method to update Rust.");
+        print_version_err(&current_version, &*current_date_str);
+        panic!("Aborting compilation due to incompatible compiler.")
+    }
+
     // Forward the profile to the main compilation
     println!("cargo:rustc-env=PROFILE={}", env::var("PROFILE").unwrap());
     // Don't rebuild even if nothing changed
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn correct_channel(version_meta: &VersionMeta) -> bool {
+    match version_meta.channel {
+        Channel::Stable | Channel::Beta => {
+            false
+        },
+        Channel::Nightly | Channel::Dev => {
+            true
+        }
+    }
+}
+
+/// Convert a string of %Y-%m-%d to a single u32 maintaining ordering.
+fn str_to_ymd(ymd: &str) -> Option<u32> {
+    let ymd: Vec<u32> = ymd.split("-").filter_map(|s| s.parse::<u32>().ok()).collect();
+    if ymd.len() != 3 {
+        return None
+    }
+
+    let (y, m, d) = (ymd[0], ymd[1], ymd[2]);
+    Some((y << 9) | (m << 5) | d)
 }

--- a/min_version.txt
+++ b/min_version.txt
@@ -1,0 +1,7 @@
+rustc 1.27.0-nightly (e82261dfb 2018-05-03)
+binary: rustc
+commit-hash: e82261dfbb5feaa2d28d2b138f4aabb2aa52c94b
+commit-date: 2018-05-03
+host: x86_64-unknown-linux-gnu
+release: 1.27.0-nightly
+LLVM version: 6.0


### PR DESCRIPTION
This extends the build script with a few version checks, as a first step towards autopublishing. 

As it is right now, the current checks will stop the compilation if the used rust version is older than the one specified in `min_version.txt` or if stable or beta were used to compile Clippy.

`min_version.txt` contains the output of `rustc -vV` as that's currently the only format that [`rustc-version-rs`](https://github.com/Kimundi/rustc-version-rs) understands. It was the quickest way to get it working, without writing a custom rust version parser.

I committed the min_version.txt manually, but with #2717 that should only be done through travis, so I added it to the .gitignore to prevent manual commits with that file. Until #2717 is done, we will have to update the min_version.txt manually with `rustc -vV > min_version.txt` when we are supporting a new nightly release.

### Examples
If Clippy is compiled on beta or stable it will show the following error:

    error: clippy requires a nightly version of Rust.
    > Installed rustc version is: 1.25.0 (2018-03-25). Minimum required rustc version: 1.27.0-nightly (2018-05-03).

If Clippy is compiled with a nightly older than specified in `min_version.txt`:

    error: clippy does not support this version of rustc nightly.
    > Use `rustup update` or your preferred method to update Rust.
    > Installed rustc version is: 1.27.0-nightly (2018-05-02). Minimum required rustc version: 1.27.0-nightly (2018-05-03).

Screenshot with colors:
![selection_030](https://user-images.githubusercontent.com/2042399/39719985-cbebd518-5232-11e8-946d-ac07d6b3ff26.png)

Closes #2716 