### PR TITLE
avoid op-ref in macros

### DIFF
--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -53,7 +53,10 @@ impl LintPass for EqOp {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprBinary(ref op, ref left, ref right) = e.node {
-            if is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) && !in_macro(e.span) {
+            if in_macro(e.span) {
+                return;
+            }
+            if is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) {
                 span_lint(
                     cx,
                     EQ_OP,


### PR DESCRIPTION
Avoid running op-ref inspection in macros since the macro
may be invoked in many different types of contexts.

Solves #2818 and incidentally avoids #2689.