### PR TITLE
panic_params: don't lint escaped squigglies 

### DIFF
--- a/clippy_lints/src/panic.rs
+++ b/clippy_lints/src/panic.rs
@@ -10,8 +10,7 @@ use utils::{is_direct_expn_of, match_def_path, opt_def_id, paths, resolve_node, 
 /// is not a format string and used literally. So while `format!("{}")` will
 /// fail to compile, `panic!("{}")` will not.
 ///
-/// **Known problems:** Should you want to use curly brackets in `panic!`
-/// without any parameter, this lint will warn.
+/// **Known problems:** None.
 ///
 /// **Example:**
 /// ```rust
@@ -45,8 +44,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let ExprLit(ref lit) = params[0].node;
             if is_direct_expn_of(expr.span, "panic").is_some();
             if let LitKind::Str(ref string, _) = lit.node;
-            if let Some(par) = string.as_str().find('{');
-            if string.as_str()[par..].contains('}');
+            let string = string.as_str().replace("{{", "").replace("}}", "");
+            if let Some(par) = string.find('{');
+            if string[par..].contains('}');
             if params[0].span.source_callee().is_none();
             if params[0].span.lo() != params[0].span.hi();
             then {

--- a/tests/ui/panic.rs
+++ b/tests/ui/panic.rs
@@ -11,6 +11,8 @@ fn missing() {
     } else {
         assert!(true, "here be missing values: {}");
     }
+
+    panic!("{{{this}}}");
 }
 
 fn ok_single() {
@@ -41,6 +43,16 @@ fn ok_nomsg() {
     assert!(if 1 == ONE { ONE == 1 } else { false });
 }
 
+fn ok_escaped() {
+    panic!("{{ why should this not be ok? }}");
+    panic!(" or {{ that ?");
+    panic!(" or }} this ?");
+    panic!(" {or {{ that ?");
+    panic!(" }or }} this ?");
+    panic!("{{ test }");
+    panic!("{case }}");
+}
+
 fn main() {
     missing();
     ok_single();
@@ -48,4 +60,5 @@ fn main() {
     ok_bracket();
     ok_inner();
     ok_nomsg();
+    ok_escaped();
 }

--- a/tests/ui/panic.stderr
+++ b/tests/ui/panic.stderr
@@ -18,5 +18,11 @@ error: you probably are missing some parameter in your format string
 12 |         assert!(true, "here be missing values: {}");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: you probably are missing some parameter in your format string
+  --> $DIR/panic.rs:15:12
+   |
+15 |     panic!("{{{this}}}");
+   |            ^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Closes #1582

This PR wasn't updated for over a year and it was just a one line fix, so I figured I could do this real quick. I hope @llogiq is okay with that! :)

If this gets merged the `escape_squigglies` branch could be deleted.