### PR TITLE
Consistently call it "Clippy", not clippy or rust-clippy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to rust-clippy
+# Contributing to Clippy
 
 Hello fellow Rustacean! Great to see your interest in compiler internals and lints!
 
@@ -63,7 +63,7 @@ an AST expression). `match_def_path()` in Clippy's `utils` module can also be us
 
 ## Writing code
 
-Compiling clippy from scratch can take almost a minute or more depending on your machine.
+Compiling Clippy from scratch can take almost a minute or more depending on your machine.
 However, since Rust 1.24.0 incremental compilation is enabled by default and compile times for small changes should be quick.
 
 [Llogiq's blog post on lints](https://llogiq.github.io/2015/06/04/workflows.html) is a nice primer
@@ -74,7 +74,7 @@ of this.
 
 ### Author lint
 
-There is also the internal `author` lint to generate clippy code that detects the offending pattern. It does not work for all of the Rust syntax, but can give a good starting point.
+There is also the internal `author` lint to generate Clippy code that detects the offending pattern. It does not work for all of the Rust syntax, but can give a good starting point.
 
 First, create a new UI test file in the `tests/ui/` directory with the pattern you want to match:
 
@@ -148,7 +148,7 @@ Therefore you should use `tests/ui/update-all-references.sh` (after running
 ### Testing manually
 
 Manually testing against an example file is useful if you have added some
-`println!`s and test suite output becomes unreadable.  To try clippy with your
+`println!`s and test suite output becomes unreadable.  To try Clippy with your
 local modifications, run `cargo run --bin clippy-driver -- -L ./target/debug input.rs` from the
 working copy root.
 

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,4 +1,4 @@
-Steps to publish a new clippy version
+Steps to publish a new Clippy version
 
 - Bump `package.version` in `./Cargo.toml` (no need to manually bump `dependencies.clippy_lints.version`).
 - Write a changelog entry.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-We are currently in the process of discussing Clippy 1.0 via the RFC process in https://github.com/rust-lang/rfcs/pull/2476 . The RFC's goal is to clarify policies around lint categorizations and the policy around which lints should be in the compiler and which lints should be in clippy. Please leave your thoughts on the RFC PR.
+We are currently in the process of discussing Clippy 1.0 via the RFC process in https://github.com/rust-lang/rfcs/pull/2476 . The RFC's goal is to clarify policies around lint categorizations and the policy around which lints should be in the compiler and which lints should be in Clippy. Please leave your thoughts on the RFC PR.
 
-# rust-clippy
+# Clippy
 
 [![Build Status](https://travis-ci.org/rust-lang-nursery/rust-clippy.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rust-clippy)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/id677xpw1dguo7iw?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/rust-clippy)
@@ -11,7 +11,7 @@ A collection of lints to catch common mistakes and improve your [Rust](https://g
 
 [There are 273 lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
 
-We have a bunch of lint categories to allow you to choose how much clippy is supposed to ~~annoy~~ help you:
+We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 
 * `clippy` (everything that has no false positives)
 * `clippy_pedantic` (everything)
@@ -33,11 +33,11 @@ Table of contents:
 ## Usage
 
 Since this is a tool for helping the developer of a library or application
-write better code, it is recommended not to include clippy as a hard dependency.
+write better code, it is recommended not to include Clippy as a hard dependency.
 Options include using it as an optional dependency, as a cargo subcommand, or
 as an included feature during build. All of these options are detailed below.
 
-As a general rule clippy will only work with the *latest* Rust nightly for now.
+As a general rule Clippy will only work with the *latest* Rust nightly for now.
 
 To install Rust nightly, the recommended way is to use [rustup](https://rustup.rs/):
 
@@ -47,7 +47,7 @@ rustup install nightly
 
 ### As a cargo subcommand (`cargo clippy`)
 
-One way to use clippy is by installing clippy through cargo as a cargo
+One way to use Clippy is by installing Clippy through cargo as a cargo
 subcommand.
 
 ```terminal
@@ -56,7 +56,7 @@ cargo +nightly install clippy
 
 (The `+nightly` is not necessary if your default `rustup` install is nightly)
 
-Now you can run clippy by invoking `cargo +nightly clippy`.
+Now you can run Clippy by invoking `cargo +nightly clippy`.
 
 To update the subcommand together with the latest nightly use the [rust-update](rust-update) script or run:
 
@@ -66,16 +66,16 @@ cargo +nightly install --force clippy
 ```
 
 In case you are not using rustup, you need to set the environment flag
-`SYSROOT` during installation so clippy knows where to find `librustc` and
+`SYSROOT` during installation so Clippy knows where to find `librustc` and
 similar crates.
 
 ```terminal
 SYSROOT=/path/to/rustc/sysroot cargo install clippy
 ```
 
-### Running clippy from the command line without installing it
+### Running Clippy from the command line without installing it
 
-To have cargo compile your crate with clippy without clippy installation
+To have cargo compile your crate with Clippy without Clippy installation
 in your code, you can use:
 
 ```terminal
@@ -83,7 +83,7 @@ cargo run --bin cargo-clippy --manifest-path=path_to_clippys_Cargo.toml
 ```
 
 *[Note](https://github.com/rust-lang-nursery/rust-clippy/wiki#a-word-of-warning):*
-Be sure that clippy was compiled with the same version of rustc that cargo invokes here!
+Be sure that Clippy was compiled with the same version of rustc that cargo invokes here!
 
 ## Configuration
 
@@ -117,7 +117,7 @@ You can add options  to `allow`/`warn`/`deny`:
 Note: `deny` produces errors instead of warnings.
 
 For convenience, `cargo clippy` automatically defines a `cargo-clippy`
-feature. This lets you set lint levels and compile with or without clippy
+feature. This lets you set lint levels and compile with or without Clippy
 transparently:
 
 ```rust
@@ -126,12 +126,12 @@ transparently:
 
 ## Updating rustc
 
-Sometimes, rustc moves forward without clippy catching up. Therefore updating
-rustc may leave clippy a non-functional state until we fix the resulting
+Sometimes, rustc moves forward without Clippy catching up. Therefore updating
+rustc may leave Clippy a non-functional state until we fix the resulting
 breakage.
 
 You can use the [rust-update](rust-update) script to update rustc only if
-clippy would also update correctly.
+Clippy would also update correctly.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
-//! This build script ensures that clippy is not compiled with an
+//! This build script ensures that Clippy is not compiled with an
 //! incompatible version of rust. It will panic with a descriptive
 //! error message instead.
 //!
-//! We specifially want to ensure that clippy is only built with a
+//! We specifially want to ensure that Clippy is only built with a
 //! rustc version that is newer or equal to the one specified in the
 //! `min_version.txt` file.
 //!
@@ -63,7 +63,7 @@ fn check_rustc_version() {
         eprintln!(
             "\n{} {}",
             Red.bold().paint("error:"),
-            "clippy requires a nightly version of Rust."
+            "Clippy requires a nightly version of Rust."
         );
         print_version_err(&current_version, &*current_date_str);
         eprintln!(
@@ -80,7 +80,7 @@ fn check_rustc_version() {
         eprintln!(
             "\n{} {}",
             Red.bold().paint("error:"),
-            "clippy does not support this version of rustc nightly."
+            "Clippy does not support this version of rustc nightly."
         );
         eprintln!(
             "> {}{}{}",

--- a/util/lintlib.py
+++ b/util/lintlib.py
@@ -44,7 +44,7 @@ def parse_lints(lints, filepath):
                     last_comment.append(line[3:])
                 elif line.startswith("declare_lint!"):
                     import sys
-                    print "don't use `declare_lint!` in clippy, use `declare_clippy_lint!` instead"
+                    print "don't use `declare_lint!` in Clippy, use `declare_clippy_lint!` instead"
                     sys.exit(42)
                 elif line.startswith("declare_clippy_lint!"):
                     comment = False


### PR DESCRIPTION
As per discussion on the Clippy 1.0 RFC