### PR TITLE
New Lint: Pass small trivially copyable objects by value

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -71,14 +71,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
 fn check_lit(cx: &LateContext, lit: &Lit, e: &Expr) {
     match lit.node {
-        LitKind::Float(ref s, FloatTy::F32) => check_known_consts(cx, e, s, "f32"),
-        LitKind::Float(ref s, FloatTy::F64) => check_known_consts(cx, e, s, "f64"),
-        LitKind::FloatUnsuffixed(ref s) => check_known_consts(cx, e, s, "f{32, 64}"),
+        LitKind::Float(s, FloatTy::F32) => check_known_consts(cx, e, s, "f32"),
+        LitKind::Float(s, FloatTy::F64) => check_known_consts(cx, e, s, "f64"),
+        LitKind::FloatUnsuffixed(s) => check_known_consts(cx, e, s, "f{32, 64}"),
         _ => (),
     }
 }
 
-fn check_known_consts(cx: &LateContext, e: &Expr, s: &symbol::Symbol, module: &str) {
+fn check_known_consts(cx: &LateContext, e: &Expr, s: symbol::Symbol, module: &str) {
     let s = s.as_str();
     if s.parse::<f64>().is_ok() {
         for &(constant, name, min_digits) in KNOWN_CONSTS {

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -151,7 +151,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AttrPass {
 
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item) {
         if is_relevant_item(cx.tcx, item) {
-            check_attrs(cx, item.span, &item.name, &item.attrs)
+            check_attrs(cx, item.span, item.name, &item.attrs)
         }
         match item.node {
             ItemExternCrate(_) | ItemUse(_, _) => {
@@ -195,13 +195,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AttrPass {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx ImplItem) {
         if is_relevant_impl(cx.tcx, item) {
-            check_attrs(cx, item.span, &item.name, &item.attrs)
+            check_attrs(cx, item.span, item.name, &item.attrs)
         }
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx TraitItem) {
         if is_relevant_trait(cx.tcx, item) {
-            check_attrs(cx, item.span, &item.name, &item.attrs)
+            check_attrs(cx, item.span, item.name, &item.attrs)
         }
     }
 }
@@ -260,7 +260,7 @@ fn is_relevant_expr(tcx: TyCtxt, tables: &ty::TypeckTables, expr: &Expr) -> bool
     }
 }
 
-fn check_attrs(cx: &LateContext, span: Span, name: &Name, attrs: &[Attribute]) {
+fn check_attrs(cx: &LateContext, span: Span, name: Name, attrs: &[Attribute]) {
     if in_macro(span) {
         return;
     }

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -52,7 +52,7 @@ impl LintPass for EqOp {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if let ExprBinary(ref op, ref left, ref right) = e.node {
+        if let ExprBinary(op, ref left, ref right) = e.node {
             if in_macro(e.span) {
                 return;
             }
@@ -157,7 +157,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
 }
 
 
-fn is_valid_operator(op: &BinOp) -> bool {
+fn is_valid_operator(op: BinOp) -> bool {
     match op.node {
         BiSub | BiDiv | BiEq | BiLt | BiLe | BiGt | BiGe | BiNe | BiAnd | BiOr | BiBitXor | BiBitAnd | BiBitOr => true,
         _ => false,

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -46,9 +46,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {
         if_chain! {
             let ty = cx.tables.expr_ty(expr);
-            if let TypeVariants::TyFloat(ref fty) = ty.sty;
+            if let TypeVariants::TyFloat(fty) = ty.sty;
             if let hir::ExprLit(ref lit) = expr.node;
-            if let LitKind::Float(ref sym, _) | LitKind::FloatUnsuffixed(ref sym) = lit.node;
+            if let LitKind::Float(sym, _) | LitKind::FloatUnsuffixed(sym) = lit.node;
             if let Some(sugg) = self.check(sym, fty);
             then {
                 span_lint_and_sugg(
@@ -66,7 +66,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
 
 impl ExcessivePrecision {
     // None if nothing to lint, Some(suggestion) if lint neccessary
-    fn check(&self, sym: &Symbol, fty: &FloatTy) -> Option<String> {
+    fn check(&self, sym: Symbol, fty: FloatTy) -> Option<String> {
         let max = max_digits(fty);
         let sym_str = sym.as_str();
         if dot_zero_exclusion(&sym_str) {
@@ -79,7 +79,7 @@ impl ExcessivePrecision {
         let digits = count_digits(&sym_str);
         if digits > max as usize {
             let formatter = FloatFormat::new(&sym_str);
-            let sr = match *fty {
+            let sr = match fty {
                 FloatTy::F32 => sym_str.parse::<f32>().map(|f| formatter.format(f)),
                 FloatTy::F64 => sym_str.parse::<f64>().map(|f| formatter.format(f)),
             };
@@ -115,7 +115,7 @@ fn dot_zero_exclusion(s: &str) -> bool {
     }
 }
 
-fn max_digits(fty: &FloatTy) -> u32 {
+fn max_digits(fty: FloatTy) -> u32 {
     match fty {
         FloatTy::F32 => f32::DIGITS,
         FloatTy::F64 => f64::DIGITS,

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Functions {
 }
 
 impl<'a, 'tcx> Functions {
-    fn check_arg_number(&self, cx: &LateContext, decl: &hir::FnDecl, span: Span) {
+    fn check_arg_number(self, cx: &LateContext, decl: &hir::FnDecl, span: Span) {
         let args = decl.inputs.len() as u64;
         if args > self.threshold {
             span_lint(
@@ -139,7 +139,7 @@ impl<'a, 'tcx> Functions {
     }
 
     fn check_raw_ptr(
-        &self,
+        self,
         cx: &LateContext<'a, 'tcx>,
         unsafety: hir::Unsafety,
         decl: &'tcx hir::FnDecl,

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -38,12 +38,12 @@ impl LintPass for Pass {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_trait_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx TraitItem) {
         if let TraitItemKind::Method(_, TraitMethod::Required(_)) = item.node {
-            check_attrs(cx, &item.name, &item.attrs);
+            check_attrs(cx, item.name, &item.attrs);
         }
     }
 }
 
-fn check_attrs(cx: &LateContext, name: &Name, attrs: &[Attribute]) {
+fn check_attrs(cx: &LateContext, name: Name, attrs: &[Attribute]) {
     for attr in attrs {
         if attr.name() != "inline" {
             continue;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -196,6 +196,7 @@ pub mod suspicious_trait_impl;
 pub mod swap;
 pub mod temporary_assignment;
 pub mod transmute;
+pub mod trivially_copy_pass_by_ref;
 pub mod types;
 pub mod unicode;
 pub mod unsafe_removed_from_name;
@@ -399,6 +400,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box large_enum_variant::LargeEnumVariant::new(conf.enum_variant_size_threshold));
     reg.register_late_lint_pass(box explicit_write::Pass);
     reg.register_late_lint_pass(box needless_pass_by_value::NeedlessPassByValue);
+    reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef);
     reg.register_early_lint_pass(box literal_representation::LiteralDigitGrouping);
     reg.register_early_lint_pass(box literal_representation::LiteralRepresentation::new(
             conf.literal_representation_threshold
@@ -672,6 +674,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         transmute::TRANSMUTE_PTR_TO_REF,
         transmute::USELESS_TRANSMUTE,
         transmute::WRONG_TRANSMUTE,
+        trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
         types::ABSURD_EXTREME_COMPARISONS,
         types::BORROWED_BOX,
         types::BOX_VEC,
@@ -916,6 +919,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         methods::SINGLE_CHAR_PATTERN,
         misc::CMP_OWNED,
         mutex_atomic::MUTEX_ATOMIC,
+        trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
         types::BOX_VEC,
         vec::USELESS_VEC,
     ]);

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -400,7 +400,10 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box large_enum_variant::LargeEnumVariant::new(conf.enum_variant_size_threshold));
     reg.register_late_lint_pass(box explicit_write::Pass);
     reg.register_late_lint_pass(box needless_pass_by_value::NeedlessPassByValue);
-    reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef);
+    reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
+            conf.trivial_copy_size_limit,
+            &reg.sess.target,
+    ));
     reg.register_early_lint_pass(box literal_representation::LiteralDigitGrouping);
     reg.register_early_lint_pass(box literal_representation::LiteralRepresentation::new(
             conf.literal_representation_threshold

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -227,12 +227,12 @@ enum WarningType {
 }
 
 impl WarningType {
-    pub fn display(&self, grouping_hint: &str, cx: &EarlyContext, span: &syntax_pos::Span) {
-        match *self {
+    pub fn display(&self, grouping_hint: &str, cx: &EarlyContext, span: syntax_pos::Span) {
+        match self {
             WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,
                 UNREADABLE_LITERAL,
-                *span,
+                span,
                 "long literal lacking separators",
                 "consider",
                 grouping_hint.to_owned(),
@@ -240,7 +240,7 @@ impl WarningType {
             WarningType::LargeDigitGroups => span_lint_and_sugg(
                 cx,
                 LARGE_DIGIT_GROUPS,
-                *span,
+                span,
                 "digit groups should be smaller",
                 "consider",
                 grouping_hint.to_owned(),
@@ -248,7 +248,7 @@ impl WarningType {
             WarningType::InconsistentDigitGrouping => span_lint_and_sugg(
                 cx,
                 INCONSISTENT_DIGIT_GROUPING,
-                *span,
+                span,
                 "digits grouped inconsistently by underscores",
                 "consider",
                 grouping_hint.to_owned(),
@@ -256,7 +256,7 @@ impl WarningType {
             WarningType::DecimalRepresentation => span_lint_and_sugg(
                 cx,
                 DECIMAL_LITERAL_REPRESENTATION,
-                *span,
+                span,
                 "integer literal has a better hexadecimal representation",
                 "consider",
                 grouping_hint.to_owned(),
@@ -291,7 +291,7 @@ impl EarlyLintPass for LiteralDigitGrouping {
 }
 
 impl LiteralDigitGrouping {
-    fn check_lit(&self, cx: &EarlyContext, lit: &Lit) {
+    fn check_lit(self, cx: &EarlyContext, lit: &Lit) {
         match lit.node {
             LitKind::Int(..) => {
                 // Lint integral literals.
@@ -302,7 +302,7 @@ impl LiteralDigitGrouping {
                     then {
                         let digit_info = DigitInfo::new(&src, false);
                         let _ = Self::do_lint(digit_info.digits).map_err(|warning_type| {
-                            warning_type.display(&digit_info.grouping_hint(), cx, &lit.span)
+                            warning_type.display(&digit_info.grouping_hint(), cx, lit.span)
                         });
                     }
                 }
@@ -337,15 +337,15 @@ impl LiteralDigitGrouping {
                                             if !consistent {
                                                 WarningType::InconsistentDigitGrouping.display(&digit_info.grouping_hint(),
                                                 cx,
-                                                &lit.span);
+                                                lit.span);
                                             }
                                         })
                                     .map_err(|warning_type| warning_type.display(&digit_info.grouping_hint(),
                                     cx,
-                                    &lit.span));
+                                    lit.span));
                                 }
                             })
-                        .map_err(|warning_type| warning_type.display(&digit_info.grouping_hint(), cx, &lit.span));
+                        .map_err(|warning_type| warning_type.display(&digit_info.grouping_hint(), cx, lit.span));
                     }
                 }
             },
@@ -436,7 +436,7 @@ impl LiteralRepresentation {
             threshold,
         }
     }
-    fn check_lit(&self, cx: &EarlyContext, lit: &Lit) {
+    fn check_lit(self, cx: &EarlyContext, lit: &Lit) {
         // Lint integral literals.
         if_chain! {
             if let LitKind::Int(..) = lit.node;
@@ -457,7 +457,7 @@ impl LiteralRepresentation {
                     let hex = format!("{:#X}", val);
                     let digit_info = DigitInfo::new(&hex[..], false);
                     let _ = Self::do_lint(digit_info.digits).map_err(|warning_type| {
-                        warning_type.display(&digit_info.grouping_hint(), cx, &lit.span)
+                        warning_type.display(&digit_info.grouping_hint(), cx, lit.span)
                     });
                 }
             }

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -2079,8 +2079,8 @@ impl SelfKind {
         }
     }
 
-    fn description(&self) -> &'static str {
-        match *self {
+    fn description(self) -> &'static str {
+        match self {
             SelfKind::Value => "self by value",
             SelfKind::Ref => "self by reference",
             SelfKind::RefMut => "self by mutable reference",
@@ -2164,13 +2164,13 @@ enum OutType {
 }
 
 impl OutType {
-    fn matches(&self, ty: &hir::FunctionRetTy) -> bool {
+    fn matches(self, ty: &hir::FunctionRetTy) -> bool {
         match (self, ty) {
-            (&OutType::Unit, &hir::DefaultReturn(_)) => true,
-            (&OutType::Unit, &hir::Return(ref ty)) if ty.node == hir::TyTup(vec![].into()) => true,
-            (&OutType::Bool, &hir::Return(ref ty)) if is_bool(ty) => true,
-            (&OutType::Any, &hir::Return(ref ty)) if ty.node != hir::TyTup(vec![].into()) => true,
-            (&OutType::Ref, &hir::Return(ref ty)) => matches!(ty.node, hir::TyRptr(_, _)),
+            (OutType::Unit, &hir::DefaultReturn(_)) => true,
+            (OutType::Unit, &hir::Return(ref ty)) if ty.node == hir::TyTup(vec![].into()) => true,
+            (OutType::Bool, &hir::Return(ref ty)) if is_bool(ty) => true,
+            (OutType::Any, &hir::Return(ref ty)) if ty.node != hir::TyTup(vec![].into()) => true,
+            (OutType::Ref, &hir::Return(ref ty)) => matches!(ty.node, hir::TyRptr(_, _)),
             _ => false,
         }
     }

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -349,7 +349,7 @@ impl EarlyLintPass for MiscEarly {
 }
 
 impl MiscEarly {
-    fn check_lit(&self, cx: &EarlyContext, lit: &Lit) {
+    fn check_lit(self, cx: &EarlyContext, lit: &Lit) {
         if_chain! {
             if let LitKind::Int(value, ..) = lit.node;
             if let Some(src) = snippet_opt(cx, lit.span);

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -92,7 +92,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for SuspiciousImpl {
             if let Some(impl_trait) = check_binop(
                 cx,
                 expr,
-                &binop.node,
+                binop.node,
                 &["Add", "Sub", "Mul", "Div"],
                 &[BiAdd, BiSub, BiMul, BiDiv],
             ) {
@@ -110,7 +110,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for SuspiciousImpl {
             if let Some(impl_trait) = check_binop(
                 cx,
                 expr,
-                &binop.node,
+                binop.node,
                 &[
                     "AddAssign",
                     "SubAssign",
@@ -144,7 +144,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for SuspiciousImpl {
 fn check_binop<'a>(
     cx: &LateContext,
     expr: &hir::Expr,
-    binop: &hir::BinOp_,
+    binop: hir::BinOp_,
     traits: &[&'a str],
     expected_ops: &[hir::BinOp_],
 ) -> Option<&'a str> {
@@ -169,7 +169,7 @@ fn check_binop<'a>(
         if let hir::map::Node::NodeItem(item) = cx.tcx.hir.get(parent_impl);
         if let hir::Item_::ItemImpl(_, _, _, _, Some(ref trait_ref), _, _) = item.node;
         if let Some(idx) = trait_ids.iter().position(|&tid| tid == trait_ref.path.def.def_id());
-        if *binop != expected_ops[idx];
+        if binop != expected_ops[idx];
         then{
             return Some(traits[idx])
         }

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -1,0 +1,116 @@
+use rustc::hir::*;
+use rustc::hir::map::*;
+use rustc::hir::intravisit::FnKind;
+use rustc::lint::*;
+use rustc::ty::TypeVariants;
+use rustc_target::spec::abi::Abi;
+use rustc_target::abi::LayoutOf;
+use syntax::ast::NodeId;
+use syntax_pos::Span;
+use crate::utils::{in_macro, is_copy, is_self, span_lint_and_sugg, snippet};
+
+/// **What it does:** Checks for functions taking arguments by reference, where
+/// the argument type is `Copy` and small enough to be more efficient to always
+/// pass by value.
+///
+/// **Why is this bad?** In many calling conventions instances of structs will
+/// be passed through registers if they fit into two or less general purpose
+/// registers.
+///
+/// **Example:**
+/// ```rust
+/// fn foo(v: &u32) {
+///     assert_eq!(v, 42);
+/// }
+/// // should be
+/// fn foo(v: u32) {
+///     assert_eq!(v, 42);
+/// }
+/// ```
+declare_clippy_lint! {
+    pub TRIVIALLY_COPY_PASS_BY_REF,
+    perf,
+    "functions taking small copyable arguments by reference"
+}
+
+pub struct TriviallyCopyPassByRef;
+
+impl LintPass for TriviallyCopyPassByRef {
+    fn get_lints(&self) -> LintArray {
+        lint_array![TRIVIALLY_COPY_PASS_BY_REF]
+    }
+}
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TriviallyCopyPassByRef {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'a, 'tcx>,
+        kind: FnKind<'tcx>,
+        decl: &'tcx FnDecl,
+        body: &'tcx Body,
+        span: Span,
+        node_id: NodeId,
+    ) {
+        if in_macro(span) {
+            return;
+        }
+
+        match kind {
+            FnKind::ItemFn(.., abi, _, attrs) => {
+                if abi != Abi::Rust {
+                    return;
+                }
+                for a in attrs {
+                    if a.meta_item_list().is_some() && a.name() == "proc_macro_derive" {
+                        return;
+                    }
+                }
+            },
+            FnKind::Method(..) => (),
+            _ => return,
+        }
+
+        // Exclude non-inherent impls
+        if let Some(NodeItem(item)) = cx.tcx.hir.find(cx.tcx.hir.get_parent_node(node_id)) {
+            if matches!(item.node, ItemImpl(_, _, _, _, Some(_), _, _) |
+                ItemTrait(..))
+            {
+                return;
+            }
+        }
+
+        let fn_def_id = cx.tcx.hir.local_def_id(node_id);
+
+        let fn_sig = cx.tcx.fn_sig(fn_def_id);
+        let fn_sig = cx.tcx.erase_late_bound_regions(&fn_sig);
+
+        for ((input, &ty), arg) in decl.inputs.iter().zip(fn_sig.inputs()).zip(&body.arguments) {
+            // All spans generated from a proc-macro invocation are the same...
+            if span == input.span {
+                return;
+            }
+
+            if_chain! {
+                if let TypeVariants::TyRef(_, ty, Mutability::MutImmutable) = ty.sty;
+                if is_copy(cx, ty);
+                if let Some(size) = cx.layout_of(ty).ok().map(|l| l.size.bytes());
+                if size < 16;
+                if let Ty_::TyRptr(_, MutTy { ty: ref decl_ty, .. }) = input.node;
+                then {
+                    let value_type = if is_self(arg) {
+                        "self".into()
+                    } else {
+                        snippet(cx, decl_ty.span, "_").into()
+                    };
+                    span_lint_and_sugg(
+                        cx,
+                        TRIVIALLY_COPY_PASS_BY_REF,
+                        input.span,
+                        "this argument is passed by reference, but would be more efficient if passed by value",
+                        "consider passing by value instead",
+                        value_type);
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1606,12 +1606,12 @@ fn node_as_const_fullint<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr)
     }
 }
 
-fn err_upcast_comparison(cx: &LateContext, span: &Span, expr: &Expr, always: bool) {
+fn err_upcast_comparison(cx: &LateContext, span: Span, expr: &Expr, always: bool) {
     if let ExprCast(ref cast_val, _) = expr.node {
         span_lint(
             cx,
             INVALID_UPCAST_COMPARISONS,
-            *span,
+            span,
             &format!(
                 "because of the numeric bounds on `{}` prior to casting, this expression is always {}",
                 snippet(cx, cast_val.span, "the expression"),
@@ -1623,7 +1623,7 @@ fn err_upcast_comparison(cx: &LateContext, span: &Span, expr: &Expr, always: boo
 
 fn upcast_comparison_bounds_err<'a, 'tcx>(
     cx: &LateContext<'a, 'tcx>,
-    span: &Span,
+    span: Span,
     rel: comparisons::Rel,
     lhs_bounds: Option<(FullInt, FullInt)>,
     lhs: &'tcx Expr,
@@ -1684,8 +1684,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidUpcastComparisons {
             let lhs_bounds = numeric_cast_precast_bounds(cx, normalized_lhs);
             let rhs_bounds = numeric_cast_precast_bounds(cx, normalized_rhs);
 
-            upcast_comparison_bounds_err(cx, &expr.span, rel, lhs_bounds, normalized_lhs, normalized_rhs, false);
-            upcast_comparison_bounds_err(cx, &expr.span, rel, rhs_bounds, normalized_rhs, normalized_lhs, true);
+            upcast_comparison_bounds_err(cx, expr.span, rel, lhs_bounds, normalized_lhs, normalized_rhs, false);
+            upcast_comparison_bounds_err(cx, expr.span, rel, rhs_bounds, normalized_rhs, normalized_lhs, true);
         }
     }
 }

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -36,12 +36,12 @@ impl LintPass for UnsafeNameRemoval {
 impl EarlyLintPass for UnsafeNameRemoval {
     fn check_item(&mut self, cx: &EarlyContext, item: &Item) {
         if let ItemKind::Use(ref use_tree) = item.node {
-            check_use_tree(use_tree, cx, &item.span);
+            check_use_tree(use_tree, cx, item.span);
         }
     }
 }
 
-fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext, span: &Span) {
+fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext, span: Span) {
     match use_tree.kind {
         UseTreeKind::Simple(Some(new_name)) => {
             let old_name = use_tree
@@ -62,14 +62,14 @@ fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext, span: &Span) {
     }
 }
 
-fn unsafe_to_safe_check(old_name: Ident, new_name: Ident, cx: &EarlyContext, span: &Span) {
+fn unsafe_to_safe_check(old_name: Ident, new_name: Ident, cx: &EarlyContext, span: Span) {
     let old_str = old_name.name.as_str();
     let new_str = new_name.name.as_str();
     if contains_unsafe(&old_str) && !contains_unsafe(&new_str) {
         span_lint(
             cx,
             UNSAFE_REMOVED_FROM_NAME,
-            *span,
+            span,
             &format!("removed \"unsafe\" from the name of `{}` in use as `{}`", old_str, new_str),
         );
     }

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -156,6 +156,8 @@ define_Conf! {
     (verbose_bit_mask_threshold, "verbose_bit_mask_threshold", 1 => u64),
     /// Lint: DECIMAL_LITERAL_REPRESENTATION. The lower bound for linting decimal literals
     (literal_representation_threshold, "literal_representation_threshold", 16384 => u64),
+    /// Lint: TRIVIALLY_COPY_PASS_BY_REF. The maximum size (in bytes) to consider a `Copy` type for passing by value instead of by reference.
+    (trivial_copy_size_limit, "trivial_copy_size_limit", None => Option<u64>),
 }
 
 /// Search for the configuration file.

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -349,7 +349,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 let c: fn(_) -> _ = ExprAgain;
                 c.hash(&mut self.s);
                 if let Some(i) = i.label {
-                    self.hash_name(&i.name);
+                    self.hash_name(i.name);
                 }
             },
             ExprYield(ref e) => {
@@ -386,7 +386,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 let c: fn(_, _) -> _ = ExprBreak;
                 c.hash(&mut self.s);
                 if let Some(i) = i.label {
-                    self.hash_name(&i.name);
+                    self.hash_name(i.name);
                 }
                 if let Some(ref j) = *j {
                     self.hash_expr(&*j);
@@ -419,7 +419,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 let c: fn(_, _) -> _ = ExprField;
                 c.hash(&mut self.s);
                 self.hash_expr(e);
-                self.hash_name(&f.name);
+                self.hash_name(f.name);
             },
             ExprIndex(ref a, ref i) => {
                 let c: fn(_, _) -> _ = ExprIndex;
@@ -450,7 +450,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 c.hash(&mut self.s);
                 self.hash_block(b);
                 if let Some(i) = *i {
-                    self.hash_name(&i.name);
+                    self.hash_name(i.name);
                 }
             },
             ExprMatch(ref e, ref arms, ref s) => {
@@ -471,7 +471,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
             ExprMethodCall(ref path, ref _tys, ref args) => {
                 let c: fn(_, _, _) -> _ = ExprMethodCall;
                 c.hash(&mut self.s);
-                self.hash_name(&path.name);
+                self.hash_name(path.name);
                 self.hash_exprs(args);
             },
             ExprRepeat(ref e, ref l_id) => {
@@ -502,7 +502,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 self.hash_qpath(path);
 
                 for f in fields {
-                    self.hash_name(&f.ident.name);
+                    self.hash_name(f.ident.name);
                     self.hash_expr(&f.expr);
                 }
 
@@ -541,7 +541,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 self.hash_expr(cond);
                 self.hash_block(b);
                 if let Some(l) = l {
-                    self.hash_name(&l.name);
+                    self.hash_name(l.name);
                 }
             },
         }
@@ -553,7 +553,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
         }
     }
 
-    pub fn hash_name(&mut self, n: &Name) {
+    pub fn hash_name(&mut self, n: Name) {
         n.as_str().hash(&mut self.s);
     }
 
@@ -563,7 +563,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 self.hash_path(path);
             },
             QPath::TypeRelative(_, ref path) => {
-                self.hash_name(&path.name);
+                self.hash_name(path.name);
             },
         }
         // self.cx.tables.qpath_def(p, id).hash(&mut self.s);
@@ -572,7 +572,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
     pub fn hash_path(&mut self, p: &Path) {
         p.is_global().hash(&mut self.s);
         for p in &p.segments {
-            self.hash_name(&p.name);
+            self.hash_name(p.name);
         }
     }
 

--- a/tests/ui-toml/toml_trivially_copy/clippy.toml
+++ b/tests/ui-toml/toml_trivially_copy/clippy.toml
@@ -1,0 +1,1 @@
+trivial-copy-size-limit = 2

--- a/tests/ui-toml/toml_trivially_copy/test.rs
+++ b/tests/ui-toml/toml_trivially_copy/test.rs
@@ -1,0 +1,19 @@
+#![allow(many_single_char_names)]
+
+#[derive(Copy, Clone)]
+struct Foo(u8);
+
+#[derive(Copy, Clone)]
+struct Bar(u32);
+
+fn good(a: &mut u32, b: u32, c: &Bar, d: &u32) {
+}
+
+fn bad(x: &u16, y: &Foo) {
+}
+
+fn main() {
+    let (mut a, b, c, d, x, y) = (0, 0, Bar(0), 0, 0, Foo(0));
+    good(&mut a, b, &c, &d);
+    bad(&x, &y);
+}

--- a/tests/ui-toml/toml_trivially_copy/test.stderr
+++ b/tests/ui-toml/toml_trivially_copy/test.stderr
@@ -1,0 +1,16 @@
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/test.rs:12:11
+   |
+12 | fn bad(x: &u16, y: &Foo) {
+   |           ^^^^ help: consider passing by value instead: `u16`
+   |
+   = note: `-D trivially-copy-pass-by-ref` implied by `-D warnings`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/test.rs:12:20
+   |
+12 | fn bad(x: &u16, y: &Foo) {
+   |                    ^^^^ help: consider passing by value instead: `Foo`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -1,4 +1,4 @@
-error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown field `foobar`, expected one of `blacklisted-names`, `cyclomatic-complexity-threshold`, `doc-valid-idents`, `too-many-arguments-threshold`, `type-complexity-threshold`, `single-char-binding-names-threshold`, `too-large-for-stack`, `enum-variant-name-threshold`, `enum-variant-size-threshold`, `verbose-bit-mask-threshold`, `literal-representation-threshold`, `third-party`
+error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown field `foobar`, expected one of `blacklisted-names`, `cyclomatic-complexity-threshold`, `doc-valid-idents`, `too-many-arguments-threshold`, `type-complexity-threshold`, `single-char-binding-names-threshold`, `too-large-for-stack`, `enum-variant-name-threshold`, `enum-variant-size-threshold`, `verbose-bit-mask-threshold`, `literal-representation-threshold`, `trivial-copy-size-limit`, `third-party`
 
 error: aborting due to previous error
 

--- a/tests/ui/clone_on_copy_mut.rs
+++ b/tests/ui/clone_on_copy_mut.rs
@@ -5,6 +5,7 @@ pub fn dec_read_dec(i: &mut i32) -> i32 {
     ret
 }
 
+#[allow(trivially_copy_pass_by_ref)]
 pub fn minus_1(i: &i32) -> i32 {
     dec_read_dec(&mut i.clone())
 }

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -1,6 +1,6 @@
 
 
-#![allow(unknown_lints, unused, no_effect, redundant_closure_call, many_single_char_names, needless_pass_by_value, option_map_unit_fn)]
+#![allow(unknown_lints, unused, no_effect, redundant_closure_call, many_single_char_names, needless_pass_by_value, option_map_unit_fn, trivially_copy_pass_by_ref)]
 #![warn(redundant_closure, needless_borrow)]
 
 fn main() {

--- a/tests/ui/infinite_iter.rs
+++ b/tests/ui/infinite_iter.rs
@@ -1,7 +1,7 @@
 #![feature(iterator_for_each)]
 
 use std::iter::repeat;
-
+#[allow(trivially_copy_pass_by_ref)]
 fn square_is_lower_64(x: &u32) -> bool { x * x < 64 }
 
 #[allow(maybe_infinite_iter)]

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -1,4 +1,4 @@
-
+#![allow(trivially_copy_pass_by_ref)]
 
 
 fn fn_val(i: i32) -> i32 { unimplemented!() }

--- a/tests/ui/lifetimes.rs
+++ b/tests/ui/lifetimes.rs
@@ -2,7 +2,7 @@
 
 
 #![warn(needless_lifetimes, extra_unused_lifetimes)]
-#![allow(dead_code, needless_pass_by_value)]
+#![allow(dead_code, needless_pass_by_value, trivially_copy_pass_by_ref)]
 
 fn distinct_lifetimes<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: u8) { }
 

--- a/tests/ui/mut_from_ref.rs
+++ b/tests/ui/mut_from_ref.rs
@@ -1,6 +1,6 @@
 
 
-#![allow(unused)]
+#![allow(unused, trivially_copy_pass_by_ref)]
 #![warn(mut_from_ref)]
 
 struct Foo;

--- a/tests/ui/mut_reference.rs
+++ b/tests/ui/mut_reference.rs
@@ -1,7 +1,7 @@
 
 
 
-#![allow(unused_variables)]
+#![allow(unused_variables, trivially_copy_pass_by_ref)]
 
 fn takes_an_immutable_reference(a: &i32) {}
 fn takes_a_mutable_reference(a: &mut i32) {}

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-
+#[allow(trivially_copy_pass_by_ref)]
 fn x(y: &i32) -> i32 {
     *y
 }

--- a/tests/ui/trivially_copy_pass_by_ref.rs
+++ b/tests/ui/trivially_copy_pass_by_ref.rs
@@ -1,0 +1,57 @@
+#![allow(many_single_char_names, blacklisted_name)]
+
+#[derive(Copy, Clone)]
+struct Foo(u32);
+
+#[derive(Copy, Clone)]
+struct Bar([u8; 24]);
+
+type Baz = u32;
+
+fn good(a: &mut u32, b: u32, c: &Bar) {
+}
+
+fn bad(x: &u32, y: &Foo, z: &Baz) {
+}
+
+impl Foo {
+    fn good(self, a: &mut u32, b: u32, c: &Bar) {
+    }
+
+    fn good2(&mut self) {
+    }
+
+    fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+    }
+
+    fn bad2(x: &u32, y: &Foo, z: &Baz) {
+    }
+}
+
+impl AsRef<u32> for Foo {
+    fn as_ref(&self) -> &u32 {
+        &self.0
+    }
+}
+
+impl Bar {
+    fn good(&self, a: &mut u32, b: u32, c: &Bar) {
+    }
+
+    fn bad2(x: &u32, y: &Foo, z: &Baz) {
+    }
+}
+
+fn main() {
+    let (mut foo, bar) = (Foo(0), Bar([0; 24]));
+    let (mut a, b, c, x, y, z) = (0, 0, Bar([0; 24]), 0, Foo(0), 0);
+    good(&mut a, b, &c);
+    bad(&x, &y, &z);
+    foo.good(&mut a, b, &c);
+    foo.good2();
+    foo.bad(&x, &y, &z);
+    Foo::bad2(&x, &y, &z);
+    bar.good(&mut a, b, &c);
+    Bar::bad2(&x, &y, &z);
+    foo.as_ref();
+}

--- a/tests/ui/trivially_copy_pass_by_ref.stderr
+++ b/tests/ui/trivially_copy_pass_by_ref.stderr
@@ -1,0 +1,82 @@
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:14:11
+   |
+14 | fn bad(x: &u32, y: &Foo, z: &Baz) {
+   |           ^^^^ help: consider passing by value instead: `u32`
+   |
+   = note: `-D trivially-copy-pass-by-ref` implied by `-D warnings`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:14:20
+   |
+14 | fn bad(x: &u32, y: &Foo, z: &Baz) {
+   |                    ^^^^ help: consider passing by value instead: `Foo`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:14:29
+   |
+14 | fn bad(x: &u32, y: &Foo, z: &Baz) {
+   |                             ^^^^ help: consider passing by value instead: `Baz`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:24:12
+   |
+24 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+   |            ^^^^^ help: consider passing by value instead: `self`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:24:22
+   |
+24 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+   |                      ^^^^ help: consider passing by value instead: `u32`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:24:31
+   |
+24 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+   |                               ^^^^ help: consider passing by value instead: `Foo`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:24:40
+   |
+24 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+   |                                        ^^^^ help: consider passing by value instead: `Baz`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:27:16
+   |
+27 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+   |                ^^^^ help: consider passing by value instead: `u32`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:27:25
+   |
+27 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+   |                         ^^^^ help: consider passing by value instead: `Foo`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:27:34
+   |
+27 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+   |                                  ^^^^ help: consider passing by value instead: `Baz`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:41:16
+   |
+41 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+   |                ^^^^ help: consider passing by value instead: `u32`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:41:25
+   |
+41 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+   |                         ^^^^ help: consider passing by value instead: `Foo`
+
+error: this argument is passed by reference, but would be more efficient if passed by value
+  --> $DIR/trivially_copy_pass_by_ref.rs:41:34
+   |
+41 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+   |                                  ^^^^ help: consider passing by value instead: `Baz`
+
+error: aborting due to 13 previous errors
+

--- a/tests/ui/unused_lt.rs
+++ b/tests/ui/unused_lt.rs
@@ -1,6 +1,6 @@
 
 
-#![allow(unused, dead_code, needless_lifetimes, needless_pass_by_value)]
+#![allow(unused, dead_code, needless_lifetimes, needless_pass_by_value, trivially_copy_pass_by_ref)]
 #![warn(extra_unused_lifetimes)]
 
 fn empty() {

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -1,5 +1,5 @@
 #![deny(useless_asref)]
-
+#![allow(trivially_copy_pass_by_ref)]
 use std::fmt::Debug;
 
 struct FakeAsRef;

--- a/tests/ui/wrong_self_convention.rs
+++ b/tests/ui/wrong_self_convention.rs
@@ -3,7 +3,7 @@
 
 #![warn(wrong_self_convention)]
 #![warn(wrong_pub_self_convention)]
-#![allow(dead_code)]
+#![allow(dead_code, trivially_copy_pass_by_ref)]
 
 fn main() {}
 


### PR DESCRIPTION
Fixes #1680

Hardcoded for 64-bit "trivial" size for now, suggestions on whether this should be target-specific/configurable/something else would be appreciated.