### PR TITLE
Add basic integration tests for travis

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # Automatically deploy on gh-pages
 
-set -e
-set -x
+set -ex
 
 SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,23 +29,21 @@ install:
   - nvm use stable
   - npm install remark-cli remark-lint
 
+matrix:
+  include:
+    - env: INTEGRATION=rust-lang/cargo
+    - env: INTEGRATION=rust-lang-nursery/rand
+  allow_failures:
+    - env: INTEGRATION=rust-lang/cargo
+    - env: INTEGRATION=rust-lang-nursery/rand
+
 script:
- - PATH=$PATH:./node_modules/.bin
- - remark -f *.md > /dev/null
- - set -e
- - cargo build --features debugging
- - cargo test --features debugging
- - mkdir -p ~/rust/cargo/bin
- - cp target/debug/cargo-clippy ~/rust/cargo/bin/cargo-clippy
- - cp target/debug/clippy-driver ~/rust/cargo/bin/clippy-driver
- - PATH=$PATH:~/rust/cargo/bin cargo clippy --all -- -D clippy
- - cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ..
- - cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
- - cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
- - cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../../..
- - PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy
- - cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy && cd ../..
- - set +e
+  - |
+    if [ -z ${INTEGRATION} ]; then
+      ./ci/base-tests.sh
+    else
+      ./ci/integration-tests.sh
+    fi
 
 after_success: |
   #!/bin/bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
 
 matrix:
   include:
+    - env: BASE_TESTS=true # runs the base tests
     - env: INTEGRATION=rust-lang/cargo
     - env: INTEGRATION=rust-lang-nursery/rand
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
 after_success: |
   #!/bin/bash
   if [ $(uname) == Linux ]; then
-    set -e
+    set -ex
     ./.github/deploy.sh
     # trigger rebuild of the clippy-service, to keep it up to date with clippy itself
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -1,3 +1,4 @@
+set -ex
 PATH=$PATH:./node_modules/.bin
 remark -f *.md > /dev/null
 set -e

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -1,0 +1,15 @@
+PATH=$PATH:./node_modules/.bin
+remark -f *.md > /dev/null
+set -e
+cargo build --features debugging
+cargo test --features debugging
+mkdir -p ~/rust/cargo/bin
+cp target/debug/cargo-clippy ~/rust/cargo/bin/cargo-clippy
+cp target/debug/clippy-driver ~/rust/cargo/bin/clippy-driver
+PATH=$PATH:~/rust/cargo/bin cargo clippy --all -- -D clippy
+cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ..
+cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
+cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
+cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../../..
+PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy
+cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy && cd ../..

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -1,7 +1,6 @@
 set -ex
 PATH=$PATH:./node_modules/.bin
 remark -f *.md > /dev/null
-set -e
 cargo build --features debugging
 cargo test --features debugging
 mkdir -p ~/rust/cargo/bin

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -3,7 +3,8 @@ cargo install --force
 
 echo "Running integration test for crate ${INTEGRATION}"
 
-git clone https://github.com/${INTEGRATION}.git
+git clone --depth=1 https://github.com/${INTEGRATION}.git checkout
+cd checkout
 
 function check() {
   cargo clippy --all &> clippy_output
@@ -19,7 +20,6 @@ case ${INTEGRATION} in
     check
     ;;
   *)
-    cd ${INTEGRATION}
     check
     ;;
 esac

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -1,0 +1,24 @@
+cargo install --force
+
+echo "Running integration test for crate ${INTEGRATION}"
+
+git clone https://github.com/${INTEGRATION}.git
+
+function check() {
+  cargo clippy --all &> clippy_output
+  cat clippy_output
+  ! cat clippy_output | grep -q "internal error"
+  if [[ $? != 0 ]]; then
+    return 1
+  fi
+}
+
+case ${INTEGRATION} in
+  rust-lang/cargo)
+    check
+    ;;
+  *)
+    cd ${INTEGRATION}
+    check
+    ;;
+esac

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -1,3 +1,4 @@
+set -ex
 cargo install --force
 
 echo "Running integration test for crate ${INTEGRATION}"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -9,7 +9,7 @@ cd checkout
 function check() {
   cargo clippy --all &> clippy_output
   cat clippy_output
-  ! cat clippy_output | grep -q "internal error"
+  ! cat clippy_output | grep -q "internal compiler error"
   if [[ $? != 0 ]]; then
     return 1
   fi

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -1,4 +1,4 @@
-set -ex
+set -x
 cargo install --force
 
 echo "Running integration test for crate ${INTEGRATION}"


### PR DESCRIPTION
This adds an integration test setup very similar to the one used by rustfmt.

The goal of this PR is to get it working for just `cargo` and `rand` and once this is merged, we can add the rest easily. I also want to make it work for AppVeyor in this PR.

I expect this to fail currently, mainly due to cargo, let's see!

cc #2736 