### PR TITLE
Move range_plus_one to style group

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -634,6 +634,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         question_mark::QUESTION_MARK,
         ranges::ITERATOR_STEP_BY_ZERO,
         ranges::RANGE_MINUS_ONE,
+        ranges::RANGE_PLUS_ONE,
         ranges::RANGE_ZIP_WITH_LEN,
         redundant_field_names::REDUNDANT_FIELD_NAMES,
         reference::DEREF_ADDROF,
@@ -756,6 +757,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         ptr::PTR_ARG,
         question_mark::QUESTION_MARK,
         ranges::RANGE_MINUS_ONE,
+        ranges::RANGE_PLUS_ONE,
         redundant_field_names::REDUNDANT_FIELD_NAMES,
         regex::REGEX_MACRO,
         regex::TRIVIAL_REGEX,
@@ -920,7 +922,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
         fallible_impl_from::FALLIBLE_IMPL_FROM,
         mutex_atomic::MUTEX_INTEGER,
         needless_borrow::NEEDLESS_BORROW,
-        ranges::RANGE_PLUS_ONE,
         unwrap::PANICKING_UNWRAP,
         unwrap::UNNECESSARY_UNWRAP,
     ]);

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -55,7 +55,7 @@ declare_clippy_lint! {
 /// ```
 declare_clippy_lint! {
     pub RANGE_PLUS_ONE,
-    nursery,
+    style,
     "`x..(y+1)` reads better as `x..=y`"
 }
 


### PR DESCRIPTION
As far as I can tell, `range_plus_one` was in the nursery due to inclusive
ranges being unstable at the time it was created. Inclusive ranges have been
stable since 1.26 so it's time to graduate.