### PR TITLE
unreadable_literal: Fills hexadecimal values with 0 to allow better grouping

### DIFF
--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -204,10 +204,9 @@ impl<'a> DigitInfo<'a> {
                 .collect::<Vec<String>>()
                 .join("_");
             // Forces hexadecimal values to be grouped by 4 being filled with zeroes (e.g 0x00ab_cdef)
-            let nb_digits_to_fill = self.digits.len() % 4;
+            let nb_digits_to_fill = self.digits.chars().filter(|&c| c != '_').collect::<Vec<_>>().len() % 4;
             if self.radix == Radix::Hexadecimal && nb_digits_to_fill != 0 {
-                let filled_digits = format!("{:0>1$}", &hint[..nb_digits_to_fill], 4);
-                hint = format!("{}{}", filled_digits, &hint[nb_digits_to_fill..]);
+                hint = format!("{:0>4}{}", &hint[..nb_digits_to_fill], &hint[nb_digits_to_fill..]);
             }
             format!(
                 "{}{}{}",

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -193,18 +193,19 @@ impl<'a> DigitInfo<'a> {
                 self.suffix.unwrap_or("")
             )
         } else {
-            let mut hint = self.digits
+            let filtered_digits_vec = self.digits
                 .chars()
-                .rev()
                 .filter(|&c| c != '_')
-                .collect::<Vec<_>>()
+                .rev()
+                .collect::<Vec<_>>();
+            let mut hint = filtered_digits_vec
                 .chunks(group_size)
                 .map(|chunk| chunk.into_iter().rev().collect())
                 .rev()
                 .collect::<Vec<String>>()
                 .join("_");
             // Forces hexadecimal values to be grouped by 4 being filled with zeroes (e.g 0x00ab_cdef)
-            let nb_digits_to_fill = self.digits.chars().filter(|&c| c != '_').collect::<Vec<_>>().len() % 4;
+            let nb_digits_to_fill = filtered_digits_vec.len() % 4;
             if self.radix == Radix::Hexadecimal && nb_digits_to_fill != 0 {
                 hint = format!("{:0>4}{}", &hint[..nb_digits_to_fill], &hint[nb_digits_to_fill..]);
             }

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -193,7 +193,7 @@ impl<'a> DigitInfo<'a> {
                 self.suffix.unwrap_or("")
             )
         } else {
-            let hint = self.digits
+            let mut hint = self.digits
                 .chars()
                 .rev()
                 .filter(|&c| c != '_')
@@ -203,6 +203,12 @@ impl<'a> DigitInfo<'a> {
                 .rev()
                 .collect::<Vec<String>>()
                 .join("_");
+            // Forces hexadecimal values to be grouped by 4 being filled with zeroes (e.g 0x00ab_cdef)
+            let nb_digits_to_fill = self.digits.len() % 4;
+            if self.radix == Radix::Hexadecimal && nb_digits_to_fill != 0 {
+                let filled_digits = format!("{:0>1$}", &hint[..nb_digits_to_fill], 4);
+                hint = format!("{}{}", filled_digits, &hint[nb_digits_to_fill..]);
+            }
             format!(
                 "{}{}{}",
                 self.prefix.unwrap_or(""),

--- a/tests/ui/large_digit_groups.stderr
+++ b/tests/ui/large_digit_groups.stderr
@@ -10,7 +10,7 @@ error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:31
   |
 7 |     let bad = (0b1_10110_i64, 0x1_23456_78901_usize, 1_23456_f32, 1_23456.12_f32, 1_23456.12345_f32, 1_23456.12345_6_f32);
-  |                               ^^^^^^^^^^^^^^^^^^^^^ help: consider: `0x123_4567_8901_usize`
+  |                               ^^^^^^^^^^^^^^^^^^^^^ help: consider: `0x0123_4567_8901_usize`
 
 error: digit groups should be smaller
  --> $DIR/large_digit_groups.rs:7:54

--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -1,5 +1,3 @@
-
-
 #![warn(mixed_case_hex_literals)]
 #![warn(unseparated_literal_suffix)]
 #![warn(zero_prefixed_literal)]
@@ -31,4 +29,10 @@ fn main() {
 
     let ok11 = 0o123;
     let ok12 = 0b10_1010;
+
+    let ok6 = 0xab_abcd;
+    let ok7 = 0xBAFE_BAFE;
+    let fail9 = 0xabcdef;
+    let fail10 = 0xBAFEBAFE;
+    let fail11 = 0xabcdeff;
 }

--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -30,9 +30,15 @@ fn main() {
     let ok11 = 0o123;
     let ok12 = 0b10_1010;
 
-    let ok6 = 0xab_abcd;
-    let ok7 = 0xBAFE_BAFE;
+    let ok13 = 0xab_abcd;
+    let ok14 = 0xBAFE_BAFE;
+    let ok15 = 0xab_cabc_abca_bcab_cabc;
+    let ok16 = 0xFE_BAFE_ABAB_ABCD;
+    let ok17 = 0x123_4567_8901_usize;
+
     let fail9 = 0xabcdef;
     let fail10 = 0xBAFEBAFE;
     let fail11 = 0xabcdeff;
+    let fail12 = 0xabcabcabcabcabcabc;
+    let fail13 = 0x1_23456_78901_usize;
 }

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -1,90 +1,110 @@
 error: inconsistent casing in hexadecimal literal
-  --> $DIR/literals.rs:14:17
+  --> $DIR/literals.rs:12:17
    |
-14 |     let fail1 = 0xabCD;
+12 |     let fail1 = 0xabCD;
    |                 ^^^^^^
    |
    = note: `-D mixed-case-hex-literals` implied by `-D warnings`
 
 error: inconsistent casing in hexadecimal literal
-  --> $DIR/literals.rs:15:17
+  --> $DIR/literals.rs:13:17
    |
-15 |     let fail2 = 0xabCD_u32;
+13 |     let fail2 = 0xabCD_u32;
    |                 ^^^^^^^^^^
 
 error: inconsistent casing in hexadecimal literal
-  --> $DIR/literals.rs:16:17
+  --> $DIR/literals.rs:14:17
    |
-16 |     let fail2 = 0xabCD_isize;
+14 |     let fail2 = 0xabCD_isize;
    |                 ^^^^^^^^^^^^
 
 error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:17:27
+  --> $DIR/literals.rs:15:27
    |
-17 |     let fail_multi_zero = 000_123usize;
+15 |     let fail_multi_zero = 000_123usize;
    |                           ^^^^^^^^^^^^
    |
    = note: `-D unseparated-literal-suffix` implied by `-D warnings`
 
 error: this is a decimal constant
-  --> $DIR/literals.rs:17:27
+  --> $DIR/literals.rs:15:27
    |
-17 |     let fail_multi_zero = 000_123usize;
+15 |     let fail_multi_zero = 000_123usize;
    |                           ^^^^^^^^^^^^
    |
    = note: `-D zero-prefixed-literal` implied by `-D warnings`
 help: if you mean to use a decimal constant, remove the `0` to remove confusion
    |
-17 |     let fail_multi_zero = 123usize;
+15 |     let fail_multi_zero = 123usize;
    |                           ^^^^^^^^
 help: if you mean to use an octal constant, use `0o`
    |
-17 |     let fail_multi_zero = 0o123usize;
+15 |     let fail_multi_zero = 0o123usize;
    |                           ^^^^^^^^^^
+
+error: integer type suffix should be separated by an underscore
+  --> $DIR/literals.rs:20:17
+   |
+20 |     let fail3 = 1234i32;
+   |                 ^^^^^^^
+
+error: integer type suffix should be separated by an underscore
+  --> $DIR/literals.rs:21:17
+   |
+21 |     let fail4 = 1234u32;
+   |                 ^^^^^^^
 
 error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:22:17
    |
-22 |     let fail3 = 1234i32;
-   |                 ^^^^^^^
+22 |     let fail5 = 1234isize;
+   |                 ^^^^^^^^^
 
 error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:23:17
    |
-23 |     let fail4 = 1234u32;
-   |                 ^^^^^^^
-
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:24:17
-   |
-24 |     let fail5 = 1234isize;
-   |                 ^^^^^^^^^
-
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:25:17
-   |
-25 |     let fail6 = 1234usize;
+23 |     let fail6 = 1234usize;
    |                 ^^^^^^^^^
 
 error: float type suffix should be separated by an underscore
-  --> $DIR/literals.rs:26:17
+  --> $DIR/literals.rs:24:17
    |
-26 |     let fail7 = 1.5f32;
+24 |     let fail7 = 1.5f32;
    |                 ^^^^^^
 
 error: this is a decimal constant
-  --> $DIR/literals.rs:30:17
+  --> $DIR/literals.rs:28:17
    |
-30 |     let fail8 = 0123;
+28 |     let fail8 = 0123;
    |                 ^^^^
 help: if you mean to use a decimal constant, remove the `0` to remove confusion
    |
-30 |     let fail8 = 123;
+28 |     let fail8 = 123;
    |                 ^^^
 help: if you mean to use an octal constant, use `0o`
    |
-30 |     let fail8 = 0o123;
+28 |     let fail8 = 0o123;
    |                 ^^^^^
 
-error: aborting due to 11 previous errors
+error: long literal lacking separators
+  --> $DIR/literals.rs:35:17
+   |
+35 |     let fail9 = 0xabcdef;
+   |                 ^^^^^^^^ help: consider: `0x00ab_cdef`
+   |
+   = note: `-D unreadable-literal` implied by `-D warnings`
+
+error: long literal lacking separators
+  --> $DIR/literals.rs:36:18
+   |
+36 |     let fail10 = 0xBAFEBAFE;
+   |                  ^^^^^^^^^^ help: consider: `0xBAFE_BAFE`
+
+error: long literal lacking separators
+  --> $DIR/literals.rs:37:18
+   |
+37 |     let fail11 = 0xabcdeff;
+   |                  ^^^^^^^^^ help: consider: `0x0abc_deff`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -87,24 +87,38 @@ help: if you mean to use an octal constant, use `0o`
    |                 ^^^^^
 
 error: long literal lacking separators
-  --> $DIR/literals.rs:35:17
+  --> $DIR/literals.rs:39:17
    |
-35 |     let fail9 = 0xabcdef;
+39 |     let fail9 = 0xabcdef;
    |                 ^^^^^^^^ help: consider: `0x00ab_cdef`
    |
    = note: `-D unreadable-literal` implied by `-D warnings`
 
 error: long literal lacking separators
-  --> $DIR/literals.rs:36:18
+  --> $DIR/literals.rs:40:18
    |
-36 |     let fail10 = 0xBAFEBAFE;
+40 |     let fail10 = 0xBAFEBAFE;
    |                  ^^^^^^^^^^ help: consider: `0xBAFE_BAFE`
 
 error: long literal lacking separators
-  --> $DIR/literals.rs:37:18
+  --> $DIR/literals.rs:41:18
    |
-37 |     let fail11 = 0xabcdeff;
+41 |     let fail11 = 0xabcdeff;
    |                  ^^^^^^^^^ help: consider: `0x0abc_deff`
 
-error: aborting due to 14 previous errors
+error: long literal lacking separators
+  --> $DIR/literals.rs:42:18
+   |
+42 |     let fail12 = 0xabcabcabcabcabcabc;
+   |                  ^^^^^^^^^^^^^^^^^^^^ help: consider: `0x00ab_cabc_abca_bcab_cabc`
+
+error: digit groups should be smaller
+  --> $DIR/literals.rs:43:18
+   |
+43 |     let fail13 = 0x1_23456_78901_usize;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ help: consider: `0x0123_4567_8901_usize`
+   |
+   = note: `-D large-digit-groups` implied by `-D warnings`
+
+error: aborting due to 16 previous errors
 

--- a/tests/ui/unreadable_literal.stderr
+++ b/tests/ui/unreadable_literal.stderr
@@ -10,7 +10,7 @@ error: long literal lacking separators
  --> $DIR/unreadable_literal.rs:7:30
   |
 7 |     let bad = (0b110110_i64, 0x12345678901_usize, 123456_f32, 1.234567_f32);
-  |                              ^^^^^^^^^^^^^^^^^^^ help: consider: `0x123_4567_8901_usize`
+  |                              ^^^^^^^^^^^^^^^^^^^ help: consider: `0x0123_4567_8901_usize`
 
 error: long literal lacking separators
  --> $DIR/unreadable_literal.rs:7:51


### PR DESCRIPTION
Fixes #2300 