### PR TITLE
Fix travis build by removing cargo-clippy

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -6,6 +6,7 @@ cargo test --features debugging
 mkdir -p ~/rust/cargo/bin
 cp target/debug/cargo-clippy ~/rust/cargo/bin/cargo-clippy
 cp target/debug/clippy-driver ~/rust/cargo/bin/clippy-driver
+rm ~/.cargo/bin/cargo-clippy
 PATH=$PATH:~/rust/cargo/bin cargo clippy --all -- -D clippy
 cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ..
 cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -1,4 +1,5 @@
 set -x
+rm ~/.cargo/bin/cargo-clippy
 cargo install --force --path .
 
 echo "Running integration test for crate ${INTEGRATION}"


### PR DESCRIPTION
Now that it's distributed via rustup, there already is a `cargo-clippy` binary installed.

I don't want to rename the binary we create here; so instead we can just delete and replace that binary as far as the travis build is concerned.