### PR TITLE
Don't run deploy script in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,8 @@ after_success: |
     set -ex
     if [ -z ${INTEGRATION} ]; then
       ./.github/deploy.sh
+    else
+      echo "Not deploying, because we're in an integration test run"
     fi
     # trigger rebuild of the clippy-service, to keep it up to date with clippy itself
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,9 @@ after_success: |
   #!/bin/bash
   if [ $(uname) == Linux ]; then
     set -ex
-    ./.github/deploy.sh
+    if [ -z ${INTEGRATION} ]; then
+      ./.github/deploy.sh
+    fi
     # trigger rebuild of the clippy-service, to keep it up to date with clippy itself
     if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&
        [ "$TRAVIS_REPO_SLUG" == "Manishearth/rust-clippy" ] &&


### PR DESCRIPTION
The deploy.sh was causing random integration tests to fail, possibly due to
multiple jobs trying to push to the same repo/branch at the same time?

This disables the deploy.sh in integration tests.

The error message is:

    +git push git@github.com:rust-lang-nursery/rust-clippy.git gh-pages
    Warning: Permanently added the RSA host key for IP address '192.30.253.112' to the list of known hosts.
    To github.com:rust-lang-nursery/rust-clippy.git
     ! [rejected]          gh-pages -> gh-pages (fetch first)
    error: failed to push some refs to 'git@github.com:rust-lang-nursery/rust-clippy.git'
    hint: Updates were rejected because the re

The travis log is always truncated in similar ways.

Some examples:

* https://travis-ci.org/rust-lang-nursery/rust-clippy/jobs/383325083#L1076-L1082
* https://travis-ci.org/rust-lang-nursery/rust-clippy/jobs/382711561#L2768-L2773