### PR TITLE
Fix chrono compile-fail due to empty param_env

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -200,8 +200,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                     let sugg = |db: &mut DiagnosticBuilder| {
                         if let ty::TypeVariants::TyAdt(def, ..) = ty.sty {
                             if let Some(span) = cx.tcx.hir.span_if_local(def.did) {
-                                let param_env = ty::ParamEnv::empty();
-                                if param_env.can_type_implement_copy(cx.tcx, ty).is_ok() {
+                                if cx.param_env.can_type_implement_copy(cx.tcx, ty).is_ok() {
                                     db.span_help(span, "consider marking this type as Copy");
                                 }
                             }

--- a/tests/run-pass/ice-2760.rs
+++ b/tests/run-pass/ice-2760.rs
@@ -1,0 +1,19 @@
+#![allow(unused_variables, blacklisted_name, needless_pass_by_value, dead_code)]
+
+// This should not compile-fail with:
+//
+//      error[E0277]: the trait bound `T: Foo` is not satisfied
+//
+// See https://github.com/rust-lang-nursery/rust-clippy/issues/2760
+
+trait Foo {
+    type Bar;
+}
+
+struct Baz<T: Foo> {
+    bar: T::Bar,
+}
+
+fn take<T: Foo>(baz: Baz<T>) {}
+
+fn main() {}


### PR DESCRIPTION
Looks like a simple fix and all tests still pass.

Fixes #2760 