### PR TITLE
rename RangeArgument->RangeBounds

### DIFF
--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -115,9 +115,9 @@ trait FalsePositive {
 // shouldn't warn on extern funcs
 extern "C" fn ext(x: String) -> usize { x.len() }
 
-// whitelist RangeArgument
-fn range<T: ::std::collections::range::RangeArgument<usize>>(range: T) {
-    let _ = range.start();
+// whitelist RangeBounds
+fn range<T: ::std::ops::RangeBounds<usize>>(range: T) {
+    let _ = range.start_bound();
 }
 
 struct CopyWrapper(u32);


### PR DESCRIPTION
Do not merge yet. Waiting for PR https://github.com/rust-lang/rust/pull/51033.

When that Rust PR is merged, `RangeBounds` is the stable name. Clippy will break, since it is using the old unstable `RangeArgument`.