### PR TITLE
rustup to nightly 2018-05-19

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -432,7 +432,7 @@ pub fn miri_to_const<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, result: &ty::Const<'
                         .interpret_interner
                         .get_alloc(ptr.alloc_id)
                         .unwrap();
-                    let offset = ptr.offset as usize;
+                    let offset = ptr.offset.bytes() as usize;
                     let n = n as usize;
                     String::from_utf8(alloc.bytes[offset..(offset + n)].to_owned()).ok().map(Constant::Str)
                 },


### PR DESCRIPTION
clippy_lints does not compile: non-primitive cast: `rustc_target::abi::Size` as `usize`

Fixes #2780