### PR TITLE
Always build  CI on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
       nvm use stable
       npm install remark-cli remark-lint
     fi
+  - cargo install rustup-toolchain-install-master
+  - travis_retry rustup-toolchain-install-master -n master -f
+  - rustup default master
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,9 @@ install:
     - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly
     - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin;C:\Users\appveyor\.rustup\toolchains\nightly-%TARGET%\bin
     - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
+    - cargo install rustup-toolchain-install-master
+    - rustup-toolchain-install-master -n master -f
+    - rustup default master
     - rustc -V
     - cargo -V
 


### PR DESCRIPTION
This switches travis over to always using master.

We can alternatively pin a hash and bump it every time something breaks, but this feels cleaner (albeit less cacheable on the travis side)


needs https://github.com/kennytm/rustup-toolchain-install-master/pull/6 to be released to work


r? @oli-obk