### PR TITLE
better parsing of condition in while loop for mutability

### DIFF
--- a/tests/run-pass/issues_loop_mut_cond.rs
+++ b/tests/run-pass/issues_loop_mut_cond.rs
@@ -1,0 +1,28 @@
+#![allow(dead_code)]
+
+/// Issue: https://github.com/rust-lang-nursery/rust-clippy/issues/2596
+pub fn loop_on_block_condition(u: &mut isize) {
+    while { *u < 0 } {
+        *u += 1;
+    }
+}
+
+/// https://github.com/rust-lang-nursery/rust-clippy/issues/2584
+fn loop_with_unsafe_condition(ptr: *const u8) {
+    let mut len = 0;
+    while unsafe { *ptr.offset(len) } != 0 {
+        len += 1;
+    }
+}
+
+/// https://github.com/rust-lang-nursery/rust-clippy/issues/2710
+static mut RUNNING: bool = true;
+fn loop_on_static_condition() {
+    unsafe {
+        while RUNNING {
+            RUNNING = false;
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
allow condition to be a block: by calling visit_expr of the visitor directly on the condition instead of walk_expr on the whole expression, we bypass the match to ExprWhile that calls visit_expr on the condition and visit_block on the body. This allow to re-enable visit_block in the visitor, as it won't be called on the while body
allow condition to use static variables: maintain a list of static variables used, and if they are mutable

fixes #2584 
fixes #2596
fixes #2710 