### PR TITLE
Next step towards Rust 2018...

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,9 +13,6 @@
 //! This build script was originally taken from the Rocket web framework:
 //! https://github.com/SergioBenitez/Rocket
 
-extern crate ansi_term;
-extern crate rustc_version;
-
 use ansi_term::Colour::Red;
 use rustc_version::{version_meta, version_meta_for, Channel, Version, VersionMeta};
 use std::env;

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -1,16 +1,16 @@
 //! checks for attributes
 
 use crate::reexport::*;
+use crate::utils::{
+    in_macro, last_line_of_span, match_def_path, opt_def_id, paths, snippet_opt, span_lint, span_lint_and_then,
+    without_block_comments,
+};
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::ty::{self, TyCtxt};
 use semver::Version;
 use syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem, NestedMetaItemKind};
 use syntax::codemap::Span;
-use crate::utils::{
-    in_macro, last_line_of_span, match_def_path, opt_def_id, paths, snippet_opt, span_lint, span_lint_and_then,
-    without_block_comments,
-};
 
 /// **What it does:** Checks for items annotated with `#[inline(always)]`,
 /// unless the annotated function is empty or simply panics.

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -134,7 +134,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CopyAndPaste {
 
 /// Implementation of `IF_SAME_THEN_ELSE`.
 fn lint_same_then_else(cx: &LateContext, blocks: &[&Block]) {
-    let eq: &Fn(&&Block, &&Block) -> bool = &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).eq_block(lhs, rhs) };
+    let eq: &dyn Fn(&&Block, &&Block) -> bool = &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).eq_block(lhs, rhs) };
 
     if let Some((i, j)) = search_same_sequenced(blocks, eq) {
         span_note_and_lint(
@@ -150,13 +150,13 @@ fn lint_same_then_else(cx: &LateContext, blocks: &[&Block]) {
 
 /// Implementation of `IFS_SAME_COND`.
 fn lint_same_cond(cx: &LateContext, conds: &[&Expr]) {
-    let hash: &Fn(&&Expr) -> u64 = &|expr| -> u64 {
+    let hash: &dyn Fn(&&Expr) -> u64 = &|expr| -> u64 {
         let mut h = SpanlessHash::new(cx, cx.tables);
         h.hash_expr(expr);
         h.finish()
     };
 
-    let eq: &Fn(&&Expr, &&Expr) -> bool = &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).ignore_fn().eq_expr(lhs, rhs) };
+    let eq: &dyn Fn(&&Expr, &&Expr) -> bool = &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).ignore_fn().eq_expr(lhs, rhs) };
 
     if let Some((i, j)) = search_same(conds, hash, eq) {
         span_note_and_lint(

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -12,49 +12,22 @@
 #![feature(iterator_find_map)]
 #![feature(macro_at_most_once_rep)]
 #![feature(rust_2018_preview)]
+#![warn(rust_2018_idioms)]
 
-extern crate cargo_metadata;
 #[macro_use]
 extern crate rustc;
-extern crate rustc_target;
-extern crate rustc_typeck;
-extern crate syntax;
-extern crate syntax_pos;
 
-extern crate toml;
-
-// for unicode nfc normalization
-
-extern crate unicode_normalization;
-
-// for semver check in attrs.rs
-
-extern crate semver;
-
-// for regex checking
-
-extern crate regex_syntax;
-
-// for finding minimal boolean expressions
-
-extern crate quine_mc_cluskey;
-
-extern crate rustc_errors;
-extern crate rustc_plugin;
+use toml;
+use rustc_plugin;
 
 #[macro_use]
 extern crate matches as matches_macro;
 
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
 #[macro_use]
 extern crate lazy_static;
-
-extern crate itertools;
-extern crate pulldown_cmark;
-extern crate url;
 
 #[macro_use]
 extern crate if_chain;
@@ -211,7 +184,7 @@ pub mod zero_div_zero;
 // end lints modules, do not remove this comment, it’s used in `update_lints`
 
 mod reexport {
-    pub use syntax::ast::{Name, NodeId};
+    crate use syntax::ast::{Name, NodeId};
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -90,7 +90,7 @@ pub(super) enum Radix {
 
 impl Radix {
     /// Return a reasonable digit group size for this radix.
-    pub fn suggest_grouping(&self) -> usize {
+    crate fn suggest_grouping(&self) -> usize {
         match *self {
             Radix::Binary | Radix::Hexadecimal => 4,
             Radix::Octal | Radix::Decimal => 3,
@@ -101,19 +101,19 @@ impl Radix {
 #[derive(Debug)]
 pub(super) struct DigitInfo<'a> {
     /// Characters of a literal between the radix prefix and type suffix.
-    pub digits: &'a str,
+    crate digits: &'a str,
     /// Which radix the literal was represented in.
-    pub radix: Radix,
+    crate radix: Radix,
     /// The radix prefix, if present.
-    pub prefix: Option<&'a str>,
+    crate prefix: Option<&'a str>,
     /// The type suffix, including preceding underscore if present.
-    pub suffix: Option<&'a str>,
+    crate suffix: Option<&'a str>,
     /// True for floating-point literals.
-    pub float: bool,
+    crate float: bool,
 }
 
 impl<'a> DigitInfo<'a> {
-    pub fn new(lit: &'a str, float: bool) -> Self {
+    crate fn new(lit: &'a str, float: bool) -> Self {
         // Determine delimiter for radix prefix, if present, and radix.
         let radix = if lit.starts_with("0x") {
             Radix::Hexadecimal
@@ -160,7 +160,7 @@ impl<'a> DigitInfo<'a> {
     }
 
     /// Returns digits grouped in a sensible way.
-    pub fn grouping_hint(&self) -> String {
+    crate fn grouping_hint(&self) -> String {
         let group_size = self.radix.suggest_grouping();
         if self.digits.contains('.') {
             let mut parts = self.digits.split('.');
@@ -227,7 +227,7 @@ enum WarningType {
 }
 
 impl WarningType {
-    pub fn display(&self, grouping_hint: &str, cx: &EarlyContext, span: syntax_pos::Span) {
+    crate fn display(&self, grouping_hint: &str, cx: &EarlyContext, span: syntax_pos::Span) {
         match self {
             WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -2,7 +2,7 @@
 //!
 //! For example, the lint would catch
 //!
-//! ```
+//! ```ignore
 //! while condition() {
 //!     update_condition();
 //!     if x {
@@ -16,7 +16,7 @@
 //!
 //! And suggest something like this:
 //!
-//! ```
+//! ```ignore
 //! while condition() {
 //!     update_condition();
 //!     if x {
@@ -365,7 +365,7 @@ fn check_and_warn<'a>(ctx: &EarlyContext, expr: &'a ast::Expr) {
 ///
 /// is transformed to
 ///
-/// ```
+/// ```ignore
 ///     {
 ///         let x = 5;
 /// ```
@@ -388,7 +388,7 @@ pub fn erode_from_back(s: &str) -> String {
 /// any number of opening braces are eaten, followed by any number of newlines.
 /// e.g.,  the string
 ///
-/// ```
+/// ```ignore
 ///         {
 ///             something();
 ///             inside_a_block();
@@ -397,7 +397,7 @@ pub fn erode_from_back(s: &str) -> String {
 ///
 /// is transformed to
 ///
-/// ```
+/// ```ignore
 ///             something();
 ///             inside_a_block();
 ///         }

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -43,7 +43,7 @@ impl LintPass for QuestionMarkPass {
 impl QuestionMarkPass {
     /// Check if the given expression on the given context matches the following structure:
     ///
-    /// ```
+    /// ```ignore
     /// if option.is_none() {
     ///    return None;
     /// }

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -76,6 +76,15 @@ lazy_static! {
 macro_rules! define_Conf {
     ($(#[$doc: meta] ($rust_name: ident, $rust_name_str: expr, $default: expr => $($ty: tt)+),)+) => {
         pub use self::helpers::Conf;
+        // FIXME(mati865): remove #[allow(rust_2018_idioms)] when it's fixed:
+        //
+        // warning: `extern crate` is not idiomatic in the new edition
+        //    --> src/utils/conf.rs:82:22
+        //     |
+        // 82  |               #[derive(Deserialize)]
+        //     |                        ^^^^^^^^^^^ help: convert it to a `use`
+        //
+        #[allow(rust_2018_idioms)]
         mod helpers {
             /// Type used to store lint configuration.
             #[derive(Deserialize)]
@@ -92,7 +101,7 @@ macro_rules! define_Conf {
                 mod $rust_name {
                     use serde;
                     use serde::Deserialize;
-                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D)
+                    crate fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D)
                     -> Result<define_Conf!(TY $($ty)+), D::Error> {
                         type T = define_Conf!(TY $($ty)+);
                         Ok(T::deserialize(deserializer).unwrap_or_else(|e| {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -612,7 +612,7 @@ pub fn span_lint_and_then<'a, 'tcx: 'a, T: LintContext<'tcx>, F>(
 /// These suggestions can be parsed by rustfix to allow it to automatically fix your code.
 /// In the example below, `help` is `"try"` and `sugg` is the suggested replacement `".any(|x| x > 2)"`.
 ///
-/// ```
+/// ```ignore
 /// error: This `.fold` can be more succinctly expressed as `.any`
 /// --> $DIR/methods.rs:390:13
 ///     |

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -3,16 +3,8 @@
 #![feature(rustc_private)]
 #![allow(unknown_lints, missing_docs_in_private_items)]
 
-extern crate clippy_lints;
-extern crate getopts;
-extern crate rustc;
-extern crate rustc_codegen_utils;
-extern crate rustc_driver;
-extern crate rustc_errors;
-extern crate rustc_plugin;
-extern crate syntax;
-
-use rustc_driver::{driver::CompileController, Compilation};
+use rustc_driver::{self, driver::CompileController, Compilation};
+use rustc_plugin;
 use std::process::{exit, Command};
 
 #[allow(print_stdout)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,9 @@
 #![feature(macro_vis_matcher)]
 #![allow(unknown_lints)]
 #![allow(missing_docs_in_private_items)]
+#![warn(rust_2018_idioms)]
 
-extern crate rustc_plugin;
 use rustc_plugin::Registry;
-
-extern crate clippy_lints;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {


### PR DESCRIPTION
...as if previous haven't made enough mess :hankey: 

- `extern crate` and `dyn` changes are pretty straightforward, `pub` which were considered unreachable are replaced by `crate`.

- `#![warn(rust_2018_idioms)]` can fire again anytime the toolchain is updated, I don't know if it should stay enabled.

- `#[macro_use] extern crate rustc;` are left intact because they don't trigger warning (probably because `use` with macros right now is broken as ****).

- A WTF moment:
```
warning: `extern crate` is not idiomatic in the new edition
 --> src/lib.rs:1:1
  |
1 | // error-pattern:cargo-clippy
  | ^ help: convert it to a `use`
  |
```
It's shown if one runs `cargo check` in `clippy_lints/`, no idea what magical thing `// error-pattern:cargo-clippy` does to trigger it.

- Apparently nobody ran `cargo test` on `clippy_lints/` recently so I did it (by accident) and fixed docs.