### PR TITLE
New lint: Enums named "Sex" or "Gender" with only two variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,6 +638,7 @@ All notable changes to this project will be documented in this file.
 [`crosspointer_transmute`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#crosspointer_transmute
 [`cyclomatic_complexity`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#cyclomatic_complexity
 [`decimal_literal_representation`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#decimal_literal_representation
+[`default_trait_access`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#default_trait_access
 [`deprecated_semver`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#deprecated_semver
 [`deref_addrof`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#deref_addrof
 [`derive_hash_xor_eq`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#derive_hash_xor_eq
@@ -656,6 +657,7 @@ All notable changes to this project will be documented in this file.
 [`empty_loop`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#empty_loop
 [`enum_clike_unportable_variant`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#enum_clike_unportable_variant
 [`enum_glob_use`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#enum_glob_use
+[`enum_sex`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#enum_sex
 [`enum_variant_names`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#enum_variant_names
 [`eq_op`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#eq_op
 [`erasing_op`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#erasing_op
@@ -778,6 +780,7 @@ All notable changes to this project will be documented in this file.
 [`out_of_bounds_indexing`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#out_of_bounds_indexing
 [`overflow_check_conditional`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#overflow_check_conditional
 [`panic_params`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#panic_params
+[`panicking_unwrap`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#panicking_unwrap
 [`partialeq_ne_impl`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#partialeq_ne_impl
 [`possible_missing_comma`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#possible_missing_comma
 [`precedence`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#precedence

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 268 lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
+[There are 271 lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/enum_sex.rs
+++ b/clippy_lints/src/enum_sex.rs
@@ -1,0 +1,57 @@
+use rustc::lint::*;
+use rustc::hir::*;
+use crate::utils::span_lint;
+
+/// **What it does:** Checks for enums named `Sex` or `Gender` with only two variants
+///
+/// **Why is this bad?** This is likely to indicate code that cannot properly
+/// model the data it is trying to represent.
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// enum Sex {
+///     Female,
+///     Male,
+/// }
+/// struct Person {
+///     sex: Sex,
+///     // other fields
+/// }
+/// ```
+///
+/// Could be written:
+///
+/// ```rust
+/// struct Person {
+///     sex: &str,
+///     // other fields
+/// }
+/// ```
+declare_clippy_lint! {
+    pub ENUM_SEX,
+    pedantic,
+    "enum named `Sex` or `Gender` with only two variants"
+}
+
+#[derive(Copy, Clone)]
+pub struct EnumSex;
+
+impl LintPass for EnumSex {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(ENUM_SEX)
+    }
+}
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EnumSex {
+    fn check_item(&mut self, cx: &LateContext, item: &Item) {
+        if item.name.as_str() == "Sex" || item.name.as_str() == "Gender" {
+            if let ItemEnum(ref enumdef, _) = item.node {
+                if enumdef.variants.len() == 2 {
+                    span_lint(cx, ENUM_SEX, item.span, "enum named `Sex` or `Gender` with only two variants");
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -123,6 +123,7 @@ pub mod empty_enum;
 pub mod entry;
 pub mod enum_clike;
 pub mod enum_glob_use;
+pub mod enum_sex;
 pub mod enum_variants;
 pub mod eq_op;
 pub mod erasing_op;
@@ -432,6 +433,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box unwrap::Pass);
     reg.register_late_lint_pass(box duration_subsec::DurationSubsec);
     reg.register_late_lint_pass(box default_trait_access::DefaultTraitAccess);
+    reg.register_late_lint_pass(box enum_sex::EnumSex);
 
 
     reg.register_lint_group("clippy_restriction", vec![
@@ -465,6 +467,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         doc::DOC_MARKDOWN,
         empty_enum::EMPTY_ENUM,
         enum_glob_use::ENUM_GLOB_USE,
+        enum_sex::ENUM_SEX,
         enum_variants::PUB_ENUM_VARIANT_NAMES,
         enum_variants::STUTTER,
         if_not_else::IF_NOT_ELSE,

--- a/tests/ui/enum_sex.rs
+++ b/tests/ui/enum_sex.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code)]
+#![warn(enum_sex)]
+
+// Separate modules so we can test the same enum name multiple times
+mod bad_cases {
+
+    // Typical cases to catch
+    enum Sex {
+        Female,
+        Male,
+    }
+
+    enum Gender {
+        M,
+        F,
+    }
+
+}
+
+mod good_cases {
+
+    // Not caught, because 3 variants
+    enum Sex {
+        A,
+        B,
+        C,
+    }
+
+    // Not caught, because only one variant
+    enum Gender {
+        No
+    }
+
+    // Not caught, because different name
+    enum Connector {
+        Male,
+        Female,
+    }
+
+}
+
+fn main() {
+}

--- a/tests/ui/enum_sex.stderr
+++ b/tests/ui/enum_sex.stderr
@@ -1,0 +1,22 @@
+error: enum named `Sex` or `Gender` with only two variants
+  --> $DIR/enum_sex.rs:8:5
+   |
+8  | /     enum Sex {
+9  | |         Female,
+10 | |         Male,
+11 | |     }
+   | |_____^
+   |
+   = note: `-D enum-sex` implied by `-D warnings`
+
+error: enum named `Sex` or `Gender` with only two variants
+  --> $DIR/enum_sex.rs:13:5
+   |
+13 | /     enum Gender {
+14 | |         M,
+15 | |         F,
+16 | |     }
+   | |_____^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This is my first time writing a lint, so let me know what can be improved :)

Notes:
Should the output text of the warning be improved? (I have no experience writing helpful warnings)

None of the categories seemed appropriate, and I didn't see a way to leave it uncategorized. Are there any other lints that would fit a category of "You're making a data model error that will cause problems for you and/or your users in the future"?

Looks like some recent lint additions didn't update the changelog or readme, so those got caught when I ran update_lints.py. I left them in.