### PR TITLE
Rust 2018 migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [package]
 name = "clippy"
 version = "0.0.205"
@@ -15,6 +17,7 @@ license = "MPL-2.0"
 keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
 build = "build.rs"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/rust-clippy" }

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -1,5 +1,5 @@
 set -x
-cargo install --force
+cargo install --force --path .
 
 echo "Running integration test for crate ${INTEGRATION}"
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [package]
 name = "clippy_lints"
 # begin automatic update
@@ -14,6 +16,7 @@ repository = "https://github.com/rust-lang-nursery/rust-clippy"
 readme = "README.md"
 license = "MPL-2.0"
 keywords = ["clippy", "lint", "plugin"]
+edition = "2018"
 
 [dependencies]
 cargo_metadata = "0.5"

--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -3,7 +3,7 @@ use rustc::lint::*;
 use std::f64::consts as f64;
 use syntax::ast::{FloatTy, Lit, LitKind};
 use syntax::symbol;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for floating point literals that approximate
 /// constants which are defined in

--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -1,7 +1,7 @@
 use rustc::hir;
 use rustc::lint::*;
 use syntax::codemap::Span;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for plain integer arithmetic.
 ///

--- a/clippy_lints/src/array_indexing.rs
+++ b/clippy_lints/src/array_indexing.rs
@@ -1,10 +1,10 @@
-use consts::{constant, Constant};
+use crate::consts::{constant, Constant};
 use rustc::hir;
 use rustc::lint::*;
 use rustc::ty;
 use syntax::ast::RangeLimits;
-use utils::higher::Range;
-use utils::{self, higher};
+use crate::utils::higher::Range;
+use crate::utils::{self, higher};
 
 /// **What it does:** Checks for out of bounds array indexing with a constant
 /// index.

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -2,8 +2,8 @@ use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::*;
 use syntax::ast;
-use utils::{get_trait_def_id, implements_trait, snippet_opt, span_lint_and_then, SpanlessEq};
-use utils::{higher, sugg};
+use crate::utils::{get_trait_def_id, implements_trait, snippet_opt, span_lint_and_then, SpanlessEq};
+use crate::utils::{higher, sugg};
 
 /// **What it does:** Checks for compound assignment operations (`+=` and
 /// similar).
@@ -145,7 +145,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssignOps {
                              $($trait_name:ident:$full_trait_name:ident),+) => {
                                 match $op {
                                     $(hir::$full_trait_name => {
-                                        let [krate, module] = ::utils::paths::OPS_MODULE;
+                                        let [krate, module] = crate::utils::paths::OPS_MODULE;
                                         let path = [krate, module, concat!(stringify!($trait_name), "Assign")];
                                         let trait_id = if let Some(trait_id) = get_trait_def_id($cx, &path) {
                                             trait_id

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -1,13 +1,13 @@
 //! checks for attributes
 
-use reexport::*;
+use crate::reexport::*;
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::ty::{self, TyCtxt};
 use semver::Version;
 use syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem, NestedMetaItemKind};
 use syntax::codemap::Span;
-use utils::{
+use crate::utils::{
     in_macro, last_line_of_span, match_def_path, opt_def_id, paths, snippet_opt, span_lint, span_lint_and_then,
     without_block_comments,
 };

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -2,9 +2,9 @@ use rustc::hir::*;
 use rustc::lint::*;
 use syntax::ast::LitKind;
 use syntax::codemap::Span;
-use utils::{span_lint, span_lint_and_then};
-use utils::sugg::Sugg;
-use consts::{constant, Constant};
+use crate::utils::{span_lint, span_lint_and_then};
+use crate::utils::sugg::Sugg;
+use crate::consts::{constant, Constant};
 
 /// **What it does:** Checks for incompatible bit masks in comparisons.
 ///

--- a/clippy_lints/src/blacklisted_name.rs
+++ b/clippy_lints/src/blacklisted_name.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for usage of blacklisted names for variables, such
 /// as `foo`.

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -1,7 +1,7 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use utils::*;
+use crate::utils::*;
 
 /// **What it does:** Checks for `if` conditions that use blocks to contain an
 /// expression.

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -4,7 +4,7 @@ use rustc::hir::intravisit::*;
 use syntax::ast::{LitKind, NodeId, DUMMY_NODE_ID};
 use syntax::codemap::{dummy_spanned, Span, DUMMY_SP};
 use syntax::util::ThinVec;
-use utils::{in_macro, paths, match_type, snippet_opt, span_lint_and_then, SpanlessEq};
+use crate::utils::{in_macro, paths, match_type, snippet_opt, span_lint_and_then, SpanlessEq};
 
 /// **What it does:** Checks for boolean expressions that can be written more
 /// concisely.

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -2,7 +2,7 @@ use rustc::hir::*;
 use rustc::lint::*;
 use rustc::ty;
 use syntax::ast::{Name, UintTy};
-use utils::{contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg,
+use crate::utils::{contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg,
             walk_ptrs_ty};
 
 /// **What it does:** Checks for naive byte counts

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -15,8 +15,8 @@
 use rustc::lint::*;
 use syntax::ast;
 
-use utils::{in_macro, snippet_block, span_lint_and_sugg, span_lint_and_then};
-use utils::sugg::Sugg;
+use crate::utils::{in_macro, snippet_block, span_lint_and_sugg, span_lint_and_then};
+use crate::utils::sugg::Sugg;
 
 /// **What it does:** Checks for nested `if` statements which can be collapsed
 /// by `&&`-combining their conditions and for `else { if ... }` expressions

--- a/clippy_lints/src/const_static_lifetime.rs
+++ b/clippy_lints/src/const_static_lifetime.rs
@@ -1,6 +1,6 @@
 use syntax::ast::*;
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use utils::{in_macro, snippet, span_lint_and_then};
+use crate::utils::{in_macro, snippet, span_lint_and_then};
 
 /// **What it does:** Checks for constants with an explicit `'static` lifetime.
 ///

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use syntax::ast::{FloatTy, LitKind};
 use syntax::ptr::P;
 use rustc::middle::const_val::ConstVal;
-use utils::{sext, unsext, clip};
+use crate::utils::{sext, unsext, clip};
 
 #[derive(Debug, Copy, Clone)]
 pub enum FloatWidth {

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use syntax::symbol::LocalInternedString;
 use syntax::util::small_vector::SmallVector;
-use utils::{SpanlessEq, SpanlessHash};
-use utils::{get_parent_expr, in_macro, snippet, span_lint_and_then, span_note_and_lint};
+use crate::utils::{SpanlessEq, SpanlessHash};
+use crate::utils::{get_parent_expr, in_macro, snippet, span_lint_and_then, span_note_and_lint};
 
 /// **What it does:** Checks for consecutive `if`s with the same condition.
 ///

--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -8,7 +8,7 @@ use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use syntax::ast::{Attribute, NodeId};
 use syntax::codemap::Span;
 
-use utils::{in_macro, is_allowed, match_type, paths, span_help_and_lint, LimitStack};
+use crate::utils::{in_macro, is_allowed, match_type, paths, span_help_and_lint, LimitStack};
 
 /// **What it does:** Checks for methods with high cyclomatic complexity.
 ///

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -2,8 +2,8 @@ use rustc::lint::*;
 use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use syntax::codemap::Span;
-use utils::paths;
-use utils::{is_automatically_derived, is_copy, match_path, span_lint_and_then};
+use crate::utils::paths;
+use crate::utils::{is_automatically_derived, is_copy, match_path, span_lint_and_then};
 
 /// **What it does:** Checks for deriving `Hash` but implementing `PartialEq`
 /// explicitly or vice versa.

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -4,7 +4,7 @@ use rustc::lint::*;
 use syntax::ast;
 use syntax::codemap::{BytePos, Span};
 use syntax_pos::Pos;
-use utils::span_lint;
+use crate::utils::span_lint;
 use url::Url;
 
 /// **What it does:** Checks for the presence of `_`, `::` or camel-case words

--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -4,7 +4,7 @@ use rustc::hir::*;
 use rustc::lint::*;
 use syntax::codemap::Span;
 
-use utils::{snippet, span_lint_and_sugg, SpanlessEq};
+use crate::utils::{snippet, span_lint_and_sugg, SpanlessEq};
 
 /// **What it does:** Checks for double comparions that could be simpified to a single expression.
 ///

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::ty;
 use rustc::hir::*;
-use utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};
+use crate::utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};
 
 /// **What it does:** Checks for calls to `std::mem::drop` with a reference
 /// instead of an owned value.

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -3,7 +3,7 @@
 use rustc::lint::*;
 use syntax::ast::*;
 
-use utils::{in_external_macro, span_lint_and_sugg};
+use crate::utils::{in_external_macro, span_lint_and_sugg};
 
 /// **What it does:** Checks for usage of if expressions with an `else if` branch,
 /// but without a final `else` branch.

--- a/clippy_lints/src/empty_enum.rs
+++ b/clippy_lints/src/empty_enum.rs
@@ -2,7 +2,7 @@
 
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::span_lint_and_then;
+use crate::utils::span_lint_and_then;
 
 /// **What it does:** Checks for `enum`s with no variants.
 ///

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -2,8 +2,8 @@ use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::*;
 use syntax::codemap::Span;
-use utils::SpanlessEq;
-use utils::{get_item_name, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty};
+use crate::utils::SpanlessEq;
+use crate::utils::{get_item_name, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty};
 
 /// **What it does:** Checks for uses of `contains_key` + `insert` on `HashMap`
 /// or `BTreeMap`.

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -6,8 +6,8 @@ use rustc::hir::*;
 use rustc::ty;
 use rustc::ty::subst::Substs;
 use syntax::ast::{IntTy, UintTy};
-use utils::span_lint;
-use consts::{Constant, miri_to_const};
+use crate::utils::span_lint;
+use crate::consts::{Constant, miri_to_const};
 use rustc::ty::util::IntTypeExt;
 use rustc::mir::interpret::GlobalId;
 

--- a/clippy_lints/src/enum_glob_use.rs
+++ b/clippy_lints/src/enum_glob_use.rs
@@ -5,7 +5,7 @@ use rustc::hir::def::Def;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use syntax::ast::NodeId;
 use syntax::codemap::Span;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for `use Enum::*`.
 ///

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -4,8 +4,8 @@ use rustc::lint::*;
 use syntax::ast::*;
 use syntax::codemap::Span;
 use syntax::symbol::LocalInternedString;
-use utils::{span_help_and_lint, span_lint};
-use utils::{camel_case_from, camel_case_until, in_macro};
+use crate::utils::{span_help_and_lint, span_lint};
+use crate::utils::{camel_case_from, camel_case_until, in_macro};
 
 /// **What it does:** Detects enumeration variants that are prefixed or suffixed
 /// by the same characters.

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -1,6 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
-use utils::{in_macro, implements_trait, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq};
+use crate::utils::{in_macro, implements_trait, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq};
 
 /// **What it does:** Checks for equal operands to comparison, logical and
 /// bitwise, difference and division binary operators (`==`, `>`, etc., `&&`,

--- a/clippy_lints/src/erasing_op.rs
+++ b/clippy_lints/src/erasing_op.rs
@@ -1,8 +1,8 @@
-use consts::{constant_simple, Constant};
+use crate::consts::{constant_simple, Constant};
 use rustc::hir::*;
 use rustc::lint::*;
 use syntax::codemap::Span;
-use utils::{in_macro, span_lint};
+use crate::utils::{in_macro, span_lint};
 
 /// **What it does:** Checks for erasing operations, e.g. `x * 0`.
 ///

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -9,7 +9,7 @@ use rustc::ty::layout::LayoutOf;
 use rustc::util::nodemap::NodeSet;
 use syntax::ast::NodeId;
 use syntax::codemap::Span;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 pub struct Pass {
     pub too_large_for_stack: u64,

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::ty;
 use rustc::hir::*;
-use utils::{is_adjusted, iter_input_pats, snippet_opt, span_lint_and_then};
+use crate::utils::{is_adjusted, iter_input_pats, snippet_opt, span_lint_and_then};
 
 #[allow(missing_copy_implementations)]
 pub struct EtaPass;

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -3,7 +3,7 @@ use rustc::hir::*;
 use rustc::ty;
 use rustc::lint::*;
 use syntax::ast;
-use utils::{get_parent_expr, span_lint, span_note_and_lint};
+use crate::utils::{get_parent_expr, span_lint, span_note_and_lint};
 
 /// **What it does:** Checks for a read and a write to the same variable where
 /// whether the read occurs before or after the write depends on the evaluation

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -6,7 +6,7 @@ use std::f64;
 use std::fmt;
 use syntax::ast::*;
 use syntax_pos::symbol::Symbol;
-use utils::span_lint_and_sugg;
+use crate::utils::span_lint_and_sugg;
 
 /// **What it does:** Checks for float literals with a precision greater
 /// than that supported by the underlying type

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -1,7 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
-use utils::{is_expn_of, match_def_path, resolve_node, span_lint};
-use utils::opt_def_id;
+use crate::utils::{is_expn_of, match_def_path, resolve_node, span_lint};
+use crate::utils::opt_def_id;
 
 /// **What it does:** Checks for usage of `write!()` / `writeln()!` which can be
 /// replaced with `(e)print!()` / `(e)println!()`

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -2,8 +2,8 @@ use rustc::lint::*;
 use rustc::hir;
 use rustc::ty;
 use syntax_pos::Span;
-use utils::{match_def_path, method_chain_args, span_lint_and_then, walk_ptrs_ty, is_expn_of};
-use utils::paths::{BEGIN_PANIC, BEGIN_PANIC_FMT, FROM_TRAIT, OPTION, RESULT};
+use crate::utils::{match_def_path, method_chain_args, span_lint_and_then, walk_ptrs_ty, is_expn_of};
+use crate::utils::paths::{BEGIN_PANIC, BEGIN_PANIC_FMT, FROM_TRAIT, OPTION, RESULT};
 
 /// **What it does:** Checks for impls of `From<..>` that contain `panic!()` or `unwrap()`
 ///

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -3,8 +3,8 @@ use rustc::lint::*;
 use rustc::ty;
 use syntax::ast::LitKind;
 use syntax_pos::Span;
-use utils::paths;
-use utils::{in_macro, is_expn_of, last_path_segment, match_def_path, match_type, opt_def_id, resolve_node, snippet, span_lint_and_then, walk_ptrs_ty};
+use crate::utils::paths;
+use crate::utils::{in_macro, is_expn_of, last_path_segment, match_def_path, match_type, opt_def_id, resolve_node, snippet, span_lint_and_then, walk_ptrs_ty};
 
 /// **What it does:** Checks for the use of `format!("string literal with no
 /// argument")` and `format!("{}", foo)` where `foo` is a string.

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use syntax::ast;
-use utils::{differing_macro_contexts, in_macro, snippet_opt, span_note_and_lint};
+use crate::utils::{differing_macro_contexts, in_macro, snippet_opt, span_note_and_lint};
 use syntax::ptr::P;
 
 /// **What it does:** Checks for use of the non-existent `=*`, `=!` and `=-`

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use syntax::ast;
 use rustc_target::spec::abi::Abi;
 use syntax::codemap::Span;
-use utils::{iter_input_pats, span_lint, type_is_unsafe_function};
+use crate::utils::{iter_input_pats, span_lint, type_is_unsafe_function};
 
 /// **What it does:** Checks for functions with too many parameters.
 ///

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -1,8 +1,8 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use syntax::ast::NodeId;
-use utils::{in_macro, match_def_path, match_trait_method, same_tys, snippet, span_lint_and_then};
-use utils::{opt_def_id, paths, resolve_node};
+use crate::utils::{in_macro, match_def_path, match_trait_method, same_tys, snippet, span_lint_and_then};
+use crate::utils::{opt_def_id, paths, resolve_node};
 
 /// **What it does:** Checks for always-identical `Into`/`From` conversions.
 ///

--- a/clippy_lints/src/identity_op.rs
+++ b/clippy_lints/src/identity_op.rs
@@ -1,8 +1,8 @@
-use consts::{constant_simple, Constant};
+use crate::consts::{constant_simple, Constant};
 use rustc::hir::*;
 use rustc::lint::*;
 use syntax::codemap::Span;
-use utils::{in_macro, snippet, span_lint, unsext, clip};
+use crate::utils::{in_macro, snippet, span_lint, unsext, clip};
 use rustc::ty;
 
 /// **What it does:** Checks for identity operations, e.g. `x + 0`.

--- a/clippy_lints/src/if_let_redundant_pattern_matching.rs
+++ b/clippy_lints/src/if_let_redundant_pattern_matching.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::{match_qpath, paths, snippet, span_lint_and_then};
+use crate::utils::{match_qpath, paths, snippet, span_lint_and_then};
 
 /// **What it does:*** Lint for redundant pattern matching over `Result` or
 /// `Option`

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -4,7 +4,7 @@
 use rustc::lint::*;
 use syntax::ast::*;
 
-use utils::{in_external_macro, span_help_and_lint};
+use crate::utils::{in_external_macro, span_help_and_lint};
 
 /// **What it does:** Checks for usage of `!` or `!=` in an if condition with an
 /// else branch.

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -1,6 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
-use utils::{get_trait_def_id, higher, implements_trait, match_qpath, paths, span_lint};
+use crate::utils::{get_trait_def_id, higher, implements_trait, match_qpath, paths, span_lint};
 
 /// **What it does:** Checks for iteration that is guaranteed to be infinite.
 ///

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -3,8 +3,8 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use syntax::ast::{Attribute, Name};
-use utils::span_lint_and_then;
-use utils::sugg::DiagnosticBuilderExt;
+use crate::utils::span_lint_and_then;
+use crate::utils::sugg::DiagnosticBuilderExt;
 
 /// **What it does:** Checks for `#[inline]` on trait methods without bodies
 ///

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -3,7 +3,7 @@
 use rustc::lint::*;
 use syntax::ast::*;
 
-use utils::{snippet_opt, span_lint_and_then};
+use crate::utils::{snippet_opt, span_lint_and_then};
 
 /// **What it does:** Checks for usage of `x >= y + 1` or `x - 1 >= y` (and `<=`) in a block
 ///

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::ty;
 use rustc::hir::*;
-use utils::{match_def_path, opt_def_id, paths, span_help_and_lint};
+use crate::utils::{match_def_path, opt_def_id, paths, span_help_and_lint};
 
 /// **What it does:** Checks for creation of references to zeroed or uninitialized memory.
 ///

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -2,7 +2,7 @@
 
 use rustc::lint::*;
 use syntax::ast::*;
-use utils::{in_macro, span_lint};
+use crate::utils::{in_macro, span_lint};
 
 /// **What it does:** Checks for items declared after some statement in a block.
 ///

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -2,7 +2,7 @@
 
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::{snippet_opt, span_lint_and_then};
+use crate::utils::{snippet_opt, span_lint_and_then};
 use rustc::ty::layout::LayoutOf;
 
 /// **What it does:** Checks for large size differences between variants on

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -5,7 +5,7 @@ use rustc::ty;
 use std::collections::HashSet;
 use syntax::ast::{Lit, LitKind, Name};
 use syntax::codemap::{Span, Spanned};
-use utils::{get_item_name, in_macro, snippet, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use crate::utils::{get_item_name, in_macro, snippet, span_lint, span_lint_and_sugg, walk_ptrs_ty};
 
 /// **What it does:** Checks for getting the length of something via `.len()`
 /// just to compare to zero, and suggests using `.is_empty()` where applicable.

--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -3,7 +3,7 @@ use rustc::hir;
 use rustc::hir::BindingAnnotation;
 use rustc::hir::def::Def;
 use syntax::ast;
-use utils::{snippet, span_lint_and_then};
+use crate::utils::{snippet, span_lint_and_then};
 
 /// **What it does:** Checks for variable declarations immediately followed by a
 /// conditional affectation.

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(stable_features)]
 #![feature(iterator_find_map)]
 #![feature(macro_at_most_once_rep)]
+#![feature(rust_2018_preview)]
 
 extern crate cargo_metadata;
 #[macro_use]

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -1,11 +1,11 @@
-use reexport::*;
+use crate::reexport::*;
 use rustc::lint::*;
 use rustc::hir::def::Def;
 use rustc::hir::*;
 use rustc::hir::intravisit::*;
 use std::collections::{HashMap, HashSet};
 use syntax::codemap::Span;
-use utils::{in_external_macro, last_path_segment, span_lint};
+use crate::utils::{in_external_macro, last_path_segment, span_lint};
 use syntax::symbol::keywords;
 
 /// **What it does:** Checks for lifetime annotations which can be removed by

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -4,7 +4,7 @@
 use rustc::lint::*;
 use syntax::ast::*;
 use syntax_pos;
-use utils::{in_external_macro, snippet_opt, span_lint_and_sugg};
+use crate::utils::{in_external_macro, snippet_opt, span_lint_and_sugg};
 
 /// **What it does:** Warns if a long integral or floating-point constant does
 /// not contain underscores.

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use reexport::*;
+use crate::reexport::*;
 use rustc::hir::*;
 use rustc::hir::def::Def;
 use rustc::hir::def_id;
@@ -17,13 +17,13 @@ use std::collections::{HashMap, HashSet};
 use std::iter::{once, Iterator};
 use syntax::ast;
 use syntax::codemap::Span;
-use utils::{sugg, sext};
-use consts::{constant, Constant};
+use crate::utils::{sugg, sext};
+use crate::consts::{constant, Constant};
 
-use utils::{get_enclosing_block, get_parent_expr, higher, in_external_macro, is_integer_literal, is_refutable,
+use crate::utils::{get_enclosing_block, get_parent_expr, higher, in_external_macro, is_integer_literal, is_refutable,
             last_path_segment, match_trait_method, match_type, match_var, multispan_sugg, snippet, snippet_opt,
             span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then};
-use utils::paths;
+use crate::utils::paths;
 
 /// **What it does:** Checks for for-loops that manually copy items between
 /// slices that could be optimized by having a memcpy.

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -2,7 +2,7 @@ use rustc::lint::*;
 use rustc::hir::*;
 use rustc::ty;
 use syntax::ast;
-use utils::{get_arg_name, is_adjusted, iter_input_pats, match_qpath, match_trait_method, match_type,
+use crate::utils::{get_arg_name, is_adjusted, iter_input_pats, match_qpath, match_trait_method, match_type,
             paths, remove_blocks, snippet, span_help_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth};
 
 /// **What it does:** Checks for mapping `clone()` over an iterator.

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -3,8 +3,8 @@ use rustc::lint::*;
 use rustc::ty;
 use rustc_errors::{Applicability};
 use syntax::codemap::Span;
-use utils::{in_macro, iter_input_pats, match_type, method_chain_args, snippet, span_lint_and_then};
-use utils::paths;
+use crate::utils::{in_macro, iter_input_pats, match_type, method_chain_args, snippet, span_lint_and_then};
+use crate::utils::paths;
 
 #[derive(Clone)]
 pub struct Pass;

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -5,11 +5,11 @@ use std::cmp::Ordering;
 use std::collections::Bound;
 use syntax::ast::LitKind;
 use syntax::codemap::Span;
-use utils::paths;
-use utils::{expr_block, in_external_macro, is_allowed, is_expn_of, match_qpath, match_type, multispan_sugg,
+use crate::utils::paths;
+use crate::utils::{expr_block, in_external_macro, is_allowed, is_expn_of, match_qpath, match_type, multispan_sugg,
             remove_blocks, snippet, span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty};
-use utils::sugg::Sugg;
-use consts::{constant, Constant};
+use crate::utils::sugg::Sugg;
+use crate::consts::{constant, Constant};
 
 /// **What it does:** Checks for matches with a single arm where an `if let`
 /// will usually suffice.

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::{Expr, ExprCall, ExprPath};
-use utils::{match_def_path, opt_def_id, paths, span_lint};
+use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
 
 /// **What it does:** Checks for usage of `std::mem::forget(t)` where `t` is
 /// `Drop`.

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -7,13 +7,13 @@ use std::fmt;
 use std::iter;
 use syntax::ast;
 use syntax::codemap::{Span, BytePos};
-use utils::{get_arg_name, get_trait_def_id, implements_trait, in_external_macro, in_macro, is_copy, is_self, is_self_ty,
+use crate::utils::{get_arg_name, get_trait_def_id, implements_trait, in_external_macro, in_macro, is_copy, is_self, is_self_ty,
             iter_input_pats, last_path_segment, match_def_path, match_path, match_qpath, match_trait_method,
             match_type, method_chain_args, match_var, return_ty, remove_blocks, same_tys, single_segment_path, snippet,
             span_lint, span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth};
-use utils::paths;
-use utils::sugg;
-use consts::{constant, Constant};
+use crate::utils::paths;
+use crate::utils::sugg;
+use crate::consts::{constant, Constant};
 
 #[derive(Clone)]
 pub struct Pass;

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -1,8 +1,8 @@
-use consts::{constant_simple, Constant};
+use crate::consts::{constant_simple, Constant};
 use rustc::lint::*;
 use rustc::hir::*;
 use std::cmp::{Ordering, PartialOrd};
-use utils::{match_def_path, opt_def_id, paths, span_lint};
+use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
 
 /// **What it does:** Checks for expressions where `std::cmp::min` and `max` are
 /// used to clamp values, but switched so that the result is constant.

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -1,15 +1,15 @@
-use reexport::*;
+use crate::reexport::*;
 use rustc::hir::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
 use rustc::ty;
 use syntax::codemap::{ExpnFormat, Span};
-use utils::{get_item_name, get_parent_expr, implements_trait, in_constant, in_macro, is_integer_literal,
+use crate::utils::{get_item_name, get_parent_expr, implements_trait, in_constant, in_macro, is_integer_literal,
             iter_input_pats, last_path_segment, match_qpath, match_trait_method, paths, snippet, span_lint,
             span_lint_and_then, walk_ptrs_ty};
-use utils::sugg::Sugg;
+use crate::utils::sugg::Sugg;
 use syntax::ast::{LitKind, CRATE_NODE_ID};
-use consts::{constant, Constant};
+use crate::consts::{constant, Constant};
 
 /// **What it does:** Checks for function arguments and let bindings denoted as
 /// `ref`.

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -4,7 +4,7 @@ use std::char;
 use syntax::ast::*;
 use syntax::codemap::Span;
 use syntax::visit::FnKind;
-use utils::{constants, in_external_macro, snippet, snippet_opt, span_help_and_lint, span_lint, span_lint_and_then};
+use crate::utils::{constants, in_external_macro, snippet, snippet_opt, span_help_and_lint, span_lint, span_lint_and_then};
 
 /// **What it does:** Checks for structure field patterns bound to wildcards.
 ///

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -24,7 +24,7 @@ use rustc::ty;
 use syntax::ast;
 use syntax::attr;
 use syntax::codemap::Span;
-use utils::in_macro;
+use crate::utils::in_macro;
 
 /// **What it does:** Warns if there is missing doc for any documentable item
 /// (public or private).

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -2,7 +2,7 @@ use rustc::hir;
 use rustc::hir::intravisit;
 use rustc::lint::*;
 use rustc::ty;
-use utils::{higher, in_external_macro, span_lint};
+use crate::utils::{higher, in_external_macro, span_lint};
 
 /// **What it does:** Checks for instances of `mut mut` references.
 ///

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -2,7 +2,7 @@ use rustc::lint::*;
 use rustc::ty::{self, Ty};
 use rustc::ty::subst::Subst;
 use rustc::hir::*;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Detects giving a mutable reference to a function that only
 /// requires an immutable reference.

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -6,7 +6,7 @@ use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::ty::{self, Ty};
 use rustc::hir::Expr;
 use syntax::ast;
-use utils::{match_type, paths, span_lint};
+use crate::utils::{match_type, paths, span_lint};
 
 /// **What it does:** Checks for usages of `Mutex<X>` where an atomic will do.
 ///

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -6,8 +6,8 @@ use rustc::lint::*;
 use rustc::hir::*;
 use syntax::ast::LitKind;
 use syntax::codemap::Spanned;
-use utils::{snippet, span_lint, span_lint_and_sugg};
-use utils::sugg::Sugg;
+use crate::utils::{snippet, span_lint, span_lint_and_sugg};
+use crate::utils::sugg::Sugg;
 
 /// **What it does:** Checks for expressions of the form `if c { true } else {
 /// false }`

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -6,7 +6,7 @@ use rustc::lint::*;
 use rustc::hir::{BindingAnnotation, Expr, ExprAddrOf, MutImmutable, Pat, PatKind};
 use rustc::ty;
 use rustc::ty::adjustment::{Adjust, Adjustment};
-use utils::{in_macro, snippet_opt, span_lint_and_then};
+use crate::utils::{in_macro, snippet_opt, span_lint_and_then};
 
 /// **What it does:** Checks for address of operations (`&`) that are going to
 /// be dereferenced immediately by the compiler.

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -4,7 +4,7 @@
 
 use rustc::lint::*;
 use rustc::hir::{BindingAnnotation, MutImmutable, Pat, PatKind};
-use utils::{in_macro, snippet, span_lint_and_then};
+use crate::utils::{in_macro, snippet, span_lint_and_then};
 
 /// **What it does:** Checks for useless borrowed references.
 ///

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -32,7 +32,7 @@ use syntax::ast;
 use syntax::codemap::{original_sp, DUMMY_SP};
 use std::borrow::Cow;
 
-use utils::{in_macro, snippet, snippet_block, span_help_and_lint, trim_multiline};
+use crate::utils::{in_macro, snippet, snippet_block, span_help_and_lint, trim_multiline};
 
 /// **What it does:** The lint checks for `if`-statements appearing in loops
 /// that contain a `continue` statement in either their main blocks or their

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -10,9 +10,9 @@ use rustc_target::spec::abi::Abi;
 use syntax::ast::NodeId;
 use syntax_pos::Span;
 use syntax::errors::DiagnosticBuilder;
-use utils::{get_trait_def_id, implements_trait, in_macro, is_copy, is_self, match_type, multispan_sugg, paths,
+use crate::utils::{get_trait_def_id, implements_trait, in_macro, is_copy, is_self, match_type, multispan_sugg, paths,
             snippet, snippet_opt, span_lint_and_then};
-use utils::ptr::get_spans;
+use crate::utils::ptr::get_spans;
 use std::collections::{HashMap, HashSet};
 use std::borrow::Cow;
 

--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -1,7 +1,7 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::ty;
 use rustc::hir::{Expr, ExprStruct};
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for needlessly including a base struct on update
 /// when all fields are changed anyway.

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -2,8 +2,8 @@ use rustc::hir::*;
 use rustc::lint::*;
 use syntax::codemap::{Span, Spanned};
 
-use consts::{self, Constant};
-use utils::span_lint;
+use crate::consts::{self, Constant};
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for multiplication by -1 as a form of negation.
 ///

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -3,9 +3,9 @@ use rustc::hir;
 use rustc::lint::*;
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
-use utils::paths;
-use utils::{get_trait_def_id, implements_trait, in_external_macro, return_ty, same_tys, span_lint_and_then};
-use utils::sugg::DiagnosticBuilderExt;
+use crate::utils::paths;
+use crate::utils::{get_trait_def_id, implements_trait, in_external_macro, return_ty, same_tys, span_lint_and_then};
+use crate::utils::sugg::DiagnosticBuilderExt;
 
 /// **What it does:** Checks for types with a `fn new() -> Self` method and no
 /// implementation of

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -153,7 +153,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
 }
 
 fn create_new_without_default_suggest_msg(ty: Ty) -> String {
-    #[rustfmt_skip]
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     format!(
 "impl Default for {} {{
     fn default() -> Self {{

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -1,7 +1,7 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::hir::def::Def;
 use rustc::hir::{BiAnd, BiOr, BlockCheckMode, Expr, Expr_, Stmt, StmtSemi, UnsafeSource};
-use utils::{has_drop, in_macro, snippet_opt, span_lint, span_lint_and_sugg};
+use crate::utils::{has_drop, in_macro, snippet_opt, span_lint, span_lint_and_sugg};
 use std::ops::Deref;
 
 /// **What it does:** Checks for statements which have no effect.

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -4,7 +4,7 @@ use syntax::symbol::LocalInternedString;
 use syntax::ast::*;
 use syntax::attr;
 use syntax::visit::{walk_block, walk_expr, walk_pat, Visitor};
-use utils::{in_macro, span_lint, span_lint_and_then};
+use crate::utils::{in_macro, span_lint, span_lint_and_then};
 
 /// **What it does:** Checks for names that are very similar and thus confusing.
 ///

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::{match_type, method_chain_args, paths, snippet, span_help_and_lint};
+use crate::utils::{match_type, method_chain_args, paths, snippet, span_help_and_lint};
 
 /// **What it does:*** Checks for unnecessary `ok()` in if let.
 ///

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -2,7 +2,7 @@ use rustc::hir::{Expr, ExprLit, ExprMethodCall};
 use rustc::lint::*;
 use syntax::ast::LitKind;
 use syntax::codemap::{Span, Spanned};
-use utils::{match_type, paths, span_lint, walk_ptrs_ty};
+use crate::utils::{match_type, paths, span_lint, walk_ptrs_ty};
 
 /// **What it does:** Checks for duplicate open options as well as combinations
 /// that make no sense.

--- a/clippy_lints/src/overflow_check_conditional.rs
+++ b/clippy_lints/src/overflow_check_conditional.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Detects classic underflow/overflow checks.
 ///

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -3,7 +3,7 @@ use rustc::lint::*;
 use syntax::ast::LitKind;
 use syntax::ptr::P;
 use syntax::ext::quote::rt::Span;
-use utils::{is_direct_expn_of, is_expn_of, match_def_path, opt_def_id, paths, resolve_node, span_lint};
+use crate::utils::{is_direct_expn_of, is_expn_of, match_def_path, opt_def_id, paths, resolve_node, span_lint};
 
 /// **What it does:** Checks for missing parameters in `panic!`.
 ///

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::{is_automatically_derived, span_lint};
+use crate::utils::{is_automatically_derived, span_lint};
 
 /// **What it does:** Checks for manual re-implementations of `PartialEq::ne`.
 ///

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use syntax::ast::*;
 use syntax::codemap::Spanned;
-use utils::{in_macro, snippet, span_lint_and_sugg};
+use crate::utils::{in_macro, snippet, span_lint_and_sugg};
 
 /// **What it does:** Checks for operations where precedence may be unclear
 /// and suggests to add parentheses. Currently it catches the following:

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -9,8 +9,8 @@ use rustc::ty;
 use syntax::ast::NodeId;
 use syntax::codemap::Span;
 use syntax_pos::MultiSpan;
-use utils::{match_qpath, match_type, paths, snippet_opt, span_lint, span_lint_and_then, walk_ptrs_hir_ty};
-use utils::ptr::get_spans;
+use crate::utils::{match_qpath, match_type, paths, snippet_opt, span_lint, span_lint_and_then, walk_ptrs_hir_ty};
+use crate::utils::ptr::get_spans;
 
 /// **What it does:** This lint checks for function arguments of type `&String`
 /// or `&Vec` unless the references are mutable. It will also suggest you

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -1,11 +1,11 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use rustc::hir::def::Def;
-use utils::sugg::Sugg;
+use crate::utils::sugg::Sugg;
 use syntax::ptr::P;
 
-use utils::{match_def_path, match_type, span_lint_and_then};
-use utils::paths::*;
+use crate::utils::{match_def_path, match_type, span_lint_and_then};
+use crate::utils::paths::*;
 
 /// **What it does:** Checks for expressions that could be replaced by the question mark operator
 ///

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -2,9 +2,9 @@ use rustc::lint::*;
 use rustc::hir::*;
 use syntax::ast::RangeLimits;
 use syntax::codemap::Spanned;
-use utils::{is_integer_literal, paths, snippet, span_lint, span_lint_and_then};
-use utils::{get_trait_def_id, higher, implements_trait};
-use utils::sugg::Sugg;
+use crate::utils::{is_integer_literal, paths, snippet, span_lint, span_lint_and_then};
+use crate::utils::{get_trait_def_id, higher, implements_trait};
+use crate::utils::sugg::Sugg;
 
 /// **What it does:** Checks for calling `.step_by(0)` on iterators,
 /// which never terminates.
@@ -93,7 +93,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
             // Range with step_by(0).
             if name == "step_by" && args.len() == 2 && has_step_by(cx, &args[0]) {
-                use consts::{constant, Constant};
+                use crate::consts::{constant, Constant};
                 if let Some((Constant::Int(0), _)) = constant(cx, cx.tables, &args[1]) {
                     span_lint(
                         cx,

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::{in_macro, is_range_expression, match_var, span_lint_and_sugg};
+use crate::utils::{in_macro, is_range_expression, match_var, span_lint_and_sugg};
 
 /// **What it does:** Checks for fields in struct literals where shorthands
 /// could be used.

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -1,6 +1,6 @@
 use syntax::ast::{Expr, ExprKind, UnOp};
 use rustc::lint::*;
-use utils::{snippet, span_lint_and_sugg};
+use crate::utils::{snippet, span_lint_and_sugg};
 
 /// **What it does:** Checks for usage of `*&` and `*&mut` in expressions.
 ///

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -4,8 +4,8 @@ use rustc::lint::*;
 use std::collections::HashSet;
 use syntax::ast::{LitKind, NodeId, StrStyle};
 use syntax::codemap::{BytePos, Span};
-use utils::{is_expn_of, match_def_path, match_type, opt_def_id, paths, span_help_and_lint, span_lint};
-use consts::{constant, Constant};
+use crate::utils::{is_expn_of, match_def_path, match_type, opt_def_id, paths, span_help_and_lint, span_lint};
+use crate::consts::{constant, Constant};
 
 /// **What it does:** Checks [regex](https://crates.io/crates/regex) creation
 /// (with `Regex::new`,`RegexBuilder::new` or `RegexSet::new`) for correct

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::hir;
 use rustc::hir::def::Def;
-use utils::{match_def_path, span_lint_and_sugg};
+use crate::utils::{match_def_path, span_lint_and_sugg};
 
 /// **What it does:** Checks for usage of `ATOMIC_X_INIT`, `ONCE_INIT`, and
 /// `uX/iX::MIN/MAX`.

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -3,7 +3,7 @@ use syntax::ast;
 use syntax::codemap::Span;
 use syntax::visit::FnKind;
 
-use utils::{in_external_macro, in_macro, match_path_ast, snippet_opt, span_lint_and_then, span_note_and_lint};
+use crate::utils::{in_external_macro, in_macro, match_path_ast, snippet_opt, span_lint_and_then, span_note_and_lint};
 
 /// **What it does:** Checks for return statements at the end of a block.
 ///

--- a/clippy_lints/src/serde_api.rs
+++ b/clippy_lints/src/serde_api.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::{get_trait_def_id, paths, span_lint};
+use crate::utils::{get_trait_def_id, paths, span_lint};
 
 /// **What it does:** Checks for mis-uses of the serde API.
 ///

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -1,10 +1,10 @@
-use reexport::*;
+use crate::reexport::*;
 use rustc::lint::*;
 use rustc::hir::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::ty;
 use syntax::codemap::Span;
-use utils::{contains_name, higher, in_external_macro, iter_input_pats, snippet, span_lint_and_then};
+use crate::utils::{contains_name, higher, in_external_macro, iter_input_pats, snippet, span_lint_and_then};
 
 /// **What it does:** Checks for bindings that shadow other bindings already in
 /// scope, while just changing reference level or mutability.

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -1,8 +1,8 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use syntax::codemap::Spanned;
-use utils::SpanlessEq;
-use utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use crate::utils::SpanlessEq;
+use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};
 
 /// **What it does:** Checks for string appends of the form `x = x + y` (without
 /// `let`!).
@@ -146,7 +146,7 @@ impl LintPass for StringLitAsBytes {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         use syntax::ast::LitKind;
-        use utils::{in_macro, snippet};
+        use crate::utils::{in_macro, snippet};
 
         if let ExprMethodCall(ref path, _, ref args) = e.node {
             if path.name == "as_bytes" {

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -2,7 +2,7 @@ use rustc::lint::*;
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use syntax::ast;
-use utils::{get_trait_def_id, span_lint};
+use crate::utils::{get_trait_def_id, span_lint};
 
 /// **What it does:** Lints for suspicious operations in impls of arithmetic operators, e.g.
 /// subtracting elements in an Add impl.
@@ -149,7 +149,7 @@ fn check_binop<'a>(
     expected_ops: &[hir::BinOp_],
 ) -> Option<&'a str> {
     let mut trait_ids = vec![];
-    let [krate, module] = ::utils::paths::OPS_MODULE;
+    let [krate, module] = crate::utils::paths::OPS_MODULE;
 
     for t in traits {
         let path = [krate, module, t];

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -1,8 +1,8 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::ty;
-use utils::{differing_macro_contexts, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty, SpanlessEq};
-use utils::sugg::Sugg;
+use crate::utils::{differing_macro_contexts, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty, SpanlessEq};
+use crate::utils::sugg::Sugg;
 
 /// **What it does:** Checks for manual swapping.
 ///

--- a/clippy_lints/src/temporary_assignment.rs
+++ b/clippy_lints/src/temporary_assignment.rs
@@ -1,7 +1,7 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::hir::{Expr, ExprAssign, ExprField, ExprStruct, ExprTup};
-use utils::is_adjusted;
-use utils::span_lint;
+use crate::utils::is_adjusted;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for construction of a structure or tuple just to
 /// assign a value in it.

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -3,8 +3,8 @@ use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use std::borrow::Cow;
 use syntax::ast;
-use utils::{last_path_segment, match_def_path, paths, snippet, span_lint, span_lint_and_then};
-use utils::{opt_def_id, sugg};
+use crate::utils::{last_path_segment, match_def_path, paths, snippet, span_lint, span_lint_and_then};
+use crate::utils::{opt_def_id, sugg};
 
 /// **What it does:** Checks for transmutes that can't ever be correct on any
 /// architecture.

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1,4 +1,4 @@
-use reexport::*;
+use crate::reexport::*;
 use rustc::hir;
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_body, walk_expr, walk_ty, FnKind, NestedVisitorMap, Visitor};
@@ -12,11 +12,11 @@ use std::borrow::Cow;
 use syntax::ast::{FloatTy, IntTy, UintTy};
 use syntax::codemap::Span;
 use syntax::errors::DiagnosticBuilder;
-use utils::{comparisons, differing_macro_contexts, higher, in_constant, in_external_macro, in_macro, last_path_segment, match_def_path, match_path,
+use crate::utils::{comparisons, differing_macro_contexts, higher, in_constant, in_external_macro, in_macro, last_path_segment, match_def_path, match_path,
             match_type, multispan_sugg, opt_def_id, same_tys, snippet, snippet_opt, span_help_and_lint, span_lint,
             span_lint_and_sugg, span_lint_and_then, clip, unsext, sext, int_bits};
-use utils::paths;
-use consts::{constant, Constant};
+use crate::utils::paths;
+use crate::consts::{constant, Constant};
 
 /// Handles all the linting of funky types
 #[allow(missing_copy_implementations)]
@@ -1290,9 +1290,9 @@ fn detect_absurd_comparison<'a, 'tcx>(
     lhs: &'tcx Expr,
     rhs: &'tcx Expr,
 ) -> Option<(ExtremeExpr<'tcx>, AbsurdComparisonResult)> {
-    use types::ExtremeType::*;
-    use types::AbsurdComparisonResult::*;
-    use utils::comparisons::*;
+    use crate::types::ExtremeType::*;
+    use crate::types::AbsurdComparisonResult::*;
+    use crate::utils::comparisons::*;
 
     // absurd comparison only makes sense on primitive types
     // primitive types don't implement comparison operators with each other
@@ -1337,7 +1337,7 @@ fn detect_absurd_comparison<'a, 'tcx>(
 }
 
 fn detect_extreme_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Option<ExtremeExpr<'tcx>> {
-    use types::ExtremeType::*;
+    use crate::types::ExtremeType::*;
 
     let ty = cx.tables.expr_ty(expr);
 
@@ -1362,8 +1362,8 @@ fn detect_extreme_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AbsurdExtremeComparisons {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
-        use types::ExtremeType::*;
-        use types::AbsurdComparisonResult::*;
+        use crate::types::ExtremeType::*;
+        use crate::types::AbsurdComparisonResult::*;
 
         if let ExprBinary(ref cmp, ref lhs, ref rhs) = expr.node {
             if let Some((culprit, result)) = detect_absurd_comparison(cx, cmp.node, lhs, rhs) {
@@ -1562,7 +1562,7 @@ fn upcast_comparison_bounds_err<'a, 'tcx>(
     rhs: &'tcx Expr,
     invert: bool,
 ) {
-    use utils::comparisons::*;
+    use crate::utils::comparisons::*;
 
     if let Some((lb, ub)) = lhs_bounds {
         if let Some(norm_rhs_val) = node_as_const_fullint(cx, rhs) {

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -3,7 +3,7 @@ use rustc::hir::*;
 use syntax::ast::{LitKind, NodeId};
 use syntax::codemap::Span;
 use unicode_normalization::UnicodeNormalization;
-use utils::{is_allowed, snippet, span_help_and_lint};
+use crate::utils::{is_allowed, snippet, span_help_and_lint};
 
 /// **What it does:** Checks for the Unicode zero-width space in the code.
 ///

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -2,7 +2,7 @@ use rustc::lint::*;
 use syntax::ast::*;
 use syntax::codemap::Span;
 use syntax::symbol::LocalInternedString;
-use utils::span_lint;
+use crate::utils::span_lint;
 
 /// **What it does:** Checks for imports that remove "unsafe" from an item's
 /// name.

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -1,6 +1,6 @@
 use rustc::lint::*;
 use rustc::hir;
-use utils::{is_try, match_qpath, match_trait_method, paths, span_lint};
+use crate::utils::{is_try, match_qpath, match_trait_method, paths, span_lint};
 
 /// **What it does:** Checks for unused written/read amount.
 ///

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::symbol::LocalInternedString;
-use utils::{in_macro, span_lint};
+use crate::utils::{in_macro, span_lint};
 
 /// **What it does:** Checks for unused labels.
 ///

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -1,7 +1,7 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_path, NestedVisitorMap, Visitor};
-use utils::{in_macro, span_lint_and_then};
+use crate::utils::{in_macro, span_lint_and_then};
 use syntax::ast::NodeId;
 use syntax_pos::symbol::keywords::SelfType;
 

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -9,7 +9,7 @@ use rustc::hir::{Expr, Expr_, QPath, Ty_, Pat, PatKind, BindingAnnotation, StmtS
 use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
 use syntax::ast::{Attribute, LitKind, DUMMY_NODE_ID};
 use std::collections::HashMap;
-use utils::get_attr;
+use crate::utils::get_attr;
 
 /// **What it does:** Generates clippy code that detects the offending pattern
 ///

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -96,8 +96,8 @@ macro_rules! define_Conf {
                     -> Result<define_Conf!(TY $($ty)+), D::Error> {
                         type T = define_Conf!(TY $($ty)+);
                         Ok(T::deserialize(deserializer).unwrap_or_else(|e| {
-                            ::utils::conf::ERRORS.lock().expect("no threading here")
-                                                        .push(::utils::conf::Error::Toml(e.to_string()));
+                            crate::utils::conf::ERRORS.lock().expect("no threading here")
+                                                        .push(crate::utils::conf::Error::Toml(e.to_string()));
                             super::$rust_name()
                         }))
                     }

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -6,7 +6,7 @@
 use rustc::{hir, ty};
 use rustc::lint::LateContext;
 use syntax::ast;
-use utils::{is_expn_of, match_def_path, match_qpath, opt_def_id, paths, resolve_node};
+use crate::utils::{is_expn_of, match_def_path, match_qpath, opt_def_id, paths, resolve_node};
 
 /// Convert a hir binary operator to the corresponding `ast` type.
 pub fn binop(op: hir::BinOp_) -> ast::BinOpKind {

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -1,4 +1,4 @@
-use consts::{constant_simple, constant_context};
+use crate::consts::{constant_simple, constant_context};
 use rustc::lint::*;
 use rustc::hir::*;
 use rustc::ty::{TypeckTables};
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
 use syntax::ast::Name;
 use syntax::ptr::P;
-use utils::differing_macro_contexts;
+use crate::utils::differing_macro_contexts;
 
 /// Type used to check whether two ast are the same. This is different from the
 /// operator

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -6,7 +6,7 @@ use rustc::lint::*;
 use rustc::hir;
 use rustc::hir::print;
 use syntax::ast::Attribute;
-use utils::get_attr;
+use crate::utils::get_attr;
 
 /// **What it does:** Dumps every ast/hir node which has the `#[clippy_dump]`
 /// attribute

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,7 +1,7 @@
 use rustc::lint::*;
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use utils::{match_qpath, paths, span_lint};
+use crate::utils::{match_qpath, paths, span_lint};
 use syntax::symbol::LocalInternedString;
 use syntax::ast::{Crate as AstCrate, ItemKind, Name, NodeId};
 use syntax::codemap::Span;

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -1,4 +1,4 @@
-use reexport::*;
+use crate::reexport::*;
 use rustc::hir;
 use rustc::hir::*;
 use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX};

--- a/clippy_lints/src/utils/ptr.rs
+++ b/clippy_lints/src/utils/ptr.rs
@@ -4,7 +4,7 @@ use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::LateContext;
 use syntax::ast::Name;
 use syntax::codemap::Span;
-use utils::{get_pat_name, match_var, snippet};
+use crate::utils::{get_pat_name, match_var, snippet};
 
 pub fn get_spans(
     cx: &LateContext,

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -14,7 +14,7 @@ use syntax::parse::token;
 use syntax::print::pprust::token_to_string;
 use syntax::util::parser::AssocOp;
 use syntax::ast;
-use utils::{higher, snippet, snippet_opt};
+use crate::utils::{higher, snippet, snippet_opt};
 use syntax_pos::{BytePos, Pos};
 
 /// A helper type to build suggestion correctly handling parenthesis.

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -2,8 +2,8 @@ use rustc::hir::*;
 use rustc::lint::*;
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
-use utils::{higher, is_copy, snippet, span_lint_and_sugg};
-use consts::constant;
+use crate::utils::{higher, is_copy, snippet, span_lint_and_sugg};
+use crate::consts::constant;
 
 /// **What it does:** Checks for usage of `&vec![..]` when using `&[..]` would
 /// be possible.

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -6,8 +6,8 @@ use syntax::ast::LitKind;
 use syntax::ptr;
 use syntax::symbol::LocalInternedString;
 use syntax_pos::Span;
-use utils::{is_expn_of, match_def_path, match_path, resolve_node, span_lint, span_lint_and_sugg};
-use utils::{opt_def_id, paths, last_path_segment};
+use crate::utils::{is_expn_of, match_def_path, match_path, resolve_node, span_lint, span_lint_and_sugg};
+use crate::utils::{opt_def_id, paths, last_path_segment};
 
 /// **What it does:** This lint warns when you use `println!("")` to
 /// print a newline.

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -1,7 +1,7 @@
-use consts::{constant_simple, Constant};
+use crate::consts::{constant_simple, Constant};
 use rustc::lint::*;
 use rustc::hir::*;
-use utils::span_help_and_lint;
+use crate::utils::span_help_and_lint;
 
 /// **What it does:** Checks for `0.0 / 0.0`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // error-pattern:cargo-clippy
 #![feature(plugin_registrar)]
+#![feature(rust_2018_preview)]
 #![feature(rustc_private)]
 #![feature(macro_vis_matcher)]
 #![allow(unknown_lints)]


### PR DESCRIPTION
Clippy being nightly-only crate can easily migrate to new Rust edition and start using new features.

This PR gives insight of required changes and is was created to open discussion about the migration.
I think it looks mostly fine although I'm not sure about setting edition in `Cargo.toml` just yet.