### PR TITLE
Get rid of all macro_use

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -21,8 +21,8 @@ edition = "2018"
 [dependencies]
 cargo_metadata = "0.5"
 itertools = "0.7"
-lazy_static = "1.0"
-matches = "0.1.2"
+lazy_static = "1.0.2"
+matches = "0.1.7"
 quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"
 semver = "0.9.0"
@@ -32,7 +32,7 @@ toml = "0.4"
 unicode-normalization = "0.1"
 pulldown-cmark = "0.1"
 url = "1.7.0"
-if_chain = "0.1"
+if_chain = "0.1.3"
 
 [features]
 debugging = []

--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -1,6 +1,7 @@
 use crate::utils::span_lint;
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use std::f64::consts as f64;
 use syntax::ast::{FloatTy, Lit, LitKind};
 use syntax::symbol;

--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -1,6 +1,7 @@
 use crate::utils::span_lint;
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Span;
 
 /// **What it does:** Checks for plain integer arithmetic.

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -4,6 +4,7 @@ use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast;
 
 /// **What it does:** Checks for compound assignment operations (`+=` and

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -3,6 +3,7 @@ use crate::utils::{higher, sugg};
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 
 /// **What it does:** Checks for compound assignment operations (`+=` and

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -7,6 +7,7 @@ use crate::utils::{
 };
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, TyCtxt};
 use semver::Version;
 use syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem, NestedMetaItemKind};

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -8,6 +8,7 @@ use crate::utils::{
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, TyCtxt};
 use semver::Version;
 use syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem, NestedMetaItemKind};

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::LitKind;
 use syntax::codemap::Span;
 use crate::utils::{span_lint, span_lint_and_then};

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast::LitKind;
 use syntax::codemap::Span;
 use crate::utils::{span_lint, span_lint_and_then};

--- a/clippy_lints/src/blacklisted_name.rs
+++ b/clippy_lints/src/blacklisted_name.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::span_lint;
 

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -1,4 +1,5 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use crate::utils::*;

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -1,3 +1,4 @@
+use matches::matches;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint, lint_array};
 use rustc::hir::*;

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -1,4 +1,5 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir::intravisit::*;
 use syntax::ast::{LitKind, NodeId, DUMMY_NODE_ID};

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use syntax::ast::{Name, UintTy};
 use crate::utils::{contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg,

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use syntax::ast::{Name, UintTy};
 use crate::utils::{contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg,

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -13,6 +13,7 @@
 //! This lint is **warn** by default
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 
 use crate::utils::{in_macro, snippet_block, span_lint_and_sugg, span_lint_and_then};

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -14,6 +14,7 @@
 
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast;
 
 use crate::utils::{in_macro, snippet_block, span_lint_and_sugg, span_lint_and_then};

--- a/clippy_lints/src/const_static_lifetime.rs
+++ b/clippy_lints/src/const_static_lifetime.rs
@@ -1,5 +1,6 @@
 use syntax::ast::*;
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use crate::utils::{in_macro, snippet, span_lint_and_then};
 
 /// **What it does:** Checks for constants with an explicit `'static` lifetime.

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -2,6 +2,7 @@
 #![allow(float_cmp)]
 
 use rustc::lint::LateContext;
+use rustc::{span_bug, bug};
 use rustc::hir::def::Def;
 use rustc::hir::*;
 use rustc::ty::{self, Ty, TyCtxt, Instance};

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::Ty;
 use rustc::hir::*;
 use std::collections::HashMap;

--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -2,6 +2,7 @@
 
 use rustc::cfg::CFG;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::ty;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::TypeVariants;
 
 use crate::utils::{any_parent_is_automatically_derived, match_def_path, opt_def_id, paths, span_lint_and_sugg};

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::TypeVariants;
 
 use crate::utils::{any_parent_is_automatically_derived, match_def_path, opt_def_id, paths, span_lint_and_sugg};

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use syntax::codemap::Span;

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use syntax::codemap::Span;

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use pulldown_cmark;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 use syntax::codemap::{BytePos, Span};
 use syntax_pos::Pos;

--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -2,6 +2,7 @@
 
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Span;
 
 use crate::utils::{snippet, span_lint_and_sugg, SpanlessEq};

--- a/clippy_lints/src/double_parens.rs
+++ b/clippy_lints/src/double_parens.rs
@@ -1,5 +1,6 @@
 use syntax::ast::*;
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_lint, lint_array};
 
 /// **What it does:** Checks for unnecessary double parentheses.
 ///

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use rustc::hir::*;
 use crate::utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use rustc::hir::*;
 use crate::utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};

--- a/clippy_lints/src/duration_subsec.rs
+++ b/clippy_lints/src/duration_subsec.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::codemap::Spanned;
 
 use crate::consts::{constant, Constant};

--- a/clippy_lints/src/duration_subsec.rs
+++ b/clippy_lints/src/duration_subsec.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Spanned;
 
 use crate::consts::{constant, Constant};

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -1,6 +1,7 @@
 //! lint on if expressions with an else if, but without a final else branch
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 
 use crate::utils::{in_external_macro, span_lint_and_sugg};

--- a/clippy_lints/src/empty_enum.rs
+++ b/clippy_lints/src/empty_enum.rs
@@ -1,6 +1,7 @@
 //! lint when there is an enum with no variants
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::span_lint_and_then;
 

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -2,6 +2,7 @@ use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::codemap::Span;
 use crate::utils::SpanlessEq;
 use crate::utils::{get_item_name, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty};

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Span;
 use crate::utils::SpanlessEq;
 use crate::utils::{get_item_name, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty};

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -2,6 +2,7 @@
 //! don't fit into an `i32`
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::ty;
 use rustc::ty::subst::Substs;

--- a/clippy_lints/src/enum_glob_use.rs
+++ b/clippy_lints/src/enum_glob_use.rs
@@ -3,6 +3,7 @@
 use rustc::hir::*;
 use rustc::hir::def::Def;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use syntax::ast::NodeId;
 use syntax::codemap::Span;
 use crate::utils::span_lint;

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -1,6 +1,7 @@
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 use syntax::codemap::Span;
 use syntax::symbol::LocalInternedString;

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use crate::utils::{in_macro, implements_trait, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq};
 
 /// **What it does:** Checks for equal operands to comparison, logical and

--- a/clippy_lints/src/erasing_op.rs
+++ b/clippy_lints/src/erasing_op.rs
@@ -1,6 +1,7 @@
 use crate::consts::{constant_simple, Constant};
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Span;
 use crate::utils::{in_macro, span_lint};
 

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -2,6 +2,7 @@ use rustc::hir::*;
 use rustc::hir::intravisit as visit;
 use rustc::hir::map::Node::{NodeExpr, NodeStmt};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::middle::expr_use_visitor::*;
 use rustc::middle::mem_categorization::{cmt_, Categorization};
 use rustc::ty::{self, Ty};

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use rustc::hir::*;
 use crate::utils::{is_adjusted, iter_input_pats, snippet_opt, span_lint_and_then};

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -3,6 +3,7 @@ use rustc::hir::*;
 use rustc::ty;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast;
 use crate::utils::{get_parent_expr, span_lint, span_note_and_lint};
 

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -2,6 +2,7 @@ use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::hir::*;
 use rustc::ty;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 use crate::utils::{get_parent_expr, span_lint, span_note_and_lint};
 

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -1,5 +1,6 @@
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::TypeVariants;
 use std::f32;
 use std::f64;

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -1,6 +1,7 @@
 use rustc::hir;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::TypeVariants;
 use std::f32;
 use std::f64;

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use crate::utils::{is_expn_of, match_def_path, resolve_node, span_lint};
 use crate::utils::opt_def_id;
 

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use crate::utils::{is_expn_of, match_def_path, resolve_node, span_lint};
 use crate::utils::opt_def_id;
 

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::ty;
 use syntax_pos::Span;

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::ty;
 use syntax_pos::Span;

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use syntax::ast::LitKind;
 use syntax_pos::Span;

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use syntax::ast::LitKind;
 use syntax_pos::Span;

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 use crate::utils::{differing_macro_contexts, in_macro, snippet_opt, span_note_and_lint};
 use syntax::ptr::P;

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -1,6 +1,7 @@
 use rustc::hir::intravisit;
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use rustc::hir::def::Def;
 use std::collections::HashSet;

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -1,3 +1,4 @@
+use matches::matches;
 use rustc::hir::intravisit;
 use rustc::hir;
 use rustc::lint::*;

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use syntax::ast::NodeId;
 use crate::utils::{in_macro, match_def_path, match_trait_method, same_tys, snippet, span_lint_and_then};

--- a/clippy_lints/src/identity_op.rs
+++ b/clippy_lints/src/identity_op.rs
@@ -1,6 +1,7 @@
 use crate::consts::{constant_simple, Constant};
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Span;
 use crate::utils::{in_macro, snippet, span_lint, unsext, clip};
 use rustc::ty;

--- a/clippy_lints/src/if_let_redundant_pattern_matching.rs
+++ b/clippy_lints/src/if_let_redundant_pattern_matching.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{match_qpath, paths, snippet, span_lint_and_then};
 

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -2,6 +2,7 @@
 //! on the condition
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 
 use crate::utils::{in_external_macro, span_help_and_lint};

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -6,6 +6,7 @@ use crate::utils::higher;
 use crate::utils::higher::Range;
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use syntax::ast::RangeLimits;
 

--- a/clippy_lints/src/infallible_destructuring_match.rs
+++ b/clippy_lints/src/infallible_destructuring_match.rs
@@ -2,6 +2,7 @@ use super::utils::{get_arg_name, match_var, remove_blocks, snippet, span_lint_an
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 
 /// **What it does:** Checks for matches being used to destructure a single-variant enum
 /// or tuple struct where a `let` will suffice.

--- a/clippy_lints/src/infallible_destructuring_match.rs
+++ b/clippy_lints/src/infallible_destructuring_match.rs
@@ -1,6 +1,7 @@
 use super::utils::{get_arg_name, match_var, remove_blocks, snippet, span_lint_and_sugg};
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 
 /// **What it does:** Checks for matches being used to destructure a single-variant enum
 /// or tuple struct where a `let` will suffice.

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use crate::utils::{get_trait_def_id, higher, implements_trait, match_qpath, paths, span_lint};
 
 /// **What it does:** Checks for iteration that is guaranteed to be infinite.

--- a/clippy_lints/src/inherent_impl.rs
+++ b/clippy_lints/src/inherent_impl.rs
@@ -2,6 +2,7 @@
 
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use std::collections::HashMap;
 use std::default::Default;
 use syntax_pos::Span;

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -1,6 +1,7 @@
 //! checks for `#[inline]` on trait methods without bodies
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use syntax::ast::{Attribute, Name};
 use crate::utils::span_lint_and_then;

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -1,6 +1,7 @@
 //! lint on blocks unnecessarily using >= with a + 1 or - 1
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 
 use crate::utils::{snippet_opt, span_lint_and_then};

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use rustc::hir::*;
 use crate::utils::{match_def_path, opt_def_id, paths, span_help_and_lint};

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use rustc::hir::*;
 use crate::utils::{match_def_path, opt_def_id, paths, span_help_and_lint};

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -1,6 +1,7 @@
 //! lint when items are used after statements
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 use crate::utils::{in_macro, span_lint};
 

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -1,5 +1,6 @@
 //! lint when items are used after statements
 
+use matches::matches;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
 use syntax::ast::*;

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -1,6 +1,7 @@
 //! lint when there is a large size difference between variants on an enum
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{snippet_opt, span_lint_and_then};
 use rustc::ty::layout::LayoutOf;

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use std::collections::HashSet;
 use syntax::ast::{Lit, LitKind, Name};

--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::hir::BindingAnnotation;
 use rustc::hir::def::Def;

--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::BindingAnnotation;
 use rustc::hir::def::Def;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -25,9 +25,6 @@ use rustc_plugin;
 extern crate matches as matches_macro;
 
 #[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
 extern crate lazy_static;
 
 #[macro_use]

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -25,9 +25,6 @@ use rustc_plugin;
 extern crate matches as matches_macro;
 
 #[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
 extern crate if_chain;
 
 macro_rules! declare_clippy_lint {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -15,9 +15,6 @@
 #![warn(rust_2018_idioms)]
 #![allow(macro_use_extern_crate)]
 
-#[macro_use]
-extern crate rustc;
-
 use toml;
 use rustc_plugin;
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(macro_at_most_once_rep)]
 #![feature(rust_2018_preview)]
 #![warn(rust_2018_idioms)]
-#![allow(macro_use_extern_crate)]
 
 use toml;
 use rustc_plugin;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -19,9 +19,6 @@ use toml;
 use rustc_plugin;
 
 
-#[macro_use]
-extern crate if_chain;
-
 macro_rules! declare_clippy_lint {
     { pub $name:tt, style, $description:tt } => {
         declare_lint! { pub $name, Warn, $description }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -18,8 +18,6 @@
 use toml;
 use rustc_plugin;
 
-#[macro_use]
-extern crate matches as matches_macro;
 
 #[macro_use]
 extern crate if_chain;

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -1,4 +1,5 @@
 use crate::reexport::*;
+use matches::matches;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
 use rustc::hir::def::Def;

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -1,5 +1,6 @@
 use crate::reexport::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::def::Def;
 use rustc::hir::*;
 use rustc::hir::intravisit::*;

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -3,6 +3,7 @@
 
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast::*;
 use syntax_pos;
 use crate::utils::{in_external_macro, snippet_opt, span_lint_and_sugg};

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -2,6 +2,7 @@
 //! floating-point literal expressions.
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 use syntax_pos;
 use crate::utils::{in_external_macro, snippet_opt, span_lint_and_sugg};

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -6,6 +6,7 @@ use rustc::hir::def_id;
 use rustc::hir::intravisit::{walk_block, walk_decl, walk_expr, walk_pat, walk_stmt, NestedVisitorMap, Visitor};
 use rustc::hir::map::Node::{NodeBlock, NodeExpr, NodeStmt};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::middle::region;
 // use rustc::middle::region::CodeExtent;
 use rustc::middle::expr_use_visitor::*;

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -7,6 +7,7 @@ use rustc::hir::intravisit::{walk_block, walk_decl, walk_expr, walk_pat, walk_st
 use rustc::hir::map::Node::{NodeBlock, NodeExpr, NodeStmt};
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::middle::region;
 // use rustc::middle::region::CodeExtent;
 use rustc::middle::expr_use_visitor::*;

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::ty;
 use syntax::ast;

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::ty;
 use syntax::ast;

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -1,6 +1,7 @@
 use rustc::hir;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use rustc_errors::Applicability;
 use syntax::codemap::Span;

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -1,5 +1,6 @@
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use rustc_errors::Applicability;
 use syntax::codemap::Span;

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty};
 use std::cmp::Ordering;
 use std::collections::Bound;

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use std::cmp::Ordering;
 use std::collections::Bound;

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::{Expr, ExprKind};
 use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
 

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -1,5 +1,6 @@
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use rustc::hir::def::Def;
 use std::borrow::Cow;

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -2,6 +2,7 @@ use matches::matches;
 use rustc::hir;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty};
 use rustc::hir::def::Def;
 use std::borrow::Cow;

--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -1,3 +1,4 @@
+use matches::matches;
 use rustc::hir;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -2,6 +2,7 @@ use crate::consts::{constant_simple, Constant};
 use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use std::cmp::Ordering;
 
 /// **What it does:** Checks for expressions where `std::cmp::min` and `max` are

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -2,6 +2,7 @@ use crate::reexport::*;
 use rustc::hir::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use syntax::codemap::{ExpnFormat, Span};
 use crate::utils::{get_item_name, get_parent_expr, implements_trait, in_constant, in_macro, is_integer_literal,

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -4,6 +4,7 @@ use rustc::hir::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use syntax::codemap::{ExpnFormat, Span};
 use crate::utils::{get_item_name, get_parent_expr, implements_trait, in_constant, in_macro, is_integer_literal,

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -1,4 +1,5 @@
 use crate::reexport::*;
+use matches::matches;
 use rustc::hir::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use std::collections::HashMap;
 use std::char;
 use syntax::ast::*;

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use std::collections::HashMap;
 use std::char;
 use syntax::ast::*;

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -20,6 +20,7 @@
 
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use syntax::ast;
 use syntax::attr;

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -11,6 +11,7 @@
 
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 use syntax::codemap::Span;
 

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -1,6 +1,7 @@
 //! lint on multiple versions of a crate being used
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 
 use cargo_metadata;

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -1,6 +1,7 @@
 use rustc::hir;
 use rustc::hir::intravisit;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use crate::utils::{higher, in_external_macro, span_lint};
 

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use rustc::ty::subst::Subst;
 use rustc::hir::*;

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -3,6 +3,7 @@
 //! This lint is **warn** by default
 
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use rustc::hir::Expr;
 use syntax::ast;

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -3,6 +3,7 @@
 //! This lint is **warn** by default
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use syntax::ast::LitKind;
 use syntax::codemap::Spanned;

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -3,6 +3,7 @@
 //! This lint is **warn** by default
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::{BindingAnnotation, Expr, ExprKind, MutImmutable, Pat, PatKind};
 use rustc::ty;
 use rustc::ty::adjustment::{Adjust, Adjustment};

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -4,6 +4,7 @@
 
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::{BindingAnnotation, Expr, ExprKind, MutImmutable, Pat, PatKind};
 use rustc::ty;
 use rustc::ty::adjustment::{Adjust, Adjustment};

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -3,6 +3,7 @@
 //! This lint is **warn** by default
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::{BindingAnnotation, MutImmutable, Pat, PatKind};
 use crate::utils::{in_macro, snippet, span_lint_and_then};
 

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -4,6 +4,7 @@
 
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::{BindingAnnotation, MutImmutable, Pat, PatKind};
 use crate::utils::{in_macro, snippet, span_lint_and_then};
 

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -28,6 +28,7 @@
 //!
 //! This lint is **warn** by default.
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 use syntax::codemap::{original_sp, DUMMY_SP};
 use std::borrow::Cow;

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -1,3 +1,4 @@
+use matches::matches;
 use rustc::hir::*;
 use rustc::hir::map::*;
 use rustc::hir::intravisit::FnKind;

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -2,6 +2,7 @@ use rustc::hir::*;
 use rustc::hir::map::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, RegionKind, TypeFoldable};
 use rustc::traits;
 use rustc::middle::expr_use_visitor as euv;

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -4,6 +4,7 @@ use rustc::hir::map::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, RegionKind, TypeFoldable};
 use rustc::traits;
 use rustc::middle::expr_use_visitor as euv;

--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -1,4 +1,5 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use rustc::hir::{Expr, ExprKind};
 use crate::utils::span_lint;

--- a/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
+++ b/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 
 use crate::utils::{self, paths, span_lint, in_external_macro};
 

--- a/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
+++ b/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 
 use crate::utils::{self, paths, span_lint, in_external_macro};
 

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::codemap::{Span, Spanned};
 
 use crate::consts::{self, Constant};

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::{Span, Spanned};
 
 use crate::consts::{self, Constant};

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -2,6 +2,7 @@ use rustc::hir::def_id::DefId;
 use rustc::hir;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
 use crate::utils::paths;

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::hir;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
 use crate::utils::paths;

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -1,4 +1,5 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::hir::def::Def;
 use rustc::hir::{BinOpKind, BlockCheckMode, Expr, ExprKind, Stmt, StmtKind, UnsafeSource};
 use crate::utils::{has_drop, in_macro, snippet_opt, span_lint, span_lint_and_sugg};

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -3,6 +3,7 @@
 //! This lint is **deny** by default.
 
 use rustc::lint::{LateContext, LateLintPass, Lint, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir::def::Def;
 use rustc::ty::{self, TypeFlags};

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Span;
 use syntax::symbol::LocalInternedString;
 use syntax::ast::*;

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use crate::utils::{match_type, method_chain_args, paths, snippet, span_help_and_lint};
 

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{match_type, method_chain_args, paths, snippet, span_help_and_lint};
 

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -1,5 +1,6 @@
 use rustc::hir::{Expr, ExprKind};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::LitKind;
 use syntax::codemap::{Span, Spanned};
 use crate::utils::{match_type, paths, span_lint, walk_ptrs_ty};

--- a/clippy_lints/src/overflow_check_conditional.rs
+++ b/clippy_lints/src/overflow_check_conditional.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use crate::utils::{span_lint, SpanlessEq};
 

--- a/clippy_lints/src/overflow_check_conditional.rs
+++ b/clippy_lints/src/overflow_check_conditional.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{span_lint, SpanlessEq};
 

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast::LitKind;
 use syntax::ptr::P;
 use syntax::ext::quote::rt::Span;

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::LitKind;
 use syntax::ptr::P;
 use syntax::ext::quote::rt::Span;

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use crate::utils::{is_automatically_derived, span_lint};
 

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{is_automatically_derived, span_lint};
 

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 use syntax::codemap::Spanned;
 use crate::utils::{in_macro, snippet, span_lint_and_sugg};

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -6,6 +6,7 @@ use rustc::hir::map::NodeItem;
 use rustc::hir::QPath;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use syntax::ast::NodeId;
 use syntax::codemap::Span;

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -5,6 +5,7 @@ use rustc::hir::*;
 use rustc::hir::map::NodeItem;
 use rustc::hir::QPath;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use syntax::ast::NodeId;
 use syntax::codemap::Span;

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir::def::Def;
 use crate::utils::sugg::Sugg;

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::hir::def::Def;
 use crate::utils::sugg::Sugg;

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use syntax::ast::RangeLimits;
 use syntax::codemap::Spanned;

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use syntax::ast::RangeLimits;
 use syntax::codemap::Spanned;

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{in_macro, is_range_expression, match_var, span_lint_and_sugg};
 

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -1,5 +1,6 @@
 use syntax::ast::{Expr, ExprKind, UnOp};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use crate::utils::{snippet, span_lint_and_sugg};
 
 /// **What it does:** Checks for usage of `*&` and `*&mut` in expressions.

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -1,6 +1,7 @@
 use syntax::ast::{Expr, ExprKind, UnOp};
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use crate::utils::{snippet, span_lint_and_sugg};
 
 /// **What it does:** Checks for usage of `*&` and `*&mut` in expressions.

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -2,6 +2,7 @@ use regex_syntax;
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use std::collections::HashSet;
 use syntax::ast::{LitKind, NodeId, StrStyle};
 use syntax::codemap::{BytePos, Span};

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -1,6 +1,7 @@
 use regex_syntax;
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use std::collections::HashSet;
 use syntax::ast::{LitKind, NodeId, StrStyle};
 use syntax::codemap::{BytePos, Span};

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::hir::def::Def;
 use crate::utils::{match_def_path, span_lint_and_sugg};

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::def::Def;
 use crate::utils::{match_def_path, span_lint_and_sugg};

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::visit::FnKind;

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::visit::FnKind;

--- a/clippy_lints/src/serde_api.rs
+++ b/clippy_lints/src/serde_api.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::{get_trait_def_id, paths, span_lint};
 

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -1,5 +1,6 @@
 use crate::reexport::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::ty;

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::codemap::Spanned;
 use crate::utils::SpanlessEq;
 use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use syntax::ast;

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use syntax::ast;

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty;
 use crate::utils::{differing_macro_contexts, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty, SpanlessEq};
 use crate::utils::sugg::Sugg;

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -2,6 +2,7 @@ use matches::matches;
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty;
 use crate::utils::{differing_macro_contexts, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty, SpanlessEq};
 use crate::utils::sugg::Sugg;

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -1,3 +1,4 @@
+use matches::matches;
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};

--- a/clippy_lints/src/temporary_assignment.rs
+++ b/clippy_lints/src/temporary_assignment.rs
@@ -1,4 +1,5 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::hir::{Expr, ExprKind};
 use crate::utils::is_adjusted;
 use crate::utils::span_lint;

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use std::borrow::Cow;

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty};
 use rustc::hir::*;
 use std::borrow::Cow;

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -4,6 +4,7 @@ use rustc::hir::*;
 use rustc::hir::map::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::TypeVariants;
 use rustc::session::config::Config as SessionConfig;
 use rustc_target::spec::abi::Abi;

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use matches::matches;
 use rustc::hir::*;
 use rustc::hir::map::*;
 use rustc::hir::intravisit::FnKind;

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -6,6 +6,7 @@ use rustc::hir::map::*;
 use rustc::hir::intravisit::FnKind;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::TypeVariants;
 use rustc::session::config::Config as SessionConfig;
 use rustc_target::spec::abi::Abi;

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -3,6 +3,7 @@ use rustc::hir;
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_body, walk_expr, walk_ty, FnKind, NestedVisitorMap, Visitor};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty, TyCtxt, TypeckTables};
 use rustc::ty::layout::LayoutOf;
 use rustc_typeck::hir_ty_to_ty;

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -4,6 +4,7 @@ use rustc::hir::*;
 use rustc::hir::intravisit::{walk_body, walk_expr, walk_ty, FnKind, NestedVisitorMap, Visitor};
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty, TyCtxt, TypeckTables};
 use rustc::ty::layout::LayoutOf;
 use rustc_typeck::hir_ty_to_ty;

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use syntax::ast::{LitKind, NodeId};
 use syntax::codemap::Span;

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use syntax::ast::*;
 use syntax::codemap::Span;
 use syntax::symbol::LocalInternedString;

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use crate::utils::{is_try, match_qpath, match_trait_method, paths, span_lint};
 

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, walk_fn, FnKind, NestedVisitorMap, Visitor};
 use std::collections::HashMap;

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 
 use crate::utils::{in_macro, match_type, paths, span_lint_and_then, usage::is_potentially_mutated};
 use rustc::hir::intravisit::*;

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -1,5 +1,6 @@
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 
 use crate::utils::{in_macro, match_type, paths, span_lint_and_then, usage::is_potentially_mutated};
 use rustc::hir::intravisit::*;

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -1,4 +1,5 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_path, NestedVisitorMap, Visitor};
 use crate::utils::{in_macro, span_lint_and_then};

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -1,5 +1,6 @@
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::hir::intravisit::{walk_path, NestedVisitorMap, Visitor};
 use crate::utils::{in_macro, span_lint_and_then};

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -4,6 +4,7 @@
 #![allow(print_stdout, use_debug)]
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::hir::{Expr, ExprKind, QPath, TyKind, Pat, PatKind, BindingAnnotation, StmtKind, DeclKind, Stmt};
 use rustc::hir::intravisit::{NestedVisitorMap, Visitor};

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -7,7 +7,6 @@ use std::io::Read;
 use syntax::{ast, codemap};
 use toml;
 use std::sync::Mutex;
-
 /// Get the configuration file from arguments.
 pub fn file_from_args(
     args: &[codemap::Spanned<ast::NestedMetaItemKind>],
@@ -86,10 +85,10 @@ macro_rules! define_Conf {
         //
         #[allow(rust_2018_idioms)]
         mod helpers {
+            use serde_derive::Deserialize;
             /// Type used to store lint configuration.
             #[derive(Deserialize)]
-            #[serde(rename_all="kebab-case")]
-            #[serde(deny_unknown_fields)]
+            #[serde(rename_all="kebab-case", deny_unknown_fields)]
             pub struct Conf {
                 $(#[$doc] #[serde(default=$rust_name_str)] #[serde(with=$rust_name_str)]
                           pub $rust_name: define_Conf!(TY $($ty)+),)+

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -2,11 +2,13 @@
 
 #![deny(missing_docs_in_private_items)]
 
+use lazy_static::lazy_static;
 use std::{env, fmt, fs, io, path};
 use std::io::Read;
 use syntax::{ast, codemap};
 use toml;
 use std::sync::Mutex;
+
 /// Get the configuration file from arguments.
 pub fn file_from_args(
     args: &[codemap::Spanned<ast::NestedMetaItemKind>],

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs_in_private_items)]
 
+use if_chain::if_chain;
 use rustc::{hir, ty};
 use rustc::lint::LateContext;
 use syntax::ast;

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -3,6 +3,7 @@
 //! checks for attributes
 
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir;
 use rustc::hir::print;
 use syntax::ast::Attribute;

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,4 +1,5 @@
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -1,5 +1,6 @@
 use crate::reexport::*;
 use matches::matches;
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::*;
 use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX};

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -1,4 +1,5 @@
 use crate::reexport::*;
+use matches::matches;
 use rustc::hir;
 use rustc::hir::*;
 use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX};

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -3,6 +3,7 @@
 // currently ignores lifetimes and generics
 #![allow(use_self)]
 
+use matches::matches;
 use rustc::hir;
 use rustc::lint::{EarlyContext, LateContext, LintContext};
 use rustc_errors;

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -1,5 +1,6 @@
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
 use crate::utils::{higher, is_copy, snippet, span_lint_and_sugg};

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -1,6 +1,7 @@
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
 use crate::utils::{higher, is_copy, snippet, span_lint_and_sugg};

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -1,6 +1,7 @@
 use rustc::hir::map::Node::{NodeImplItem, NodeItem};
 use rustc::hir::*;
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use std::ops::Deref;
 use syntax::ast::LitKind;
 use syntax::ptr;

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -2,6 +2,7 @@ use rustc::hir::map::Node::{NodeImplItem, NodeItem};
 use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use std::ops::Deref;
 use syntax::ast::LitKind;
 use syntax::ptr;

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -1,5 +1,6 @@
 use crate::consts::{constant_simple, Constant};
 use rustc::lint::*;
+use rustc::{declare_lint, lint_array};
 use rustc::hir::*;
 use crate::utils::span_help_and_lint;
 

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -1,6 +1,7 @@
 use crate::consts::{constant_simple, Constant};
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
+use if_chain::if_chain;
 use rustc::hir::*;
 use crate::utils::span_help_and_lint;
 


### PR DESCRIPTION
Depends on https://github.com/lfairy/if_chain/pull/3 and a cargo bump

I did a bandaid to fix the rust build for the new `macro_use` lint in https://github.com/rust-lang-nursery/rust-clippy/commit/c05adc545cff45449d40b1c72070ada7db5fc953 . 

This actually fixes the warning by importing macros directly everywhere.