### PR TITLE
WIP: Add lint on cast Fn to all numerical except usize.

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -673,6 +673,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         types::UNIT_ARG,
         types::UNIT_CMP,
         types::UNNECESSARY_CAST,
+        types::FN_TO_NUMERIC_CAST,
         unicode::ZERO_WIDTH_SPACE,
         unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME,
         unused_io_amount::UNUSED_IO_AMOUNT,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -679,9 +679,9 @@ declare_clippy_lint! {
     "cast to the same type, e.g. `x as i32` where `x: i32`"
 }
 
-/// **What it does:** Checks for casts function pointer to the numeric type.
+/// **What it does:** Checks for casts of a function pointer to a numeric type except `usize`.
 ///
-/// **Why is this bad?** Cast pointer not to usize truncate value.
+/// **Why is this bad?** Casting a function pointer to something other than `usize` could truncate the address value.
 ///
 /// **Known problems:** None.
 ///
@@ -1003,8 +1003,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                             FN_TO_NUMERIC_CAST,
                             expr.span,
                             &format!("casting a `{}` to `{}` may truncate the function address value.", cast_from, cast_to),
-                            //   &format!("if you need address of function, use cast zz `usize`:"),
-                            &format!("if you need the address of the function, z consider:"),
+                            "if you need the address of the function, consider :",
                             format!("{} as usize", &snippet(cx, ex.span, "x"))
                         );
                     }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1003,7 +1003,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                             FN_TO_NUMERIC_CAST,
                             expr.span,
                             &format!("casting a `{}` to `{}` may truncate the function address value.", cast_from, cast_to),
-                            "if you need the address of the function, consider :",
+                            "if you need the address of the function, consider",
                             format!("{} as usize", &snippet(cx, ex.span, "x"))
                         );
                     }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1002,8 +1002,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                             cx,
                             FN_TO_NUMERIC_CAST,
                             expr.span,
-                            &format!("casting a Fn to {} may truncate the function address value.", cast_to),
-                            "if you need address of function, use cast to `usize` instead:",
+                            &format!("casting a `{}` to `{}` may truncate the function address value.", cast_from, cast_to),
+                            //   &format!("if you need address of function, use cast zz `usize`:"),
+                            &format!("if you need the address of the function, z consider:"),
                             format!("{} as usize", &snippet(cx, ex.span, "x"))
                         );
                     }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -679,9 +679,9 @@ declare_clippy_lint! {
     "cast to the same type, e.g. `x as i32` where `x: i32`"
 }
 
-/// **What it does:** Checks for casts of a function pointer to a numeric type except `usize`.
+/// **What it does:** Checks for casts of a function pointer to a numeric type not enough to store address.
 ///
-/// **Why is this bad?** Casting a function pointer to something other than `usize` could truncate the address value.
+/// **Why is this bad?** Casting a function pointer to not eligable type could truncate the address value.
 ///
 /// **Known problems:** None.
 ///
@@ -691,8 +691,25 @@ declare_clippy_lint! {
 /// let _ = test_fn as i32
 /// ```
 declare_clippy_lint! {
-    pub FN_TO_NUMERIC_CAST,
+    pub FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
     correctness,
+    "cast function pointer to the numeric type with value truncation"
+}
+
+/// **What it does:** Checks for casts of a function pointer to a numeric type except `usize`.
+///
+/// **Why is this bad?** Casting a function pointer to something other than `usize` is not a good style.
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// fn test_fn() -> i16;
+/// let _ = test_fn as i128
+/// ```
+declare_clippy_lint! {
+    pub FN_TO_NUMERIC_CAST,
+    style,
     "cast function pointer to the numeric type"
 }
 
@@ -909,7 +926,8 @@ impl LintPass for CastPass {
             CAST_LOSSLESS,
             UNNECESSARY_CAST,
             CAST_PTR_ALIGNMENT,
-            FN_TO_NUMERIC_CAST
+            FN_TO_NUMERIC_CAST,
+            FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
         )
     }
 }
@@ -998,14 +1016,28 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                 ty::TyFnDef(..) |
                 ty::TyFnPtr(..) => {
                     if cast_to.is_numeric() && cast_to.sty != ty::TyUint(UintTy::Usize){
-                        span_lint_and_sugg(
-                            cx,
-                            FN_TO_NUMERIC_CAST,
-                            expr.span,
-                            &format!("casting a `{}` to `{}` may truncate the function address value.", cast_from, cast_to),
-                            "if you need the address of the function, consider",
-                            format!("{} as usize", &snippet(cx, ex.span, "x"))
-                        );
+                        let to_nbits = int_ty_to_nbits(cast_to, cx.tcx);
+                        let pointer_nbits = cx.tcx.data_layout.pointer_size.bits();
+                        if to_nbits < pointer_nbits || (to_nbits == pointer_nbits && cast_to.is_signed()) {
+                            span_lint_and_sugg(
+                                cx,
+                                FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
+                                expr.span,
+                                &format!("casting a `{}` to `{}` may truncate the function address value.", cast_from, cast_to),
+                                "if you need the address of the function, consider",
+                                format!("{} as usize", &snippet(cx, ex.span, "x"))
+                            );
+                        } else {
+                            span_lint_and_sugg(
+                                cx,
+                                FN_TO_NUMERIC_CAST,
+                                expr.span,
+                                &format!("casting a `{}` to `{}` is bad style.", cast_from, cast_to),
+                                "if you need the address of the function, consider",
+                                format!("{} as usize", &snippet(cx, ex.span, "x"))
+                            );
+
+                        };
                     }
                 }
                 _ => ()

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -975,6 +975,22 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                     },
                 }
             }
+
+            match &cast_from.sty {
+                ty::TyFnDef(..) |
+                ty::TyFnPtr(..) => {
+                    if cast_to.is_numeric() && cast_to.sty != ty::TyUint(UintTy::Usize){
+                        span_lint(
+                            cx,
+                            UNNECESSARY_CAST,
+                            expr.span,
+                            "casting Fn not to usize may truncate the value",
+                        );
+                    }
+                }
+                _ => ()
+            }
+
             if_chain!{
                 if let ty::TyRawPtr(from_ptr_ty) = &cast_from.sty;
                 if let ty::TyRawPtr(to_ptr_ty) = &cast_to.sty;

--- a/tests/ui/types_fn_to_int.rs
+++ b/tests/ui/types_fn_to_int.rs
@@ -10,6 +10,7 @@ fn bar() -> i32 {
 fn main() {
     let x = Foo::A;
     let y = x as i32;
+    let y1 = Foo::A as i32;
 
     let z = bar as u32;
 }

--- a/tests/ui/types_fn_to_int.rs
+++ b/tests/ui/types_fn_to_int.rs
@@ -9,8 +9,14 @@ fn bar() -> i32 {
 
 fn main() {
     let x = Foo::A;
-    let y = x as i32;
-    let y1 = Foo::A as i32;
-
-    let z = bar as u32;
+    let _y = x as i32;
+    let _y1 = Foo::A as i32;
+    let _y = x as u32;
+    let _z = bar as u32;
+    let _y = bar as i64;
+    let _y = bar as u64;
+    let _z = Foo::A as i128;
+    let _z = Foo::A as u128;
+    let _z = bar as i128;
+    let _z = bar as u128;
 }

--- a/tests/ui/types_fn_to_int.rs
+++ b/tests/ui/types_fn_to_int.rs
@@ -1,4 +1,3 @@
-#![feature(tool_attributes)]
 enum Foo {
     A(usize),
     B

--- a/tests/ui/types_fn_to_int.rs
+++ b/tests/ui/types_fn_to_int.rs
@@ -3,7 +3,16 @@ enum Foo {
     B
 }
 
+fn bar() -> i32 {
+    0i32
+}
+
 fn main() {
     let x = Foo::A;
     let y = x as i32;
+
+    let z = bar as u32;
+
+    //let c = || {0i32};
+    //let ac = c as u32;
 }

--- a/tests/ui/types_fn_to_int.rs
+++ b/tests/ui/types_fn_to_int.rs
@@ -1,0 +1,10 @@
+#![feature(tool_attributes)]
+enum Foo {
+    A(usize),
+    B
+}
+
+fn main() {
+    let x = Foo::A;
+    let y = x as i32;
+}

--- a/tests/ui/types_fn_to_int.rs
+++ b/tests/ui/types_fn_to_int.rs
@@ -12,7 +12,4 @@ fn main() {
     let y = x as i32;
 
     let z = bar as u32;
-
-    //let c = || {0i32};
-    //let ac = c as u32;
 }

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -1,0 +1,10 @@
+error: casting Fn not to usize may truncate the value
+ --> $DIR/types_fn_to_int.rs:9:13
+  |
+9 |     let y = x as i32;
+  |             ^^^^^^^^
+  |
+  = note: `-D unnecessary-cast` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -6,11 +6,17 @@ error: casting a `fn(usize) -> Foo {Foo::A}` to `i32` may truncate the function 
    |
    = note: #[deny(fn_to_numeric_cast)] on by default
 
-error: casting a `fn() -> i32 {bar}` to `u32` may truncate the function address value.
-  --> $DIR/types_fn_to_int.rs:14:13
+error: casting a `fn(usize) -> Foo {Foo::A}` to `i32` may truncate the function address value.
+  --> $DIR/types_fn_to_int.rs:13:14
    |
-14 |     let z = bar as u32;
+13 |     let y1 = Foo::A as i32;
+   |              ^^^^^^^^^^^^^ help: if you need the address of the function, consider: `Foo::A as usize`
+
+error: casting a `fn() -> i32 {bar}` to `u32` may truncate the function address value.
+  --> $DIR/types_fn_to_int.rs:15:13
+   |
+15 |     let z = bar as u32;
    |             ^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -1,10 +1,14 @@
-error: casting Fn not to usize may truncate the value
+error: casting a Fn to i32 may truncate the function address value.
  --> $DIR/types_fn_to_int.rs:8:13
   |
 8 |     let y = x as i32;
   |             ^^^^^^^^
   |
-  = note: `-D unnecessary-cast` implied by `-D warnings`
+  = note: #[deny(fn_to_numeric_cast)] on by default
+help: if you need address of function, use cast to `usize` instead:
+  |
+8 |     let y = x as usize;
+  |             ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -1,7 +1,7 @@
 error: casting Fn not to usize may truncate the value
- --> $DIR/types_fn_to_int.rs:9:13
+ --> $DIR/types_fn_to_int.rs:8:13
   |
-9 |     let y = x as i32;
+8 |     let y = x as i32;
   |             ^^^^^^^^
   |
   = note: `-D unnecessary-cast` implied by `-D warnings`

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -2,23 +2,15 @@ error: casting a `fn(usize) -> Foo {Foo::A}` to `i32` may truncate the function 
   --> $DIR/types_fn_to_int.rs:12:13
    |
 12 |     let y = x as i32;
-   |             ^^^^^^^^
+   |             ^^^^^^^^ help: if you need the address of the function, consider: `x as usize`
    |
    = note: #[deny(fn_to_numeric_cast)] on by default
-help: if you need the address of the function, consider :
-   |
-12 |     let y = x as usize;
-   |             ^^^^^^^^^^
 
 error: casting a `fn() -> i32 {bar}` to `u32` may truncate the function address value.
   --> $DIR/types_fn_to_int.rs:14:13
    |
 14 |     let z = bar as u32;
-   |             ^^^^^^^^^^
-help: if you need the address of the function, consider :
-   |
-14 |     let z = bar as usize;
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -1,22 +1,66 @@
 error: casting a `fn(usize) -> Foo {Foo::A}` to `i32` may truncate the function address value.
-  --> $DIR/types_fn_to_int.rs:12:13
+  --> $DIR/types_fn_to_int.rs:12:14
    |
-12 |     let y = x as i32;
-   |             ^^^^^^^^ help: if you need the address of the function, consider: `x as usize`
+12 |     let _y = x as i32;
+   |              ^^^^^^^^ help: if you need the address of the function, consider: `x as usize`
    |
-   = note: #[deny(fn_to_numeric_cast)] on by default
+   = note: #[deny(fn_to_numeric_cast_with_truncation)] on by default
 
 error: casting a `fn(usize) -> Foo {Foo::A}` to `i32` may truncate the function address value.
-  --> $DIR/types_fn_to_int.rs:13:14
+  --> $DIR/types_fn_to_int.rs:13:15
    |
-13 |     let y1 = Foo::A as i32;
-   |              ^^^^^^^^^^^^^ help: if you need the address of the function, consider: `Foo::A as usize`
+13 |     let _y1 = Foo::A as i32;
+   |               ^^^^^^^^^^^^^ help: if you need the address of the function, consider: `Foo::A as usize`
+
+error: casting a `fn(usize) -> Foo {Foo::A}` to `u32` may truncate the function address value.
+  --> $DIR/types_fn_to_int.rs:14:14
+   |
+14 |     let _y = x as u32;
+   |              ^^^^^^^^ help: if you need the address of the function, consider: `x as usize`
 
 error: casting a `fn() -> i32 {bar}` to `u32` may truncate the function address value.
-  --> $DIR/types_fn_to_int.rs:15:13
+  --> $DIR/types_fn_to_int.rs:15:14
    |
-15 |     let z = bar as u32;
-   |             ^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
+15 |     let _z = bar as u32;
+   |              ^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
 
-error: aborting due to 3 previous errors
+error: casting a `fn() -> i32 {bar}` to `i64` may truncate the function address value.
+  --> $DIR/types_fn_to_int.rs:16:14
+   |
+16 |     let _y = bar as i64;
+   |              ^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
+
+error: casting a `fn() -> i32 {bar}` to `u64` is bad style.
+  --> $DIR/types_fn_to_int.rs:17:14
+   |
+17 |     let _y = bar as u64;
+   |              ^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
+   |
+   = note: `-D fn-to-numeric-cast` implied by `-D warnings`
+
+error: casting a `fn(usize) -> Foo {Foo::A}` to `i128` is bad style.
+  --> $DIR/types_fn_to_int.rs:18:14
+   |
+18 |     let _z = Foo::A as i128;
+   |              ^^^^^^^^^^^^^^ help: if you need the address of the function, consider: `Foo::A as usize`
+
+error: casting a `fn(usize) -> Foo {Foo::A}` to `u128` is bad style.
+  --> $DIR/types_fn_to_int.rs:19:14
+   |
+19 |     let _z = Foo::A as u128;
+   |              ^^^^^^^^^^^^^^ help: if you need the address of the function, consider: `Foo::A as usize`
+
+error: casting a `fn() -> i32 {bar}` to `i128` is bad style.
+  --> $DIR/types_fn_to_int.rs:20:14
+   |
+20 |     let _z = bar as i128;
+   |              ^^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
+
+error: casting a `fn() -> i32 {bar}` to `u128` is bad style.
+  --> $DIR/types_fn_to_int.rs:21:14
+   |
+21 |     let _z = bar as u128;
+   |              ^^^^^^^^^^^ help: if you need the address of the function, consider: `bar as usize`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/types_fn_to_int.stderr
+++ b/tests/ui/types_fn_to_int.stderr
@@ -1,14 +1,24 @@
-error: casting a Fn to i32 may truncate the function address value.
- --> $DIR/types_fn_to_int.rs:8:13
-  |
-8 |     let y = x as i32;
-  |             ^^^^^^^^
-  |
-  = note: #[deny(fn_to_numeric_cast)] on by default
-help: if you need address of function, use cast to `usize` instead:
-  |
-8 |     let y = x as usize;
-  |             ^^^^^^^^^^
+error: casting a `fn(usize) -> Foo {Foo::A}` to `i32` may truncate the function address value.
+  --> $DIR/types_fn_to_int.rs:12:13
+   |
+12 |     let y = x as i32;
+   |             ^^^^^^^^
+   |
+   = note: #[deny(fn_to_numeric_cast)] on by default
+help: if you need the address of the function, consider :
+   |
+12 |     let y = x as usize;
+   |             ^^^^^^^^^^
 
-error: aborting due to previous error
+error: casting a `fn() -> i32 {bar}` to `u32` may truncate the function address value.
+  --> $DIR/types_fn_to_int.rs:14:13
+   |
+14 |     let z = bar as u32;
+   |             ^^^^^^^^^^
+help: if you need the address of the function, consider :
+   |
+14 |     let z = bar as usize;
+   |             ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This is should fix #2588. But I'm novice here and not sure is it OK.

First of all - should I add some new lint type or can use UNNECESSARY_CAST for example? Is this lint message correct?

Also I have been trying to add more specific message for casting Enum constructor to int but I can't find a way to check is 'cast_from' function returns Enum variant. May be it's unnecessary?

Thanks for review.