### PR TITLE
Ensure a non-zero value is returned by clippy if compilation fails

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -13,7 +13,7 @@ extern crate rustc_plugin;
 extern crate syntax;
 
 use rustc_driver::{driver::CompileController, Compilation};
-use std::process::Command;
+use std::process::{exit, Command};
 
 #[allow(print_stdout)]
 fn show_version() {
@@ -133,5 +133,10 @@ pub fn main() {
     }
     controller.compilation_done.stop = Compilation::Stop;
 
-    rustc_driver::run_compiler(&args, Box::new(controller), None, None);
+    if rustc_driver::run_compiler(&args, Box::new(controller), None, None)
+        .0
+        .is_err()
+    {
+        exit(101);
+    }
 }


### PR DESCRIPTION
https://github.com/rust-lang-nursery/rust-clippy/commit/b45fb35ec4cff21d027fa25dd31b5045867ccf03 changed the behaviour of clippy to always return 0 even if compilation failed; specifically the removal of the `rustc_driver::run()` call.

This PR may not be the best way to fix this issue as I've not worked with `rustc_driver`, but it at least logs the issue and appears to replicate the previous behaviour.

I also haven't had time to create a regression test for this issue.  If someone wants to point me to where such a test should live and ideally a similar test, I can look at adding that too?