### PR TITLE
Allows neg_cmp_op_on_partial_ord for external macros (fixes #2856).

### DIFF
--- a/tests/ui/neg_cmp_op_on_partial_ord.rs
+++ b/tests/ui/neg_cmp_op_on_partial_ord.rs
@@ -1,6 +1,6 @@
-/// This test case utilizes `f64` an easy example for `PartialOrd` only types
-/// but the lint itself actually validates any expression where the left
-/// operand implements `PartialOrd` but not `Ord`.
+//! This test case utilizes `f64` an easy example for `PartialOrd` only types
+//! but the lint itself actually validates any expression where the left
+//! operand implements `PartialOrd` but not `Ord`.
 
 use std::cmp::Ordering;
 
@@ -54,5 +54,14 @@ fn main() {
     let _ = a_value <= another_value;
     let _ = a_value > another_value;
     let _ = a_value >= another_value;
-}
 
+    // --- regression tests ---
+
+    // Issue 2856: False positive on assert!()
+    //
+    // The macro always negates the result of the given comparision in its
+    // internal check which automatically triggered the lint. As it's an
+    // external macro there was no chance to do anything about it which lead
+    // to a whitelisting of all external macros.
+    assert!(a_value < another_value);
+}


### PR DESCRIPTION
The macro always negates the result of the given comparison in its
internal check which automatically triggered the lint. As it's an
external macro there was no chance to do anything about it which lead
to a white listing of all external macros to prevent further issues.