### PR TITLE
Rewrite the print/write macro checks as a PreExpansionPass 

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -70,7 +70,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     }
 }
 
-fn check_lit(cx: &LateContext, lit: &Lit, e: &Expr) {
+fn check_lit(cx: &LateContext<'_, '_>, lit: &Lit, e: &Expr) {
     match lit.node {
         LitKind::Float(s, FloatTy::F32) => check_known_consts(cx, e, s, "f32"),
         LitKind::Float(s, FloatTy::F64) => check_known_consts(cx, e, s, "f64"),
@@ -79,7 +79,7 @@ fn check_lit(cx: &LateContext, lit: &Lit, e: &Expr) {
     }
 }
 
-fn check_known_consts(cx: &LateContext, e: &Expr, s: symbol::Symbol, module: &str) {
+fn check_known_consts(cx: &LateContext<'_, '_>, e: &Expr, s: symbol::Symbol, module: &str) {
     let s = s.as_str();
     if s.parse::<f64>().is_ok() {
         for &(constant, name, min_digits) in KNOWN_CONSTS {

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -226,7 +226,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AttrPass {
     }
 }
 
-fn is_relevant_item(tcx: TyCtxt, item: &Item) -> bool {
+fn is_relevant_item(tcx: TyCtxt<'_, '_, '_>, item: &Item) -> bool {
     if let ItemKind::Fn(_, _, _, eid) = item.node {
         is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir.body(eid).value)
     } else {
@@ -234,14 +234,14 @@ fn is_relevant_item(tcx: TyCtxt, item: &Item) -> bool {
     }
 }
 
-fn is_relevant_impl(tcx: TyCtxt, item: &ImplItem) -> bool {
+fn is_relevant_impl(tcx: TyCtxt<'_, '_, '_>, item: &ImplItem) -> bool {
     match item.node {
         ImplItemKind::Method(_, eid) => is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir.body(eid).value),
         _ => false,
     }
 }
 
-fn is_relevant_trait(tcx: TyCtxt, item: &TraitItem) -> bool {
+fn is_relevant_trait(tcx: TyCtxt<'_, '_, '_>, item: &TraitItem) -> bool {
     match item.node {
         TraitItemKind::Method(_, TraitMethod::Required(_)) => true,
         TraitItemKind::Method(_, TraitMethod::Provided(eid)) => {
@@ -251,7 +251,7 @@ fn is_relevant_trait(tcx: TyCtxt, item: &TraitItem) -> bool {
     }
 }
 
-fn is_relevant_block(tcx: TyCtxt, tables: &ty::TypeckTables, block: &Block) -> bool {
+fn is_relevant_block(tcx: TyCtxt<'_, '_, '_>, tables: &ty::TypeckTables<'_>, block: &Block) -> bool {
     if let Some(stmt) = block.stmts.first() {
         match stmt.node {
             StmtKind::Decl(_, _) => true,
@@ -262,7 +262,7 @@ fn is_relevant_block(tcx: TyCtxt, tables: &ty::TypeckTables, block: &Block) -> b
     }
 }
 
-fn is_relevant_expr(tcx: TyCtxt, tables: &ty::TypeckTables, expr: &Expr) -> bool {
+fn is_relevant_expr(tcx: TyCtxt<'_, '_, '_>, tables: &ty::TypeckTables<'_>, expr: &Expr) -> bool {
     match expr.node {
         ExprKind::Block(ref block, _) => is_relevant_block(tcx, tables, block),
         ExprKind::Ret(Some(ref e)) => is_relevant_expr(tcx, tables, e),
@@ -280,7 +280,7 @@ fn is_relevant_expr(tcx: TyCtxt, tables: &ty::TypeckTables, expr: &Expr) -> bool
     }
 }
 
-fn check_attrs(cx: &LateContext, span: Span, name: Name, attrs: &[Attribute]) {
+fn check_attrs(cx: &LateContext<'_, '_>, span: Span, name: Name, attrs: &[Attribute]) {
     if in_macro(span) {
         return;
     }
@@ -331,7 +331,7 @@ fn check_attrs(cx: &LateContext, span: Span, name: Name, attrs: &[Attribute]) {
     }
 }
 
-fn check_semver(cx: &LateContext, span: Span, lit: &Lit) {
+fn check_semver(cx: &LateContext<'_, '_>, span: Span, lit: &Lit) {
     if let LitKind::Str(ref is, _) = lit.node {
         if Version::parse(&is.as_str()).is_ok() {
             return;
@@ -358,7 +358,7 @@ fn is_word(nmi: &NestedMetaItem, expected: &str) -> bool {
 // sources that the user has no control over.
 // For some reason these attributes don't have any expansion info on them, so
 // we have to check it this way until there is a better way.
-fn is_present_in_source(cx: &LateContext, span: Span) -> bool {
+fn is_present_in_source(cx: &LateContext<'_, '_>, span: Span) -> bool {
     if let Some(snippet) = snippet_opt(cx, span) {
         if snippet.is_empty() {
             return false;

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -158,7 +158,7 @@ fn invert_cmp(cmp: BinOpKind) -> BinOpKind {
 }
 
 
-fn check_compare(cx: &LateContext, bit_op: &Expr, cmp_op: BinOpKind, cmp_value: u128, span: Span) {
+fn check_compare(cx: &LateContext<'_, '_>, bit_op: &Expr, cmp_op: BinOpKind, cmp_value: u128, span: Span) {
     if let ExprKind::Binary(ref op, ref left, ref right) = bit_op.node {
         if op.node != BinOpKind::BitAnd && op.node != BinOpKind::BitOr {
             return;
@@ -169,7 +169,7 @@ fn check_compare(cx: &LateContext, bit_op: &Expr, cmp_op: BinOpKind, cmp_value: 
     }
 }
 
-fn check_bit_mask(cx: &LateContext, bit_op: BinOpKind, cmp_op: BinOpKind, mask_value: u128, cmp_value: u128, span: Span) {
+fn check_bit_mask(cx: &LateContext<'_, '_>, bit_op: BinOpKind, cmp_op: BinOpKind, mask_value: u128, cmp_value: u128, span: Span) {
     match cmp_op {
         BinOpKind::Eq | BinOpKind::Ne => match bit_op {
             BinOpKind::BitAnd => if mask_value & cmp_value != cmp_value {
@@ -270,7 +270,7 @@ fn check_bit_mask(cx: &LateContext, bit_op: BinOpKind, cmp_op: BinOpKind, mask_v
     }
 }
 
-fn check_ineffective_lt(cx: &LateContext, span: Span, m: u128, c: u128, op: &str) {
+fn check_ineffective_lt(cx: &LateContext<'_, '_>, span: Span, m: u128, c: u128, op: &str) {
     if c.is_power_of_two() && m < c {
         span_lint(
             cx,
@@ -286,7 +286,7 @@ fn check_ineffective_lt(cx: &LateContext, span: Span, m: u128, c: u128, op: &str
     }
 }
 
-fn check_ineffective_gt(cx: &LateContext, span: Span, m: u128, c: u128, op: &str) {
+fn check_ineffective_gt(cx: &LateContext<'_, '_>, span: Span, m: u128, c: u128, op: &str) {
     if (c + 1).is_power_of_two() && m <= c {
         span_lint(
             cx,
@@ -302,7 +302,7 @@ fn check_ineffective_gt(cx: &LateContext, span: Span, m: u128, c: u128, op: &str
     }
 }
 
-fn fetch_int_literal(cx: &LateContext, lit: &Expr) -> Option<u128> {
+fn fetch_int_literal(cx: &LateContext<'_, '_>, lit: &Expr) -> Option<u128> {
     match constant(cx, cx.tables, lit)?.0 {
         Constant::Int(n) => Some(n),
         _ => None,

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -275,7 +275,7 @@ impl<'a, 'tcx, 'v> SuggestContext<'a, 'tcx, 'v> {
 }
 
 // The boolean part of the return indicates whether some simplifications have been applied.
-fn suggest(cx: &LateContext, suggestion: &Bool, terminals: &[&Expr]) -> (String, bool) {
+fn suggest(cx: &LateContext<'_, '_>, suggestion: &Bool, terminals: &[&Expr]) -> (String, bool) {
     let mut suggest_context = SuggestContext {
         terminals,
         cx,

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -38,7 +38,7 @@ impl LintPass for ByteCount {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
-    fn check_expr(&mut self, cx: &LateContext, expr: &Expr) {
+    fn check_expr(&mut self, cx: &LateContext<'_, '_>, expr: &Expr) {
         if_chain! {
             if let ExprKind::MethodCall(ref count, _, ref count_args) = expr.node;
             if count.ident.name == "count";

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -80,14 +80,14 @@ impl LintPass for CollapsibleIf {
 }
 
 impl EarlyLintPass for CollapsibleIf {
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &ast::Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
         if !in_macro(expr.span) {
             check_if(cx, expr)
         }
     }
 }
 
-fn check_if(cx: &EarlyContext, expr: &ast::Expr) {
+fn check_if(cx: &EarlyContext<'_>, expr: &ast::Expr) {
     match expr.node {
         ast::ExprKind::If(ref check, ref then, ref else_) => if let Some(ref else_) = *else_ {
             check_collapsible_maybe_if_let(cx, else_);
@@ -101,7 +101,7 @@ fn check_if(cx: &EarlyContext, expr: &ast::Expr) {
     }
 }
 
-fn check_collapsible_maybe_if_let(cx: &EarlyContext, else_: &ast::Expr) {
+fn check_collapsible_maybe_if_let(cx: &EarlyContext<'_>, else_: &ast::Expr) {
     if_chain! {
         if let ast::ExprKind::Block(ref block, _) = else_.node;
         if let Some(else_) = expr_block(block);
@@ -122,7 +122,7 @@ fn check_collapsible_maybe_if_let(cx: &EarlyContext, else_: &ast::Expr) {
     }
 }
 
-fn check_collapsible_no_if_let(cx: &EarlyContext, expr: &ast::Expr, check: &ast::Expr, then: &ast::Block) {
+fn check_collapsible_no_if_let(cx: &EarlyContext<'_>, expr: &ast::Expr, check: &ast::Expr, then: &ast::Block) {
     if_chain! {
         if let Some(inner) = expr_block(then);
         if let ast::ExprKind::If(ref check_inner, ref content, None) = inner.node;

--- a/clippy_lints/src/const_static_lifetime.rs
+++ b/clippy_lints/src/const_static_lifetime.rs
@@ -35,7 +35,7 @@ impl LintPass for StaticConst {
 
 impl StaticConst {
     // Recursively visit types
-    fn visit_type(&mut self, ty: &Ty, cx: &EarlyContext) {
+    fn visit_type(&mut self, ty: &Ty, cx: &EarlyContext<'_>) {
         match ty.node {
             // Be careful of nested structures (arrays and tuples)
             TyKind::Array(ref ty, _) => {
@@ -79,7 +79,7 @@ impl StaticConst {
 }
 
 impl EarlyLintPass for StaticConst {
-    fn check_item(&mut self, cx: &EarlyContext, item: &Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if !in_macro(item.span) {
             // Match only constants...
             if let ItemKind::Const(ref var_type, _) = item.node {

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -123,7 +123,7 @@ impl Hash for Constant {
 }
 
 impl Constant {
-    pub fn partial_cmp(tcx: TyCtxt, cmp_type: &ty::TypeVariants, left: &Self, right: &Self) -> Option<Ordering> {
+    pub fn partial_cmp(tcx: TyCtxt<'_, '_, '_>, cmp_type: &ty::TypeVariants<'_>, left: &Self, right: &Self) -> Option<Ordering> {
         match (left, right) {
             (&Constant::Str(ref ls), &Constant::Str(ref rs)) => Some(ls.cmp(rs)),
             (&Constant::Char(ref l), &Constant::Char(ref r)) => Some(l.cmp(r)),
@@ -236,7 +236,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
         }
     }
 
-    fn constant_not(&self, o: &Constant, ty: ty::Ty) -> Option<Constant> {
+    fn constant_not(&self, o: &Constant, ty: ty::Ty<'_>) -> Option<Constant> {
         use self::Constant::*;
         match *o {
             Bool(b) => Some(Bool(!b)),
@@ -252,7 +252,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
         }
     }
 
-    fn constant_negate(&self, o: &Constant, ty: ty::Ty) -> Option<Constant> {
+    fn constant_negate(&self, o: &Constant, ty: ty::Ty<'_>) -> Option<Constant> {
         use self::Constant::*;
         match *o {
             Int(value) => {

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -134,7 +134,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CopyAndPaste {
 }
 
 /// Implementation of `IF_SAME_THEN_ELSE`.
-fn lint_same_then_else(cx: &LateContext, blocks: &[&Block]) {
+fn lint_same_then_else(cx: &LateContext<'_, '_>, blocks: &[&Block]) {
     let eq: &dyn Fn(&&Block, &&Block) -> bool = &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).eq_block(lhs, rhs) };
 
     if let Some((i, j)) = search_same_sequenced(blocks, eq) {
@@ -150,7 +150,7 @@ fn lint_same_then_else(cx: &LateContext, blocks: &[&Block]) {
 }
 
 /// Implementation of `IFS_SAME_COND`.
-fn lint_same_cond(cx: &LateContext, conds: &[&Expr]) {
+fn lint_same_cond(cx: &LateContext<'_, '_>, conds: &[&Expr]) {
     let hash: &dyn Fn(&&Expr) -> u64 = &|expr| -> u64 {
         let mut h = SpanlessHash::new(cx, cx.tables);
         h.hash_expr(expr);
@@ -172,7 +172,7 @@ fn lint_same_cond(cx: &LateContext, conds: &[&Expr]) {
 }
 
 /// Implementation of `MATCH_SAME_ARMS`.
-fn lint_match_arms(cx: &LateContext, expr: &Expr) {
+fn lint_match_arms(cx: &LateContext<'_, '_>, expr: &Expr) {
     if let ExprKind::Match(_, ref arms, MatchSource::Normal) = expr.node {
         let hash = |&(_, arm): &(usize, &Arm)| -> u64 {
             let mut h = SpanlessHash::new(cx, cx.tables);

--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -187,7 +187,7 @@ impl<'a, 'tcx> Visitor<'tcx> for CCHelper<'a, 'tcx> {
 
 #[cfg(feature = "debugging")]
 #[allow(too_many_arguments)]
-fn report_cc_bug(_: &LateContext, cc: u64, narms: u64, div: u64, shorts: u64, returns: u64, span: Span, _: NodeId) {
+fn report_cc_bug(_: &LateContext<'_, '_>, cc: u64, narms: u64, div: u64, shorts: u64, returns: u64, span: Span, _: NodeId) {
     span_bug!(
         span,
         "Clippy encountered a bug calculating cyclomatic complexity: cc = {}, arms = {}, \
@@ -201,7 +201,7 @@ fn report_cc_bug(_: &LateContext, cc: u64, narms: u64, div: u64, shorts: u64, re
 }
 #[cfg(not(feature = "debugging"))]
 #[allow(too_many_arguments)]
-fn report_cc_bug(cx: &LateContext, cc: u64, narms: u64, div: u64, shorts: u64, returns: u64, span: Span, id: NodeId) {
+fn report_cc_bug(cx: &LateContext<'_, '_>, cc: u64, narms: u64, div: u64, shorts: u64, returns: u64, span: Span, id: NodeId) {
     if !is_allowed(cx, CYCLOMATIC_COMPLEXITY, id) {
         cx.sess().span_note_without_error(
             span,

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -52,11 +52,11 @@ impl LintPass for Doc {
 }
 
 impl EarlyLintPass for Doc {
-    fn check_crate(&mut self, cx: &EarlyContext, krate: &ast::Crate) {
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &ast::Crate) {
         check_attrs(cx, &self.valid_idents, &krate.attrs);
     }
 
-    fn check_item(&mut self, cx: &EarlyContext, item: &ast::Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
         check_attrs(cx, &self.valid_idents, &item.attrs);
     }
 }
@@ -139,7 +139,7 @@ pub fn strip_doc_comment_decoration(comment: &str, span: Span) -> (String, Vec<(
     panic!("not a doc-comment: {}", comment);
 }
 
-pub fn check_attrs<'a>(cx: &EarlyContext, valid_idents: &[String], attrs: &'a [ast::Attribute]) {
+pub fn check_attrs<'a>(cx: &EarlyContext<'_>, valid_idents: &[String], attrs: &'a [ast::Attribute]) {
     let mut doc = String::new();
     let mut spans = vec![];
 
@@ -186,7 +186,7 @@ pub fn check_attrs<'a>(cx: &EarlyContext, valid_idents: &[String], attrs: &'a [a
 }
 
 fn check_doc<'a, Events: Iterator<Item = (usize, pulldown_cmark::Event<'a>)>>(
-    cx: &EarlyContext,
+    cx: &EarlyContext<'_>,
     valid_idents: &[String],
     docs: Events,
     spans: &[(usize, Span)],
@@ -232,7 +232,7 @@ fn check_doc<'a, Events: Iterator<Item = (usize, pulldown_cmark::Event<'a>)>>(
     }
 }
 
-fn check_text(cx: &EarlyContext, valid_idents: &[String], text: &str, span: Span) {
+fn check_text(cx: &EarlyContext<'_>, valid_idents: &[String], text: &str, span: Span) {
     for word in text.split_whitespace() {
         // Trim punctuation as in `some comment (see foo::bar).`
         //                                                   ^^
@@ -255,7 +255,7 @@ fn check_text(cx: &EarlyContext, valid_idents: &[String], text: &str, span: Span
     }
 }
 
-fn check_word(cx: &EarlyContext, word: &str, span: Span) {
+fn check_word(cx: &EarlyContext<'_>, word: &str, span: Span) {
     /// Checks if a string is camel-case, ie. contains at least two uppercase
     /// letter (`Clippy` is
     /// ok) and one lower-case letter (`NASA` is ok). Plural are also excluded

--- a/clippy_lints/src/double_parens.rs
+++ b/clippy_lints/src/double_parens.rs
@@ -31,7 +31,7 @@ impl LintPass for DoubleParens {
 }
 
 impl EarlyLintPass for DoubleParens {
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         match expr.node {
             ExprKind::Paren(ref in_paren) => match in_paren.node {
                 ExprKind::Paren(_) | ExprKind::Tup(_) => {

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -49,7 +49,7 @@ impl LintPass for ElseIfWithoutElse {
 }
 
 impl EarlyLintPass for ElseIfWithoutElse {
-    fn check_expr(&mut self, cx: &EarlyContext, mut item: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, mut item: &Expr) {
         if in_external_macro(cx, item.span) {
             return;
         }

--- a/clippy_lints/src/empty_enum.rs
+++ b/clippy_lints/src/empty_enum.rs
@@ -33,7 +33,7 @@ impl LintPass for EmptyEnum {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EmptyEnum {
-    fn check_item(&mut self, cx: &LateContext, item: &Item) {
+    fn check_item(&mut self, cx: &LateContext<'_, '_>, item: &Item) {
         let did = cx.tcx.hir.local_def_id(item.id);
         if let ItemKind::Enum(..) = item.node {
             let ty = cx.tcx.type_of(did);

--- a/clippy_lints/src/enum_glob_use.rs
+++ b/clippy_lints/src/enum_glob_use.rs
@@ -44,7 +44,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EnumGlobUse {
 }
 
 impl EnumGlobUse {
-    fn lint_item(&self, cx: &LateContext, item: &Item) {
+    fn lint_item(&self, cx: &LateContext<'_, '_>, item: &Item) {
         if item.vis.node.is_pub() {
             return; // re-exports are fine
         }

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -149,7 +149,7 @@ fn partial_rmatch(post: &str, name: &str) -> usize {
 // FIXME: #600
 #[allow(while_let_on_iterator)]
 fn check_variant(
-    cx: &EarlyContext,
+    cx: &EarlyContext<'_>,
     threshold: u64,
     def: &EnumDef,
     item_name: &str,
@@ -240,12 +240,12 @@ fn to_camel_case(item_name: &str) -> String {
 }
 
 impl EarlyLintPass for EnumVariantNames {
-    fn check_item_post(&mut self, _cx: &EarlyContext, _item: &Item) {
+    fn check_item_post(&mut self, _cx: &EarlyContext<'_>, _item: &Item) {
         let last = self.modules.pop();
         assert!(last.is_some());
     }
 
-    fn check_item(&mut self, cx: &EarlyContext, item: &Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         let item_name = item.ident.as_str();
         let item_name_chars = item_name.chars().count();
         let item_camel = to_camel_case(&item_name);

--- a/clippy_lints/src/erasing_op.rs
+++ b/clippy_lints/src/erasing_op.rs
@@ -50,7 +50,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ErasingOp {
     }
 }
 
-fn check(cx: &LateContext, e: &Expr, span: Span) {
+fn check(cx: &LateContext<'_, '_>, e: &Expr, span: Span) {
     if let Some(Constant::Int(v)) = constant_simple(cx, cx.tables, e) {
         if v == 0 {
             span_lint(

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     "using `Box<T>` where unnecessary"
 }
 
-fn is_non_trait_box(ty: Ty) -> bool {
+fn is_non_trait_box(ty: Ty<'_>) -> bool {
     ty.is_box() && !ty.boxed_ty().is_trait()
 }
 
@@ -137,7 +137,7 @@ impl<'a, 'tcx> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
             }
         }
     }
-    fn borrow(&mut self, _: NodeId, _: Span, cmt: &cmt_<'tcx>, _: ty::Region, _: ty::BorrowKind, loan_cause: LoanCause) {
+    fn borrow(&mut self, _: NodeId, _: Span, cmt: &cmt_<'tcx>, _: ty::Region<'_>, _: ty::BorrowKind, loan_cause: LoanCause) {
         if let Categorization::Local(lid) = cmt.cat {
             match loan_cause {
                 // x.foo()

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EtaPass {
     }
 }
 
-fn check_closure(cx: &LateContext, expr: &Expr) {
+fn check_closure(cx: &LateContext<'_, '_>, expr: &Expr) {
     if let ExprKind::Closure(_, ref decl, eid, _, _) = expr.node {
         let body = cx.tcx.hir.body(eid);
         let ex = &body.value;

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> Visitor<'tcx> for DivergenceVisitor<'a, 'tcx> {
 ///   logical operators are considered to have a defined evaluation order.
 ///
 /// When such a read is found, the lint is triggered.
-fn check_for_unsequenced_reads(vis: &mut ReadVisitor) {
+fn check_for_unsequenced_reads(vis: &mut ReadVisitor<'_, '_>) {
     let map = &vis.cx.tcx.hir;
     let mut cur_id = vis.write_expr.id;
     loop {
@@ -348,7 +348,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
 }
 
 /// Returns true if `expr` is the LHS of an assignment, like `expr = ...`.
-fn is_in_assignment_position(cx: &LateContext, expr: &Expr) -> bool {
+fn is_in_assignment_position(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
     if let Some(parent) = get_parent_expr(cx, expr) {
         if let ExprKind::Assign(ref lhs, _) = parent.node {
             return lhs.id == expr.id;

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -128,7 +128,7 @@ fn lint_impl_body<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, impl_span: Span, impl_it
     }
 }
 
-fn match_type(tcx: ty::TyCtxt, ty: ty::Ty, path: &[&str]) -> bool {
+fn match_type(tcx: ty::TyCtxt<'_, '_, '_>, ty: ty::Ty<'_>, path: &[&str]) -> bool {
     match ty.sty {
         ty::TyAdt(adt, _) => match_def_path(tcx, adt.did, path),
         _ => false,

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -105,7 +105,7 @@ fn check_single_piece(expr: &Expr) -> bool {
 /// ```
 /// and that type of `__arg0` is `&str` or `String`
 /// then returns the span of first element of the matched tuple
-fn get_single_string_arg(cx: &LateContext, expr: &Expr) -> Option<Span> {
+fn get_single_string_arg(cx: &LateContext<'_, '_>, expr: &Expr) -> Option<Span> {
     if_chain! {
         if let ExprKind::AddrOf(_, ref expr) = expr.node;
         if let ExprKind::Match(ref match_expr, ref arms, _) = expr.node;

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -83,7 +83,7 @@ impl LintPass for Formatting {
 }
 
 impl EarlyLintPass for Formatting {
-    fn check_block(&mut self, cx: &EarlyContext, block: &ast::Block) {
+    fn check_block(&mut self, cx: &EarlyContext<'_>, block: &ast::Block) {
         for w in block.stmts.windows(2) {
             match (&w[0].node, &w[1].node) {
                 (&ast::StmtKind::Expr(ref first), &ast::StmtKind::Expr(ref second)) |
@@ -95,7 +95,7 @@ impl EarlyLintPass for Formatting {
         }
     }
 
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &ast::Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
         check_assign(cx, expr);
         check_else_if(cx, expr);
         check_array(cx, expr);
@@ -103,7 +103,7 @@ impl EarlyLintPass for Formatting {
 }
 
 /// Implementation of the `SUSPICIOUS_ASSIGNMENT_FORMATTING` lint.
-fn check_assign(cx: &EarlyContext, expr: &ast::Expr) {
+fn check_assign(cx: &EarlyContext<'_>, expr: &ast::Expr) {
     if let ast::ExprKind::Assign(ref lhs, ref rhs) = expr.node {
         if !differing_macro_contexts(lhs.span, rhs.span) && !in_macro(lhs.span) {
             let eq_span = lhs.span.between(rhs.span);
@@ -132,7 +132,7 @@ fn check_assign(cx: &EarlyContext, expr: &ast::Expr) {
 }
 
 /// Implementation of the `SUSPICIOUS_ELSE_FORMATTING` lint for weird `else if`.
-fn check_else_if(cx: &EarlyContext, expr: &ast::Expr) {
+fn check_else_if(cx: &EarlyContext<'_>, expr: &ast::Expr) {
     if let Some((then, &Some(ref else_))) = unsugar_if(expr) {
         if unsugar_if(else_).is_some() && !differing_macro_contexts(then.span, else_.span) && !in_macro(then.span) {
             // this will be a span from the closing ‘}’ of the “then” block (excluding) to
@@ -164,7 +164,7 @@ fn check_else_if(cx: &EarlyContext, expr: &ast::Expr) {
 }
 
 /// Implementation of the `POSSIBLE_MISSING_COMMA` lint for array
-fn check_array(cx: &EarlyContext, expr: &ast::Expr) {
+fn check_array(cx: &EarlyContext<'_>, expr: &ast::Expr) {
     if let ast::ExprKind::Array(ref array) = expr.node {
         for element in array {
             if let ast::ExprKind::Binary(ref op, ref lhs, _) = element.node {
@@ -190,7 +190,7 @@ fn check_array(cx: &EarlyContext, expr: &ast::Expr) {
 }
 
 /// Implementation of the `SUSPICIOUS_ELSE_FORMATTING` lint for consecutive ifs.
-fn check_consecutive_ifs(cx: &EarlyContext, first: &ast::Expr, second: &ast::Expr) {
+fn check_consecutive_ifs(cx: &EarlyContext<'_>, first: &ast::Expr, second: &ast::Expr) {
     if !differing_macro_contexts(first.span, second.span) && !in_macro(first.span) && unsugar_if(first).is_some()
         && unsugar_if(second).is_some()
     {

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -128,7 +128,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Functions {
 }
 
 impl<'a, 'tcx> Functions {
-    fn check_arg_number(self, cx: &LateContext, decl: &hir::FnDecl, span: Span) {
+    fn check_arg_number(self, cx: &LateContext<'_, '_>, decl: &hir::FnDecl, span: Span) {
         let args = decl.inputs.len() as u64;
         if args > self.threshold {
             span_lint(

--- a/clippy_lints/src/identity_op.rs
+++ b/clippy_lints/src/identity_op.rs
@@ -60,7 +60,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityOp {
 }
 
 #[allow(cast_possible_wrap)]
-fn check(cx: &LateContext, e: &Expr, m: i8, span: Span, arg: Span) {
+fn check(cx: &LateContext<'_, '_>, e: &Expr, m: i8, span: Span, arg: Span) {
     if let Some(Constant::Int(v)) = constant_simple(cx, cx.tables, e) {
         let check = match cx.tables.expr_ty(e).sty {
             ty::TyInt(ity) => unsext(cx.tcx, -1i128, ity),

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -47,7 +47,7 @@ impl LintPass for IfNotElse {
 }
 
 impl EarlyLintPass for IfNotElse {
-    fn check_expr(&mut self, cx: &EarlyContext, item: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, item: &Expr) {
         if in_external_macro(cx, item.span) {
             return;
         }

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -155,7 +155,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IndexingSlicing {
 /// the range.
 fn to_const_range<'a, 'tcx>(
     cx: &LateContext<'a, 'tcx>,
-    range: Range,
+    range: Range<'_>,
     array_size: u128,
 ) -> Option<(u128, u128)> {
     let s = range

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -140,7 +140,7 @@ static HEURISTICS: &[(&str, usize, Heuristic, Finiteness)] = &[
     ("scan", 3, First, MaybeInfinite),
 ];
 
-fn is_infinite(cx: &LateContext, expr: &Expr) -> Finiteness {
+fn is_infinite(cx: &LateContext<'_, '_>, expr: &Expr) -> Finiteness {
     match expr.node {
         ExprKind::MethodCall(ref method, _, ref args) => {
             for &(name, len, heuristic, cap) in HEURISTICS.iter() {
@@ -204,7 +204,7 @@ static COMPLETING_METHODS: &[(&str, usize)] = &[
     ("product", 1),
 ];
 
-fn complete_infinite_iter(cx: &LateContext, expr: &Expr) -> Finiteness {
+fn complete_infinite_iter(cx: &LateContext<'_, '_>, expr: &Expr) -> Finiteness {
     match expr.node {
         ExprKind::MethodCall(ref method, _, ref args) => {
             for &(name, len) in COMPLETING_METHODS.iter() {

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -44,7 +44,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     }
 }
 
-fn check_attrs(cx: &LateContext, name: Name, attrs: &[Attribute]) {
+fn check_attrs(cx: &LateContext<'_, '_>, name: Name, attrs: &[Attribute]) {
     for attr in attrs {
         if attr.name() != "inline" {
             continue;

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -61,7 +61,7 @@ impl IntPlusOne {
         false
     }
 
-    fn check_binop(&self, cx: &EarlyContext, binop: BinOpKind, lhs: &Expr, rhs: &Expr) -> Option<String> {
+    fn check_binop(&self, cx: &EarlyContext<'_>, binop: BinOpKind, lhs: &Expr, rhs: &Expr) -> Option<String> {
         match (binop, &lhs.node, &rhs.node) {
             // case where `x - 1 >= ...` or `-1 + x >= ...`
             (BinOpKind::Ge, &ExprKind::Binary(ref lhskind, ref lhslhs, ref lhsrhs), _) => {
@@ -127,7 +127,7 @@ impl IntPlusOne {
 
     fn generate_recommendation(
         &self,
-        cx: &EarlyContext,
+        cx: &EarlyContext<'_>,
         binop: BinOpKind,
         node: &Expr,
         other_side: &Expr,
@@ -150,7 +150,7 @@ impl IntPlusOne {
         None
     }
 
-    fn emit_warning(&self, cx: &EarlyContext, block: &Expr, recommendation: String) {
+    fn emit_warning(&self, cx: &EarlyContext<'_>, block: &Expr, recommendation: String) {
         span_lint_and_then(cx, INT_PLUS_ONE, block.span, "Unnecessary `>= y + 1` or `x - 1 >=`", |db| {
             db.span_suggestion(block.span, "change `>= y + 1` to `> y` as shown", recommendation);
         });
@@ -158,7 +158,7 @@ impl IntPlusOne {
 }
 
 impl EarlyLintPass for IntPlusOne {
-    fn check_expr(&mut self, cx: &EarlyContext, item: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, item: &Expr) {
         if let ExprKind::Binary(ref kind, ref lhs, ref rhs) = item.node {
             if let Some(ref rec) = self.check_binop(cx, kind.node, lhs, rhs) {
                 self.emit_warning(cx, item, rec.clone());

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -43,7 +43,7 @@ impl LintPass for ItemsAfterStatements {
 }
 
 impl EarlyLintPass for ItemsAfterStatements {
-    fn check_block(&mut self, cx: &EarlyContext, item: &Block) {
+    fn check_block(&mut self, cx: &EarlyContext<'_>, item: &Block) {
         if in_macro(item.span) {
             return;
         }

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -48,7 +48,7 @@ impl LintPass for LargeEnumVariant {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
-    fn check_item(&mut self, cx: &LateContext, item: &Item) {
+    fn check_item(&mut self, cx: &LateContext<'_, '_>, item: &Item) {
         let did = cx.tcx.hir.local_def_id(item.id);
         if let ItemKind::Enum(ref def, _) = item.node {
             let ty = cx.tcx.type_of(did);

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -106,8 +106,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LenZero {
     }
 }
 
-fn check_trait_items(cx: &LateContext, visited_trait: &Item, trait_items: &[TraitItemRef]) {
-    fn is_named_self(cx: &LateContext, item: &TraitItemRef, name: &str) -> bool {
+fn check_trait_items(cx: &LateContext<'_, '_>, visited_trait: &Item, trait_items: &[TraitItemRef]) {
+    fn is_named_self(cx: &LateContext<'_, '_>, item: &TraitItemRef, name: &str) -> bool {
         item.ident.name == name && if let AssociatedItemKind::Method { has_self } = item.kind {
             has_self && {
                 let did = cx.tcx.hir.local_def_id(item.id.node_id);
@@ -119,7 +119,7 @@ fn check_trait_items(cx: &LateContext, visited_trait: &Item, trait_items: &[Trai
     }
 
     // fill the set with current and super traits
-    fn fill_trait_set(traitt: DefId, set: &mut HashSet<DefId>, cx: &LateContext) {
+    fn fill_trait_set(traitt: DefId, set: &mut HashSet<DefId>, cx: &LateContext<'_, '_>) {
         if set.insert(traitt) {
             for supertrait in ::rustc::traits::supertrait_def_ids(cx.tcx, traitt) {
                 fill_trait_set(supertrait, set, cx);
@@ -154,8 +154,8 @@ fn check_trait_items(cx: &LateContext, visited_trait: &Item, trait_items: &[Trai
     }
 }
 
-fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[ImplItemRef]) {
-    fn is_named_self(cx: &LateContext, item: &ImplItemRef, name: &str) -> bool {
+fn check_impl_items(cx: &LateContext<'_, '_>, item: &Item, impl_items: &[ImplItemRef]) {
+    fn is_named_self(cx: &LateContext<'_, '_>, item: &ImplItemRef, name: &str) -> bool {
         item.ident.name == name && if let AssociatedItemKind::Method { has_self } = item.kind {
             has_self && {
                 let did = cx.tcx.hir.local_def_id(item.id.node_id);
@@ -194,7 +194,7 @@ fn check_impl_items(cx: &LateContext, item: &Item, impl_items: &[ImplItemRef]) {
     }
 }
 
-fn check_cmp(cx: &LateContext, span: Span, method: &Expr, lit: &Expr, op: &str, compare_to: u32) {
+fn check_cmp(cx: &LateContext<'_, '_>, span: Span, method: &Expr, lit: &Expr, op: &str, compare_to: u32) {
     if let (&ExprKind::MethodCall(ref method_path, _, ref args), &ExprKind::Lit(ref lit)) = (&method.node, &lit.node) {
         // check if we are in an is_empty() method
         if let Some(name) = get_item_name(cx, method) {
@@ -207,7 +207,7 @@ fn check_cmp(cx: &LateContext, span: Span, method: &Expr, lit: &Expr, op: &str, 
     }
 }
 
-fn check_len(cx: &LateContext, span: Span, method_name: Name, args: &[Expr], lit: &Lit, op: &str, compare_to: u32) {
+fn check_len(cx: &LateContext<'_, '_>, span: Span, method_name: Name, args: &[Expr], lit: &Lit, op: &str, compare_to: u32) {
     if let Spanned {
         node: LitKind::Int(lit, _),
         ..
@@ -232,9 +232,9 @@ fn check_len(cx: &LateContext, span: Span, method_name: Name, args: &[Expr], lit
 }
 
 /// Check if this type has an `is_empty` method.
-fn has_is_empty(cx: &LateContext, expr: &Expr) -> bool {
+fn has_is_empty(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
     /// Get an `AssociatedItem` and return true if it matches `is_empty(self)`.
-    fn is_is_empty(cx: &LateContext, item: &ty::AssociatedItem) -> bool {
+    fn is_is_empty(cx: &LateContext<'_, '_>, item: &ty::AssociatedItem) -> bool {
         if let ty::AssociatedKind::Method = item.kind {
             if item.ident.name == "is_empty" {
                 let sig = cx.tcx.fn_sig(item.def_id);
@@ -249,7 +249,7 @@ fn has_is_empty(cx: &LateContext, expr: &Expr) -> bool {
     }
 
     /// Check the inherent impl's items for an `is_empty(self)` method.
-    fn has_is_empty_impl(cx: &LateContext, id: DefId) -> bool {
+    fn has_is_empty_impl(cx: &LateContext<'_, '_>, id: DefId) -> bool {
         cx.tcx.inherent_impls(id).iter().any(|imp| {
             cx.tcx
                 .associated_items(*imp)

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -20,34 +20,34 @@ use rustc_plugin;
 
 macro_rules! declare_clippy_lint {
     { pub $name:tt, style, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
     };
     { pub $name:tt, correctness, $description:tt } => {
-        declare_lint! { pub $name, Deny, $description }
+        declare_lint! { pub $name, Deny, $description, report_in_external_macro }
     };
     { pub $name:tt, complexity, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
     };
     { pub $name:tt, perf, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
     };
     { pub $name:tt, pedantic, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
     };
     { pub $name:tt, restriction, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
     };
     { pub $name:tt, cargo, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
     };
     { pub $name:tt, nursery, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
     };
     { pub $name:tt, internal, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
     };
     { pub $name:tt, internal_warn, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
     };
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -20,34 +20,34 @@ use rustc_plugin;
 
 macro_rules! declare_clippy_lint {
     { pub $name:tt, style, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro: true }
     };
     { pub $name:tt, correctness, $description:tt } => {
-        declare_lint! { pub $name, Deny, $description, report_in_external_macro }
+        declare_lint! { pub $name, Deny, $description, report_in_external_macro: true }
     };
     { pub $name:tt, complexity, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro: true }
     };
     { pub $name:tt, perf, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro: true }
     };
     { pub $name:tt, pedantic, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro: true }
     };
     { pub $name:tt, restriction, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro: true }
     };
     { pub $name:tt, cargo, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro: true }
     };
     { pub $name:tt, nursery, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro: true }
     };
     { pub $name:tt, internal, $description:tt } => {
-        declare_lint! { pub $name, Allow, $description, report_in_external_macro }
+        declare_lint! { pub $name, Allow, $description, report_in_external_macro: true }
     };
     { pub $name:tt, internal_warn, $description:tt } => {
-        declare_lint! { pub $name, Warn, $description, report_in_external_macro }
+        declare_lint! { pub $name, Warn, $description, report_in_external_macro: true }
     };
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -181,7 +181,7 @@ pub fn register_pre_expansion_lints(session: &rustc::session::Session, store: &m
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
+pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>) {
     let conf = match utils::conf::file_from_args(reg.args()) {
         Ok(file_name) => {
             // if the user specified a file, it must exist, otherwise default to `clippy.toml` but

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -16,6 +16,7 @@
 
 use toml;
 use rustc_plugin;
+use rustc;
 
 
 macro_rules! declare_clippy_lint {
@@ -175,6 +176,10 @@ mod reexport {
     crate use syntax::ast::{Name, NodeId};
 }
 
+pub fn register_pre_expansion_lints(session: &rustc::session::Session, store: &mut rustc::lint::LintStore) {
+    store.register_pre_expansion_pass(Some(session), box write::Pass);
+}
+
 #[cfg_attr(rustfmt, rustfmt_skip)]
 pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     let conf = match utils::conf::file_from_args(reg.args()) {
@@ -320,7 +325,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry) {
     reg.register_late_lint_pass(box strings::StringLitAsBytes);
     reg.register_late_lint_pass(box derive::Derive);
     reg.register_late_lint_pass(box types::CharLitAsU8);
-    reg.register_late_lint_pass(box write::Pass);
     reg.register_late_lint_pass(box vec::Pass);
     reg.register_early_lint_pass(box non_expressive_names::NonExpressiveNames {
         single_char_binding_names_threshold: conf.single_char_binding_names_threshold,

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -229,7 +229,7 @@ enum WarningType {
 }
 
 impl WarningType {
-    crate fn display(&self, grouping_hint: &str, cx: &EarlyContext, span: syntax_pos::Span) {
+    crate fn display(&self, grouping_hint: &str, cx: &EarlyContext<'_>, span: syntax_pos::Span) {
         match self {
             WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,
@@ -281,7 +281,7 @@ impl LintPass for LiteralDigitGrouping {
 }
 
 impl EarlyLintPass for LiteralDigitGrouping {
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if in_external_macro(cx, expr.span) {
             return;
         }
@@ -293,7 +293,7 @@ impl EarlyLintPass for LiteralDigitGrouping {
 }
 
 impl LiteralDigitGrouping {
-    fn check_lit(self, cx: &EarlyContext, lit: &Lit) {
+    fn check_lit(self, cx: &EarlyContext<'_>, lit: &Lit) {
         match lit.node {
             LitKind::Int(..) => {
                 // Lint integral literals.
@@ -421,7 +421,7 @@ impl LintPass for LiteralRepresentation {
 }
 
 impl EarlyLintPass for LiteralRepresentation {
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if in_external_macro(cx, expr.span) {
             return;
         }
@@ -438,7 +438,7 @@ impl LiteralRepresentation {
             threshold,
         }
     }
-    fn check_lit(self, cx: &EarlyContext, lit: &Lit) {
+    fn check_lit(self, cx: &EarlyContext<'_>, lit: &Lit) {
         // Lint integral literals.
         if_chain! {
             if let LitKind::Int(..) = lit.node;

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -743,7 +743,7 @@ struct FixedOffsetVar {
     offset: Offset,
 }
 
-fn is_slice_like<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty) -> bool {
+fn is_slice_like<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'_>) -> bool {
     let is_slice = match ty.sty {
         ty::TyRef(_, subty, _) => is_slice_like(cx, subty),
         ty::TySlice(..) | ty::TyArray(..) => true,
@@ -1185,7 +1185,7 @@ fn check_for_loop_reverse_range<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, arg: &'tcx
     }
 }
 
-fn lint_iter_method(cx: &LateContext, args: &[Expr], arg: &Expr, method_name: &str) {
+fn lint_iter_method(cx: &LateContext<'_, '_>, args: &[Expr], arg: &Expr, method_name: &str) {
     let object = snippet(cx, args[0].span, "_");
     let muta = if method_name == "iter_mut" {
         "mut "
@@ -1203,7 +1203,7 @@ fn lint_iter_method(cx: &LateContext, args: &[Expr], arg: &Expr, method_name: &s
     )
 }
 
-fn check_for_loop_arg(cx: &LateContext, pat: &Pat, arg: &Expr, expr: &Expr) {
+fn check_for_loop_arg(cx: &LateContext<'_, '_>, pat: &Pat, arg: &Expr, expr: &Expr) {
     let mut next_loop_linted = false; // whether or not ITER_NEXT_LOOP lint was used
     if let ExprKind::MethodCall(ref method, _, ref args) = arg.node {
         // just the receiver, no arguments
@@ -1258,7 +1258,7 @@ fn check_for_loop_arg(cx: &LateContext, pat: &Pat, arg: &Expr, expr: &Expr) {
 }
 
 /// Check for `for` loops over `Option`s and `Results`
-fn check_arg_type(cx: &LateContext, pat: &Pat, arg: &Expr) {
+fn check_arg_type(cx: &LateContext<'_, '_>, pat: &Pat, arg: &Expr) {
     let ty = cx.tables.expr_ty(arg);
     if match_type(cx, ty, &paths::OPTION) {
         span_help_and_lint(
@@ -1420,7 +1420,7 @@ impl<'tcx> Delegate<'tcx> for MutatePairDelegate {
 
     fn consume_pat(&mut self, _: &Pat, _: &cmt_<'tcx>, _: ConsumeMode) {}
 
-    fn borrow(&mut self, _: NodeId, sp: Span, cmt: &cmt_<'tcx>, _: ty::Region, bk: ty::BorrowKind, _: LoanCause) {
+    fn borrow(&mut self, _: NodeId, sp: Span, cmt: &cmt_<'tcx>, _: ty::Region<'_>, bk: ty::BorrowKind, _: LoanCause) {
         if let ty::BorrowKind::MutBorrow = bk {
             if let Categorization::Local(id) = cmt.cat {
                 if Some(id) == self.node_id_low {
@@ -1453,7 +1453,7 @@ impl<'tcx> MutatePairDelegate {
     }
 }
 
-fn check_for_mut_range_bound(cx: &LateContext, arg: &Expr, body: &Expr) {
+fn check_for_mut_range_bound(cx: &LateContext<'_, '_>, arg: &Expr, body: &Expr) {
     if let Some(higher::Range {
         start: Some(start),
         end: Some(end),
@@ -1472,7 +1472,7 @@ fn check_for_mut_range_bound(cx: &LateContext, arg: &Expr, body: &Expr) {
     }
 }
 
-fn mut_warn_with_span(cx: &LateContext, span: Option<Span>) {
+fn mut_warn_with_span(cx: &LateContext<'_, '_>, span: Option<Span>) {
     if let Some(sp) = span {
         span_lint(
             cx,
@@ -1483,7 +1483,7 @@ fn mut_warn_with_span(cx: &LateContext, span: Option<Span>) {
     }
 }
 
-fn check_for_mutability(cx: &LateContext, bound: &Expr) -> Option<NodeId> {
+fn check_for_mutability(cx: &LateContext<'_, '_>, bound: &Expr) -> Option<NodeId> {
     if_chain! {
         if let ExprKind::Path(ref qpath) = bound.node;
         if let QPath::Resolved(None, _) = *qpath;
@@ -1505,7 +1505,7 @@ fn check_for_mutability(cx: &LateContext, bound: &Expr) -> Option<NodeId> {
     None
 }
 
-fn check_for_mutation(cx: &LateContext, body: &Expr, bound_ids: &[Option<NodeId>]) -> (Option<Span>, Option<Span>) {
+fn check_for_mutation(cx: &LateContext<'_, '_>, body: &Expr, bound_ids: &[Option<NodeId>]) -> (Option<Span>, Option<Span>) {
     let mut delegate = MutatePairDelegate {
         node_id_low: bound_ids[0],
         node_id_high: bound_ids[1],
@@ -1782,7 +1782,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarUsedAfterLoopVisitor<'a, 'tcx> {
 /// Return true if the type of expr is one that provides `IntoIterator` impls
 /// for `&T` and `&mut T`, such as `Vec`.
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn is_ref_iterable_type(cx: &LateContext, e: &Expr) -> bool {
+fn is_ref_iterable_type(cx: &LateContext<'_, '_>, e: &Expr) -> bool {
     // no walk_ptrs_ty: calling iter() on a reference can make sense because it
     // will allow further borrows afterwards
     let ty = cx.tables.expr_ty(e);
@@ -1797,7 +1797,7 @@ fn is_ref_iterable_type(cx: &LateContext, e: &Expr) -> bool {
     match_type(cx, ty, &paths::BTREESET)
 }
 
-fn is_iterable_array(ty: Ty, cx: &LateContext) -> bool {
+fn is_iterable_array(ty: Ty<'_>, cx: &LateContext<'_, '_>) -> bool {
     // IntoIterator is currently only implemented for array sizes <= 32 in rustc
     match ty.sty {
         ty::TyArray(_, n) => (0..=32).contains(&n.assert_usize(cx.tcx).expect("array length")),
@@ -2006,7 +2006,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
     }
 }
 
-fn var_def_id(cx: &LateContext, expr: &Expr) -> Option<NodeId> {
+fn var_def_id(cx: &LateContext<'_, '_>, expr: &Expr) -> Option<NodeId> {
     if let ExprKind::Path(ref qpath) = expr.node {
         let path_res = cx.tables.qpath_def(qpath, expr.hir_id);
         if let Def::Local(node_id) = path_res {
@@ -2030,7 +2030,7 @@ fn is_conditional(expr: &Expr) -> bool {
     }
 }
 
-fn is_nested(cx: &LateContext, match_expr: &Expr, iter_expr: &Expr) -> bool {
+fn is_nested(cx: &LateContext<'_, '_>, match_expr: &Expr, iter_expr: &Expr) -> bool {
     if_chain! {
         if let Some(loop_block) = get_enclosing_block(cx, match_expr.id);
         if let Some(map::Node::NodeExpr(loop_expr)) = cx.tcx.hir.find(cx.tcx.hir.get_parent_node(loop_block.id));
@@ -2041,7 +2041,7 @@ fn is_nested(cx: &LateContext, match_expr: &Expr, iter_expr: &Expr) -> bool {
     false
 }
 
-fn is_loop_nested(cx: &LateContext, loop_expr: &Expr, iter_expr: &Expr) -> bool {
+fn is_loop_nested(cx: &LateContext<'_, '_>, loop_expr: &Expr, iter_expr: &Expr) -> bool {
     let mut id = loop_expr.id;
     let iter_name = if let Some(name) = path_name(iter_expr) {
         name

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -100,7 +100,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     }
 }
 
-fn expr_eq_name(cx: &LateContext, expr: &Expr, id: ast::Ident) -> bool {
+fn expr_eq_name(cx: &LateContext<'_, '_>, expr: &Expr, id: ast::Ident) -> bool {
     match expr.node {
         ExprKind::Path(QPath::Resolved(None, ref path)) => {
             let arg_segment = [
@@ -116,7 +116,7 @@ fn expr_eq_name(cx: &LateContext, expr: &Expr, id: ast::Ident) -> bool {
     }
 }
 
-fn get_type_name(cx: &LateContext, expr: &Expr, arg: &Expr) -> Option<&'static str> {
+fn get_type_name(cx: &LateContext<'_, '_>, expr: &Expr, arg: &Expr) -> Option<&'static str> {
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         Some("iterator")
     } else if match_type(cx, walk_ptrs_ty(cx.tables.expr_ty(arg)), &paths::OPTION) {
@@ -126,7 +126,7 @@ fn get_type_name(cx: &LateContext, expr: &Expr, arg: &Expr) -> Option<&'static s
     }
 }
 
-fn only_derefs(cx: &LateContext, expr: &Expr, id: ast::Ident) -> bool {
+fn only_derefs(cx: &LateContext<'_, '_>, expr: &Expr, id: ast::Ident) -> bool {
     match expr.node {
         ExprKind::Unary(UnDeref, ref subexpr) if !is_adjusted(cx, subexpr) => only_derefs(cx, subexpr, id),
         _ => expr_eq_name(cx, expr, id),

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -84,7 +84,7 @@ impl LintPass for Pass {
     }
 }
 
-fn is_unit_type(ty: ty::Ty) -> bool {
+fn is_unit_type(ty: ty::Ty<'_>) -> bool {
     match ty.sty {
         ty::TyTuple(slice) => slice.is_empty(),
         ty::TyNever => true,
@@ -92,7 +92,7 @@ fn is_unit_type(ty: ty::Ty) -> bool {
     }
 }
 
-fn is_unit_function(cx: &LateContext, expr: &hir::Expr) -> bool {
+fn is_unit_function(cx: &LateContext<'_, '_>, expr: &hir::Expr) -> bool {
     let ty = cx.tables.expr_ty(expr);
 
     if let ty::TyFnDef(id, _) = ty.sty {
@@ -103,7 +103,7 @@ fn is_unit_function(cx: &LateContext, expr: &hir::Expr) -> bool {
     false
 }
 
-fn is_unit_expression(cx: &LateContext, expr: &hir::Expr) -> bool {
+fn is_unit_expression(cx: &LateContext<'_, '_>, expr: &hir::Expr) -> bool {
     is_unit_type(cx.tables.expr_ty(expr))
 }
 
@@ -111,7 +111,7 @@ fn is_unit_expression(cx: &LateContext, expr: &hir::Expr) -> bool {
 /// semicolons, which causes problems when generating a suggestion. Given an
 /// expression that evaluates to '()' or '!', recursively remove useless braces
 /// and semi-colons until is suitable for including in the suggestion template
-fn reduce_unit_expression<'a>(cx: &LateContext, expr: &'a hir::Expr) -> Option<Span> {
+fn reduce_unit_expression<'a>(cx: &LateContext<'_, '_>, expr: &'a hir::Expr) -> Option<Span> {
     if !is_unit_expression(cx, expr) {
         return None;
     }
@@ -175,7 +175,7 @@ fn unit_closure<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'a hir::Expr) -> Op
 /// `y` => `_y`
 ///
 /// Anything else will return `_`.
-fn let_binding_name(cx: &LateContext, var_arg: &hir::Expr) -> String {
+fn let_binding_name(cx: &LateContext<'_, '_>, var_arg: &hir::Expr) -> String {
     match &var_arg.node {
         hir::ExprKind::Field(_, _) => snippet(cx, var_arg.span, "_").replace(".", "_"),
         hir::ExprKind::Path(_) => format!("_{}", snippet(cx, var_arg.span, "")),
@@ -191,7 +191,7 @@ fn suggestion_msg(function_type: &str, map_type: &str) -> String {
     )
 }
 
-fn lint_map_unit_fn(cx: &LateContext, stmt: &hir::Stmt, expr: &hir::Expr, map_args: &[hir::Expr]) {
+fn lint_map_unit_fn(cx: &LateContext<'_, '_>, stmt: &hir::Stmt, expr: &hir::Expr, map_args: &[hir::Expr]) {
     let var_arg = &map_args[0];
     let fn_arg = &map_args[1];
 
@@ -244,7 +244,7 @@ fn lint_map_unit_fn(cx: &LateContext, stmt: &hir::Stmt, expr: &hir::Expr, map_ar
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_stmt(&mut self, cx: &LateContext, stmt: &hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext<'_, '_>, stmt: &hir::Stmt) {
         if in_macro(stmt.span) {
             return;
         }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -200,7 +200,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MatchPass {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn check_single_match(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) {
+fn check_single_match(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     if arms.len() == 2 &&
       arms[0].pats.len() == 1 && arms[0].guard.is_none() &&
       arms[1].pats.len() == 1 && arms[1].guard.is_none() {
@@ -222,13 +222,13 @@ fn check_single_match(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) {
     }
 }
 
-fn check_single_match_single_pattern(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr, els: Option<&Expr>) {
+fn check_single_match_single_pattern(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr, els: Option<&Expr>) {
     if is_wild(&arms[1].pats[0]) {
         report_single_match_single_pattern(cx, ex, arms, expr, els);
     }
 }
 
-fn report_single_match_single_pattern(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr, els: Option<&Expr>) {
+fn report_single_match_single_pattern(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr, els: Option<&Expr>) {
     let lint = if els.is_some() {
         SINGLE_MATCH_ELSE
     } else {
@@ -252,7 +252,7 @@ fn report_single_match_single_pattern(cx: &LateContext, ex: &Expr, arms: &[Arm],
     );
 }
 
-fn check_single_match_opt_like(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr, ty: Ty, els: Option<&Expr>) {
+fn check_single_match_opt_like(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr, ty: Ty<'_>, els: Option<&Expr>) {
     // list of candidate Enums we know will never get any more members
     let candidates = &[
         (&paths::COW, "Borrowed"),
@@ -284,7 +284,7 @@ fn check_single_match_opt_like(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: 
     }
 }
 
-fn check_match_bool(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) {
+fn check_match_bool(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     // type of expression == bool
     if cx.tables.expr_ty(ex).sty == ty::TyBool {
         span_lint_and_then(
@@ -365,7 +365,7 @@ fn is_wild(pat: &impl std::ops::Deref<Target = Pat>) -> bool {
     }
 }
 
-fn check_wild_err_arm(cx: &LateContext, ex: &Expr, arms: &[Arm]) {
+fn check_wild_err_arm(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm]) {
     let ex_ty = walk_ptrs_ty(cx.tables.expr_ty(ex));
     if match_type(cx, ex_ty, &paths::RESULT) {
         for arm in arms {
@@ -405,7 +405,7 @@ fn is_panic_block(block: &Block) -> bool {
     }
 }
 
-fn check_match_ref_pats(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) {
+fn check_match_ref_pats(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     if has_only_ref_pats(arms) {
         let mut suggs = Vec::new();
         let (title, msg) = if let ExprKind::AddrOf(Mutability::MutImmutable, ref inner) = ex.node {
@@ -436,7 +436,7 @@ fn check_match_ref_pats(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) 
     }
 }
 
-fn check_match_as_ref(cx: &LateContext, ex: &Expr, arms: &[Arm], expr: &Expr) {
+fn check_match_as_ref(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     if arms.len() == 2 &&
         arms[0].pats.len() == 1 && arms[0].guard.is_none() &&
         arms[1].pats.len() == 1 && arms[1].guard.is_none() {

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -66,7 +66,7 @@ enum MinMax {
     Max,
 }
 
-fn min_max<'a>(cx: &LateContext, expr: &'a Expr) -> Option<(MinMax, Constant, &'a Expr)> {
+fn min_max<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<(MinMax, Constant, &'a Expr)> {
     if let ExprKind::Call(ref path, ref args) = expr.node {
         if let ExprKind::Path(ref qpath) = path.node {
             opt_def_id(cx.tables.qpath_def(qpath, path.hir_id)).and_then(|def_id| {
@@ -86,7 +86,7 @@ fn min_max<'a>(cx: &LateContext, expr: &'a Expr) -> Option<(MinMax, Constant, &'
     }
 }
 
-fn fetch_const<'a>(cx: &LateContext, args: &'a [Expr], m: MinMax) -> Option<(MinMax, Constant, &'a Expr)> {
+fn fetch_const<'a>(cx: &LateContext<'_, '_>, args: &'a [Expr], m: MinMax) -> Option<(MinMax, Constant, &'a Expr)> {
     if args.len() != 2 {
         return None;
     }

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -189,7 +189,7 @@ impl LintPass for MiscEarly {
 }
 
 impl EarlyLintPass for MiscEarly {
-    fn check_generics(&mut self, cx: &EarlyContext, gen: &Generics) {
+    fn check_generics(&mut self, cx: &EarlyContext<'_>, gen: &Generics) {
         for param in &gen.params {
             if let GenericParamKind::Type { .. } = param.kind {
                 let name = param.ident.as_str();
@@ -205,7 +205,7 @@ impl EarlyLintPass for MiscEarly {
         }
     }
 
-    fn check_pat(&mut self, cx: &EarlyContext, pat: &Pat) {
+    fn check_pat(&mut self, cx: &EarlyContext<'_>, pat: &Pat) {
         if let PatKind::Struct(ref npat, ref pfields, _) = pat.node {
             let mut wilds = 0;
             let type_name = npat.segments
@@ -266,7 +266,7 @@ impl EarlyLintPass for MiscEarly {
         }
     }
 
-    fn check_fn(&mut self, cx: &EarlyContext, _: FnKind, decl: &FnDecl, _: Span, _: NodeId) {
+    fn check_fn(&mut self, cx: &EarlyContext<'_>, _: FnKind<'_>, decl: &FnDecl, _: Span, _: NodeId) {
         let mut registered_names: HashMap<String, Span> = HashMap::new();
 
         for arg in &decl.inputs {
@@ -293,7 +293,7 @@ impl EarlyLintPass for MiscEarly {
         }
     }
 
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if in_external_macro(cx, expr.span) {
             return;
         }
@@ -325,7 +325,7 @@ impl EarlyLintPass for MiscEarly {
         }
     }
 
-    fn check_block(&mut self, cx: &EarlyContext, block: &Block) {
+    fn check_block(&mut self, cx: &EarlyContext<'_>, block: &Block) {
         for w in block.stmts.windows(2) {
             if_chain! {
                 if let StmtKind::Local(ref local) = w[0].node;
@@ -352,7 +352,7 @@ impl EarlyLintPass for MiscEarly {
 }
 
 impl MiscEarly {
-    fn check_lit(self, cx: &EarlyContext, lit: &Lit) {
+    fn check_lit(self, cx: &EarlyContext<'_>, lit: &Lit) {
         if_chain! {
             if let LitKind::Int(value, ..) = lit.node;
             if let Some(src) = snippet_opt(cx, lit.span);

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -67,7 +67,7 @@ impl MissingDoc {
             .expect("empty doc_hidden_stack")
     }
 
-    fn check_missing_docs_attrs(&self, cx: &LateContext, attrs: &[ast::Attribute], sp: Span, desc: &'static str) {
+    fn check_missing_docs_attrs(&self, cx: &LateContext<'_, '_>, attrs: &[ast::Attribute], sp: Span, desc: &'static str) {
         // If we're building a test harness, then warning about
         // documentation is probably not really relevant right now.
         if cx.sess().opts.test {

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -68,7 +68,7 @@ declare_clippy_lint! {
 
 pub struct MissingInline;
 
-fn check_missing_inline_attrs(cx: &LateContext,
+fn check_missing_inline_attrs(cx: &LateContext<'_, '_>,
                               attrs: &[ast::Attribute], sp: Span, desc: &'static str) {
     let has_inline = attrs
         .iter()

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -39,7 +39,7 @@ impl LintPass for Pass {
 }
 
 impl EarlyLintPass for Pass {
-    fn check_crate(&mut self, cx: &EarlyContext, krate: &Crate) {
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &Crate) {
         let metadata = match cargo_metadata::metadata_deps(None, true) {
             Ok(metadata) => metadata,
             Err(_) => {

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutexAtomic {
     }
 }
 
-fn get_atomic_name(ty: Ty) -> Option<(&'static str)> {
+fn get_atomic_name(ty: Ty<'_>) -> Option<(&'static str)> {
     match ty.sty {
         ty::TyBool => Some("AtomicBool"),
         ty::TyUint(_) => Some("AtomicUsize"),

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -110,7 +110,7 @@ impl LintPass for NeedlessContinue {
 }
 
 impl EarlyLintPass for NeedlessContinue {
-    fn check_expr(&mut self, ctx: &EarlyContext, expr: &ast::Expr) {
+    fn check_expr(&mut self, ctx: &EarlyContext<'_>, expr: &ast::Expr) {
         if !in_macro(expr.span) {
             check_and_warn(ctx, expr);
         }
@@ -265,7 +265,7 @@ const DROP_ELSE_BLOCK_MSG: &str = "Consider dropping the else clause, and moving
                                    block, like so:\n";
 
 
-fn emit_warning<'a>(ctx: &EarlyContext, data: &'a LintData, header: &str, typ: LintType) {
+fn emit_warning<'a>(ctx: &EarlyContext<'_>, data: &'a LintData<'_>, header: &str, typ: LintType) {
     // snip    is the whole *help* message that appears after the warning.
     // message is the warning message.
     // expr    is the expression which the lint warning message refers to.
@@ -284,7 +284,7 @@ fn emit_warning<'a>(ctx: &EarlyContext, data: &'a LintData, header: &str, typ: L
     span_help_and_lint(ctx, NEEDLESS_CONTINUE, expr.span, message, &snip);
 }
 
-fn suggestion_snippet_for_continue_inside_if<'a>(ctx: &EarlyContext, data: &'a LintData, header: &str) -> String {
+fn suggestion_snippet_for_continue_inside_if<'a>(ctx: &EarlyContext<'_>, data: &'a LintData<'_>, header: &str) -> String {
     let cond_code = snippet(ctx, data.if_cond.span, "..");
 
     let if_code = format!("if {} {{\n    continue;\n}}\n", cond_code);
@@ -301,7 +301,7 @@ fn suggestion_snippet_for_continue_inside_if<'a>(ctx: &EarlyContext, data: &'a L
     ret
 }
 
-fn suggestion_snippet_for_continue_inside_else<'a>(ctx: &EarlyContext, data: &'a LintData, header: &str) -> String {
+fn suggestion_snippet_for_continue_inside_else<'a>(ctx: &EarlyContext<'_>, data: &'a LintData<'_>, header: &str) -> String {
     let cond_code = snippet(ctx, data.if_cond.span, "..");
     let mut if_code = format!("if {} {{\n", cond_code);
 
@@ -332,7 +332,7 @@ fn suggestion_snippet_for_continue_inside_else<'a>(ctx: &EarlyContext, data: &'a
     ret
 }
 
-fn check_and_warn<'a>(ctx: &EarlyContext, expr: &'a ast::Expr) {
+fn check_and_warn<'a>(ctx: &EarlyContext<'_>, expr: &'a ast::Expr) {
     with_loop_block(expr, |loop_block| {
         for (i, stmt) in loop_block.stmts.iter().enumerate() {
             with_if_expr(stmt, |if_expr, cond, then_block, else_expr| {

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -204,7 +204,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                     }
 
                     // Dereference suggestion
-                    let sugg = |db: &mut DiagnosticBuilder| {
+                    let sugg = |db: &mut DiagnosticBuilder<'_>| {
                         if let ty::TypeVariants::TyAdt(def, ..) = ty.sty {
                             if let Some(span) = cx.tcx.hir.span_if_local(def.did) {
                                 if cx.param_env.can_type_implement_copy(cx.tcx, ty).is_ok() {
@@ -396,7 +396,7 @@ impl<'a, 'tcx> euv::Delegate<'tcx> for MovedVariablesCtxt<'a, 'tcx> {
         }
     }
 
-    fn borrow(&mut self, _: NodeId, _: Span, _: &mc::cmt_<'tcx>, _: ty::Region, _: ty::BorrowKind, _: euv::LoanCause) {}
+    fn borrow(&mut self, _: NodeId, _: Span, _: &mc::cmt_<'tcx>, _: ty::Region<'_>, _: ty::BorrowKind, _: euv::LoanCause) {}
 
     fn mutate(&mut self, _: NodeId, _: Span, _: &mc::cmt_<'tcx>, _: euv::MutateMode) {}
 

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NegMultiply {
     }
 }
 
-fn check_mul(cx: &LateContext, span: Span, lit: &Expr, exp: &Expr) {
+fn check_mul(cx: &LateContext<'_, '_>, span: Span, lit: &Expr, exp: &Expr) {
     if_chain! {
         if let ExprKind::Lit(ref l) = lit.node;
         if let Constant::Int(val) = consts::lit_to_constant(&l.node, cx.tables.expr_ty(lit));

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -157,7 +157,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
     }
 }
 
-fn create_new_without_default_suggest_msg(ty: Ty) -> String {
+fn create_new_without_default_suggest_msg(ty: Ty<'_>) -> String {
     #[cfg_attr(rustfmt, rustfmt_skip)]
     format!(
 "impl Default for {} {{

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -41,7 +41,7 @@ declare_clippy_lint! {
     "outer expressions with no effect"
 }
 
-fn has_no_effect(cx: &LateContext, expr: &Expr) -> bool {
+fn has_no_effect(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
     if in_macro(expr.span) {
         return false;
     }
@@ -128,7 +128,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 }
 
 
-fn reduce_expression<'a>(cx: &LateContext, expr: &'a Expr) -> Option<Vec<&'a Expr>> {
+fn reduce_expression<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<Vec<&'a Expr>> {
     if in_macro(expr.span) {
         return None;
     }

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -312,13 +312,13 @@ impl<'a, 'tcx> Visitor<'tcx> for SimilarNamesLocalVisitor<'a, 'tcx> {
 }
 
 impl EarlyLintPass for NonExpressiveNames {
-    fn check_item(&mut self, cx: &EarlyContext, item: &Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if let ItemKind::Fn(ref decl, _, _, ref blk) = item.node {
             do_check(self, cx, &item.attrs, decl, blk);
         }
     }
 
-    fn check_impl_item(&mut self, cx: &EarlyContext, item: &ImplItem) {
+    fn check_impl_item(&mut self, cx: &EarlyContext<'_>, item: &ImplItem) {
         if let ImplItemKind::Method(ref sig, ref blk) = item.node {
             do_check(self, cx, &item.attrs, &sig.decl, blk);
         }
@@ -326,7 +326,7 @@ impl EarlyLintPass for NonExpressiveNames {
 
 }
 
-fn do_check(lint: &mut NonExpressiveNames, cx: &EarlyContext, attrs: &[Attribute], decl: &FnDecl, blk: &Block) {
+fn do_check(lint: &mut NonExpressiveNames, cx: &EarlyContext<'_>, attrs: &[Attribute], decl: &FnDecl, blk: &Block) {
     if !attr::contains_name(attrs, "test") {
         let mut visitor = SimilarNamesLocalVisitor {
             names: Vec::new(),

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -61,7 +61,7 @@ enum OpenOption {
     Append,
 }
 
-fn get_open_options(cx: &LateContext, argument: &Expr, options: &mut Vec<(OpenOption, Argument)>) {
+fn get_open_options(cx: &LateContext<'_, '_>, argument: &Expr, options: &mut Vec<(OpenOption, Argument)>) {
     if let ExprKind::MethodCall(ref path, _, ref arguments) = argument.node {
         let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(&arguments[0]));
 
@@ -112,7 +112,7 @@ fn get_open_options(cx: &LateContext, argument: &Expr, options: &mut Vec<(OpenOp
     }
 }
 
-fn check_open_options(cx: &LateContext, options: &[(OpenOption, Argument)], span: Span) {
+fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument)], span: Span) {
     let (mut create, mut append, mut truncate, mut read, mut write) = (false, false, false, false, false);
     let (mut create_arg, mut append_arg, mut truncate_arg, mut read_arg, mut write_arg) =
         (false, false, false, false, false);

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -86,7 +86,7 @@ fn get_outer_span(expr: &Expr) -> Span {
     }
 }
 
-fn match_panic(params: &P<[Expr]>, expr: &Expr, cx: &LateContext) {
+fn match_panic(params: &P<[Expr]>, expr: &Expr, cx: &LateContext<'_, '_>) {
     if_chain! {
         if let ExprKind::Lit(ref lit) = params[0].node;
         if is_direct_expn_of(expr.span, "panic").is_some();

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -37,7 +37,7 @@ impl LintPass for Precedence {
 }
 
 impl EarlyLintPass for Precedence {
-    fn check_expr(&mut self, cx: &EarlyContext, expr: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if in_macro(expr.span) {
             return;
         }

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PointerPass {
     }
 }
 
-fn check_fn(cx: &LateContext, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<BodyId>) {
+fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl, fn_id: NodeId, opt_body_id: Option<BodyId>) {
     let fn_def_id = cx.tcx.hir.local_def_id(fn_id);
     let sig = cx.tcx.fn_sig(fn_def_id);
     let fn_ty = sig.skip_binder();

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -52,7 +52,7 @@ impl QuestionMarkPass {
     /// ```
     ///
     /// If it matches, it will suggest to use the question mark operator instead
-    fn check_is_none_and_early_return_none(cx: &LateContext, expr: &Expr) {
+    fn check_is_none_and_early_return_none(cx: &LateContext<'_, '_>, expr: &Expr) {
         if_chain! {
             if let ExprKind::If(ref if_expr, ref body, _) = expr.node;
             if let ExprKind::MethodCall(ref segment, _, ref args) = if_expr.node;
@@ -81,13 +81,13 @@ impl QuestionMarkPass {
         }
     }
 
-    fn is_option(cx: &LateContext, expression: &Expr) -> bool {
+    fn is_option(cx: &LateContext<'_, '_>, expression: &Expr) -> bool {
         let expr_ty = cx.tables.expr_ty(expression);
 
         match_type(cx, expr_ty, &OPTION)
     }
 
-    fn expression_returns_none(cx: &LateContext, expression: &Expr) -> bool {
+    fn expression_returns_none(cx: &LateContext<'_, '_>, expression: &Expr) -> bool {
         match expression.node {
             ExprKind::Block(ref block, _) => {
                 if let Some(return_expression) = Self::return_expression(block) {

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -176,7 +176,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     }
 }
 
-fn has_step_by(cx: &LateContext, expr: &Expr) -> bool {
+fn has_step_by(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
     // No need for walk_ptrs_ty here because step_by moves self, so it
     // can't be called on a borrowed range.
     let ty = cx.tables.expr_ty_adjusted(expr);

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -39,7 +39,7 @@ fn without_parens(mut e: &Expr) -> &Expr {
 }
 
 impl EarlyLintPass for Pass {
-    fn check_expr(&mut self, cx: &EarlyContext, e: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if_chain! {
             if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.node;
             if let ExprKind::AddrOf(_, ref addrof_target) = without_parens(deref_target).node;
@@ -84,7 +84,7 @@ impl LintPass for DerefPass {
 }
 
 impl EarlyLintPass for DerefPass {
-    fn check_expr(&mut self, cx: &EarlyContext, e: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if_chain! {
             if let ExprKind::Field(ref object, ref field_name) = e.node;
             if let ExprKind::Paren(ref parened) = object.node;

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -49,7 +49,7 @@ pub struct ReturnPass;
 
 impl ReturnPass {
     // Check the final stmt or expr in a block for unnecessary return.
-    fn check_block_return(&mut self, cx: &EarlyContext, block: &ast::Block) {
+    fn check_block_return(&mut self, cx: &EarlyContext<'_>, block: &ast::Block) {
         if let Some(stmt) = block.stmts.last() {
             match stmt.node {
                 ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => {
@@ -61,7 +61,7 @@ impl ReturnPass {
     }
 
     // Check a the final expression in a block if it's a return.
-    fn check_final_expr(&mut self, cx: &EarlyContext, expr: &ast::Expr, span: Option<Span>) {
+    fn check_final_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr, span: Option<Span>) {
         match expr.node {
             // simple return is always "bad"
             ast::ExprKind::Ret(Some(ref inner)) => {
@@ -89,7 +89,7 @@ impl ReturnPass {
         }
     }
 
-    fn emit_return_lint(&mut self, cx: &EarlyContext, ret_span: Span, inner_span: Span) {
+    fn emit_return_lint(&mut self, cx: &EarlyContext<'_>, ret_span: Span, inner_span: Span) {
         if in_external_macro(cx, inner_span) || in_macro(inner_span) {
             return;
         }
@@ -101,7 +101,7 @@ impl ReturnPass {
     }
 
     // Check for "let x = EXPR; x"
-    fn check_let_return(&mut self, cx: &EarlyContext, block: &ast::Block) {
+    fn check_let_return(&mut self, cx: &EarlyContext<'_>, block: &ast::Block) {
         let mut it = block.stmts.iter();
 
         // we need both a let-binding stmt and an expr
@@ -138,14 +138,14 @@ impl LintPass for ReturnPass {
 }
 
 impl EarlyLintPass for ReturnPass {
-    fn check_fn(&mut self, cx: &EarlyContext, kind: FnKind, _: &ast::FnDecl, _: Span, _: ast::NodeId) {
+    fn check_fn(&mut self, cx: &EarlyContext<'_>, kind: FnKind<'_>, _: &ast::FnDecl, _: Span, _: ast::NodeId) {
         match kind {
             FnKind::ItemFn(.., block) | FnKind::Method(.., block) => self.check_block_return(cx, block),
             FnKind::Closure(body) => self.check_final_expr(cx, body, Some(body.span)),
         }
     }
 
-    fn check_block(&mut self, cx: &EarlyContext, block: &ast::Block) {
+    fn check_block(&mut self, cx: &EarlyContext<'_>, block: &ast::Block) {
         self.check_let_return(cx, block);
     }
 }

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -148,7 +148,7 @@ fn check_decl<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, decl: &'tcx Decl, bindings: 
     }
 }
 
-fn is_binding(cx: &LateContext, pat_id: HirId) -> bool {
+fn is_binding(cx: &LateContext<'_, '_>, pat_id: HirId) -> bool {
     let var_ty = cx.tables.node_id_to_type(pat_id);
     match var_ty.sty {
         ty::TyAdt(..) => false,

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -117,11 +117,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringAdd {
     }
 }
 
-fn is_string(cx: &LateContext, e: &Expr) -> bool {
+fn is_string(cx: &LateContext<'_, '_>, e: &Expr) -> bool {
     match_type(cx, walk_ptrs_ty(cx.tables.expr_ty(e)), &paths::STRING)
 }
 
-fn is_add(cx: &LateContext, src: &Expr, target: &Expr) -> bool {
+fn is_add(cx: &LateContext<'_, '_>, src: &Expr, target: &Expr) -> bool {
     match src.node {
         ExprKind::Binary(Spanned { node: BinOpKind::Add, .. }, ref left, _) => SpanlessEq::new(cx).eq_expr(target, left),
         ExprKind::Block(ref block, _) => {

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -163,7 +163,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for SuspiciousImpl {
 }
 
 fn check_binop<'a>(
-    cx: &LateContext,
+    cx: &LateContext<'_, '_>,
     expr: &hir::Expr,
     binop: hir::BinOpKind,
     traits: &[&'a str],

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -60,7 +60,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Swap {
 }
 
 /// Implementation of the `MANUAL_SWAP` lint.
-fn check_manual_swap(cx: &LateContext, block: &Block) {
+fn check_manual_swap(cx: &LateContext<'_, '_>, block: &Block) {
     for w in block.stmts.windows(3) {
         if_chain! {
             // let t = foo();
@@ -84,7 +84,7 @@ fn check_manual_swap(cx: &LateContext, block: &Block) {
             if SpanlessEq::new(cx).ignore_fn().eq_expr(rhs1, lhs2);
             then {
                 fn check_for_slice<'a>(
-                    cx: &LateContext,
+                    cx: &LateContext<'_, '_>,
                     lhs1: &'a Expr,
                     lhs2: &'a Expr,
                 ) -> Option<(&'a Expr, &'a Expr, &'a Expr)> {
@@ -145,7 +145,7 @@ fn check_manual_swap(cx: &LateContext, block: &Block) {
 }
 
 /// Implementation of the `ALMOST_SWAPPED` lint.
-fn check_suspicious_swap(cx: &LateContext, block: &Block) {
+fn check_suspicious_swap(cx: &LateContext<'_, '_>, block: &Block) {
     for w in block.stmts.windows(2) {
         if_chain! {
             if let StmtKind::Semi(ref first, _) = w[0].node;

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -454,7 +454,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Transmute {
 /// the type's `ToString` implementation. In weird cases it could lead to types
 /// with invalid `'_`
 /// lifetime, but it should be rare.
-fn get_type_snippet(cx: &LateContext, path: &QPath, to_ref_ty: Ty) -> String {
+fn get_type_snippet(cx: &LateContext<'_, '_>, path: &QPath, to_ref_ty: Ty<'_>) -> String {
     let seg = last_path_segment(path);
     if_chain! {
         if let Some(ref params) = seg.args;

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -138,7 +138,7 @@ impl LintPass for TypePass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypePass {
-    fn check_fn(&mut self, cx: &LateContext, _: FnKind, decl: &FnDecl, _: &Body, _: Span, id: NodeId) {
+    fn check_fn(&mut self, cx: &LateContext<'_, '_>, _: FnKind<'_>, decl: &FnDecl, _: &Body, _: Span, id: NodeId) {
         // skip trait implementations, see #605
         if let Some(map::NodeItem(item)) = cx.tcx.hir.find(cx.tcx.hir.get_parent(id)) {
             if let ItemKind::Impl(_, _, _, _, Some(..), _, _) = item.node {
@@ -149,11 +149,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypePass {
         check_fn_decl(cx, decl);
     }
 
-    fn check_struct_field(&mut self, cx: &LateContext, field: &StructField) {
+    fn check_struct_field(&mut self, cx: &LateContext<'_, '_>, field: &StructField) {
         check_ty(cx, &field.ty, false);
     }
 
-    fn check_trait_item(&mut self, cx: &LateContext, item: &TraitItem) {
+    fn check_trait_item(&mut self, cx: &LateContext<'_, '_>, item: &TraitItem) {
         match item.node {
             TraitItemKind::Const(ref ty, _) | TraitItemKind::Type(_, Some(ref ty)) => check_ty(cx, ty, false),
             TraitItemKind::Method(ref sig, _) => check_fn_decl(cx, &sig.decl),
@@ -161,14 +161,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypePass {
         }
     }
 
-    fn check_local(&mut self, cx: &LateContext, local: &Local) {
+    fn check_local(&mut self, cx: &LateContext<'_, '_>, local: &Local) {
         if let Some(ref ty) = local.ty {
             check_ty(cx, ty, true);
         }
     }
 }
 
-fn check_fn_decl(cx: &LateContext, decl: &FnDecl) {
+fn check_fn_decl(cx: &LateContext<'_, '_>, decl: &FnDecl) {
     for input in &decl.inputs {
         check_ty(cx, input, false);
     }
@@ -179,7 +179,7 @@ fn check_fn_decl(cx: &LateContext, decl: &FnDecl) {
 }
 
 /// Check if `qpath` has last segment with type parameter matching `path`
-fn match_type_parameter(cx: &LateContext, qpath: &QPath, path: &[&str]) -> bool {
+fn match_type_parameter(cx: &LateContext<'_, '_>, qpath: &QPath, path: &[&str]) -> bool {
     let last = last_path_segment(qpath);
     if_chain! {
         if let Some(ref params) = last.args;
@@ -203,7 +203,7 @@ fn match_type_parameter(cx: &LateContext, qpath: &QPath, path: &[&str]) -> bool 
 ///
 /// The parameter `is_local` distinguishes the context of the type; types from
 /// local bindings should only be checked for the `BORROWED_BOX` lint.
-fn check_ty(cx: &LateContext, ast_ty: &hir::Ty, is_local: bool) {
+fn check_ty(cx: &LateContext<'_, '_>, ast_ty: &hir::Ty, is_local: bool) {
     if in_macro(ast_ty.span) {
         return;
     }
@@ -294,7 +294,7 @@ fn check_ty(cx: &LateContext, ast_ty: &hir::Ty, is_local: bool) {
     }
 }
 
-fn check_ty_rptr(cx: &LateContext, ast_ty: &hir::Ty, is_local: bool, lt: &Lifetime, mut_ty: &MutTy) {
+fn check_ty_rptr(cx: &LateContext<'_, '_>, ast_ty: &hir::Ty, is_local: bool, lt: &Lifetime, mut_ty: &MutTy) {
     match mut_ty.ty.node {
         TyKind::Path(ref qpath) => {
             let hir_id = cx.tcx.hir.node_to_hir_id(mut_ty.ty.id);
@@ -378,7 +378,7 @@ declare_clippy_lint! {
     "creating a let binding to a value of unit type, which usually can't be used afterwards"
 }
 
-fn check_let_unit(cx: &LateContext, decl: &Decl) {
+fn check_let_unit(cx: &LateContext<'_, '_>, decl: &Decl) {
     if let DeclKind::Local(ref local) = decl.node {
         if is_unit(cx.tables.pat_ty(&local.pat)) {
             if in_external_macro(cx, decl.span) || in_macro(local.pat.span) {
@@ -548,7 +548,7 @@ fn is_questionmark_desugar_marked_call(expr: &Expr) -> bool {
     }
 }
 
-fn is_unit(ty: Ty) -> bool {
+fn is_unit(ty: Ty<'_>) -> bool {
     match ty.sty {
         ty::TyTuple(slice) if slice.is_empty() => true,
         _ => false,
@@ -753,7 +753,7 @@ declare_clippy_lint! {
 
 /// Returns the size in bits of an integral type.
 /// Will return 0 if the type is not an int or uint variant
-fn int_ty_to_nbits(typ: Ty, tcx: TyCtxt) -> u64 {
+fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_, '_, '_>) -> u64 {
     match typ.sty {
         ty::TyInt(i) => match i {
             IntTy::Isize => tcx.data_layout.pointer_size.bits(),
@@ -775,14 +775,14 @@ fn int_ty_to_nbits(typ: Ty, tcx: TyCtxt) -> u64 {
     }
 }
 
-fn is_isize_or_usize(typ: Ty) -> bool {
+fn is_isize_or_usize(typ: Ty<'_>) -> bool {
     match typ.sty {
         ty::TyInt(IntTy::Isize) | ty::TyUint(UintTy::Usize) => true,
         _ => false,
     }
 }
 
-fn span_precision_loss_lint(cx: &LateContext, expr: &Expr, cast_from: Ty, cast_to_f64: bool) {
+fn span_precision_loss_lint(cx: &LateContext<'_, '_>, expr: &Expr, cast_from: Ty<'_>, cast_to_f64: bool) {
     let mantissa_nbits = if cast_to_f64 { 52 } else { 23 };
     let arch_dependent = is_isize_or_usize(cast_from) && cast_to_f64;
     let arch_dependent_str = "on targets with 64-bit wide pointers ";
@@ -822,7 +822,7 @@ fn should_strip_parens(op: &Expr, snip: &str) -> bool {
     false
 }
 
-fn span_lossless_lint(cx: &LateContext, expr: &Expr, op: &Expr, cast_from: Ty, cast_to: Ty) {
+fn span_lossless_lint(cx: &LateContext<'_, '_>, expr: &Expr, op: &Expr, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     // Do not suggest using From in consts/statics until it is valid to do so (see #2267).
     if in_constant(cx, expr.id) { return }
     // The suggestion is to use a function call, so if the original expression
@@ -854,7 +854,7 @@ enum ArchSuffix {
     None,
 }
 
-fn check_truncation_and_wrapping(cx: &LateContext, expr: &Expr, cast_from: Ty, cast_to: Ty) {
+fn check_truncation_and_wrapping(cx: &LateContext<'_, '_>, expr: &Expr, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     let arch_64_suffix = " on targets with 64-bit wide pointers";
     let arch_32_suffix = " on targets with 32-bit wide pointers";
     let cast_unsigned_to_signed = !cast_from.is_signed() && cast_to.is_signed();
@@ -925,7 +925,7 @@ fn check_truncation_and_wrapping(cx: &LateContext, expr: &Expr, cast_from: Ty, c
     }
 }
 
-fn check_lossless(cx: &LateContext, expr: &Expr, op: &Expr, cast_from: Ty, cast_to: Ty) {
+fn check_lossless(cx: &LateContext<'_, '_>, expr: &Expr, op: &Expr, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     let cast_signed_to_unsigned = cast_from.is_signed() && !cast_to.is_signed();
     let from_nbits = int_ty_to_nbits(cast_from, cx.tcx);
     let to_nbits = int_ty_to_nbits(cast_to, cx.tcx);
@@ -1183,7 +1183,7 @@ impl<'a, 'tcx> TypeComplexityPass {
         }
     }
 
-    fn check_type(&self, cx: &LateContext, ty: &hir::Ty) {
+    fn check_type(&self, cx: &LateContext<'_, '_>, ty: &hir::Ty) {
         if in_macro(ty.span) {
             return;
         }
@@ -1562,7 +1562,7 @@ impl Ord for FullInt {
 }
 
 
-fn numeric_cast_precast_bounds<'a>(cx: &LateContext, expr: &'a Expr) -> Option<(FullInt, FullInt)> {
+fn numeric_cast_precast_bounds<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<(FullInt, FullInt)> {
     use syntax::ast::{IntTy, UintTy};
     use std::*;
 
@@ -1628,7 +1628,7 @@ fn node_as_const_fullint<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr)
     }
 }
 
-fn err_upcast_comparison(cx: &LateContext, span: Span, expr: &Expr, always: bool) {
+fn err_upcast_comparison(cx: &LateContext<'_, '_>, span: Span, expr: &Expr, always: bool) {
     if let ExprKind::Cast(ref cast_val, _) = expr.node {
         span_lint(
             cx,
@@ -1750,11 +1750,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
 
         fn suggestion<'a, 'tcx>(
             cx: &LateContext<'a, 'tcx>,
-            db: &mut DiagnosticBuilder,
+            db: &mut DiagnosticBuilder<'_>,
             generics_span: Span,
             generics_suggestion_span: Span,
-            target: &ImplicitHasherType,
-            vis: ImplicitHasherConstructorVisitor,
+            target: &ImplicitHasherType<'_>,
+            vis: ImplicitHasherConstructorVisitor<'_, '_, '_>,
         ) {
             let generics_snip = snippet(cx, generics_span, "");
             // trim `<` `>`

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -94,7 +94,7 @@ fn escape<T: Iterator<Item = char>>(s: T) -> String {
     result
 }
 
-fn check_str(cx: &LateContext, span: Span, id: NodeId) {
+fn check_str(cx: &LateContext<'_, '_>, span: Span, id: NodeId) {
     let string = snippet(cx, span, "");
     if string.contains('\u{200B}') {
         span_help_and_lint(

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -35,14 +35,14 @@ impl LintPass for UnsafeNameRemoval {
 }
 
 impl EarlyLintPass for UnsafeNameRemoval {
-    fn check_item(&mut self, cx: &EarlyContext, item: &Item) {
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if let ItemKind::Use(ref use_tree) = item.node {
             check_use_tree(use_tree, cx, item.span);
         }
     }
 }
 
-fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext, span: Span) {
+fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext<'_>, span: Span) {
     match use_tree.kind {
         UseTreeKind::Simple(Some(new_name), ..) => {
             let old_name = use_tree
@@ -63,7 +63,7 @@ fn check_use_tree(use_tree: &UseTree, cx: &EarlyContext, span: Span) {
     }
 }
 
-fn unsafe_to_safe_check(old_name: Ident, new_name: Ident, cx: &EarlyContext, span: Span) {
+fn unsafe_to_safe_check(old_name: Ident, new_name: Ident, cx: &EarlyContext<'_>, span: Span) {
     let old_str = old_name.name.as_str();
     let new_str = new_name.name.as_str();
     if contains_unsafe(&old_str) && !contains_unsafe(&new_str) {

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -39,7 +39,7 @@ impl LintPass for UnusedIoAmount {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedIoAmount {
-    fn check_stmt(&mut self, cx: &LateContext, s: &hir::Stmt) {
+    fn check_stmt(&mut self, cx: &LateContext<'_, '_>, s: &hir::Stmt) {
         let expr = match s.node {
             hir::StmtKind::Semi(ref expr, _) | hir::StmtKind::Expr(ref expr, _) => &**expr,
             _ => return,
@@ -70,7 +70,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedIoAmount {
     }
 }
 
-fn check_method_call(cx: &LateContext, call: &hir::Expr, expr: &hir::Expr) {
+fn check_method_call(cx: &LateContext<'_, '_>, call: &hir::Expr, expr: &hir::Expr) {
     if let hir::ExprKind::MethodCall(ref path, _, _) = call.node {
         let symbol = &*path.ident.as_str();
         if match_trait_method(cx, call, &paths::IO_READ) && symbol == "read" {

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -52,7 +52,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             Error::Io(ref err) => err.fmt(f),
             Error::Toml(ref err) => err.fmt(f),

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -212,7 +212,7 @@ pub enum VecArgs<'a> {
 
 /// Returns the arguments of the `vec!` macro if this expression was expanded
 /// from `vec!`.
-pub fn vec_macro<'e>(cx: &LateContext, expr: &'e hir::Expr) -> Option<VecArgs<'e>> {
+pub fn vec_macro<'e>(cx: &LateContext<'_, '_>, expr: &'e hir::Expr) -> Option<VecArgs<'e>> {
     if_chain! {
         if let hir::ExprKind::Call(ref fun, ref args) = expr.node;
         if let hir::ExprKind::Path(ref path) = fun.node;

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -141,7 +141,7 @@ fn has_attr(attrs: &[Attribute]) -> bool {
     get_attr(attrs, "dump").count() > 0
 }
 
-fn print_decl(cx: &LateContext, decl: &hir::Decl) {
+fn print_decl(cx: &LateContext<'_, '_>, decl: &hir::Decl) {
     match decl.node {
         hir::DeclKind::Local(ref local) => {
             println!("local variable of type {}", cx.tables.node_id_to_type(local.hir_id));
@@ -156,7 +156,7 @@ fn print_decl(cx: &LateContext, decl: &hir::Decl) {
     }
 }
 
-fn print_expr(cx: &LateContext, expr: &hir::Expr, indent: usize) {
+fn print_expr(cx: &LateContext<'_, '_>, expr: &hir::Expr, indent: usize) {
     let ind = "  ".repeat(indent);
     println!("{}+", ind);
     println!("{}ty: {}", ind, cx.tables.expr_ty(expr));
@@ -342,7 +342,7 @@ fn print_expr(cx: &LateContext, expr: &hir::Expr, indent: usize) {
     }
 }
 
-fn print_item(cx: &LateContext, item: &hir::Item) {
+fn print_item(cx: &LateContext<'_, '_>, item: &hir::Item) {
     let did = cx.tcx.hir.local_def_id(item.id);
     println!("item `{}`", item.name);
     match item.vis.node {
@@ -414,7 +414,7 @@ fn print_item(cx: &LateContext, item: &hir::Item) {
     }
 }
 
-fn print_pat(cx: &LateContext, pat: &hir::Pat, indent: usize) {
+fn print_pat(cx: &LateContext<'_, '_>, pat: &hir::Pat, indent: usize) {
     let ind = "  ".repeat(indent);
     println!("{}+", ind);
     match pat.node {

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -64,7 +64,7 @@ impl LintPass for Clippy {
 }
 
 impl EarlyLintPass for Clippy {
-    fn check_crate(&mut self, cx: &EarlyContext, krate: &AstCrate) {
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &AstCrate) {
         if let Some(utils) = krate
             .module
             .items

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -48,7 +48,7 @@ pub fn differing_macro_contexts(lhs: Span, rhs: Span) -> bool {
     rhs.ctxt() != lhs.ctxt()
 }
 
-pub fn in_constant(cx: &LateContext, id: NodeId) -> bool {
+pub fn in_constant(cx: &LateContext<'_, '_>, id: NodeId) -> bool {
     let parent_id = cx.tcx.hir.get_parent(id);
     match cx.tcx.hir.body_owner_kind(parent_id) {
         hir::BodyOwnerKind::Fn => false,
@@ -115,7 +115,7 @@ pub fn in_external_macro<'a, T: LintContext<'a>>(cx: &T, span: Span) -> bool {
 /// ```
 ///
 /// See also the `paths` module.
-pub fn match_def_path(tcx: TyCtxt, def_id: DefId, path: &[&str]) -> bool {
+pub fn match_def_path(tcx: TyCtxt<'_, '_, '_>, def_id: DefId, path: &[&str]) -> bool {
     use syntax::symbol;
 
     struct AbsolutePathBuffer {
@@ -145,7 +145,7 @@ pub fn match_def_path(tcx: TyCtxt, def_id: DefId, path: &[&str]) -> bool {
 }
 
 /// Check if type is struct, enum or union type with given def path.
-pub fn match_type(cx: &LateContext, ty: Ty, path: &[&str]) -> bool {
+pub fn match_type(cx: &LateContext<'_, '_>, ty: Ty<'_>, path: &[&str]) -> bool {
     match ty.sty {
         ty::TyAdt(adt, _) => match_def_path(cx.tcx, adt.did, path),
         _ => false,
@@ -153,7 +153,7 @@ pub fn match_type(cx: &LateContext, ty: Ty, path: &[&str]) -> bool {
 }
 
 /// Check if the method call given in `expr` belongs to given type.
-pub fn match_impl_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool {
+pub fn match_impl_method(cx: &LateContext<'_, '_>, expr: &Expr, path: &[&str]) -> bool {
     let method_call = cx.tables.type_dependent_defs()[expr.hir_id];
     let trt_id = cx.tcx.impl_of_method(method_call.def_id());
     if let Some(trt_id) = trt_id {
@@ -164,7 +164,7 @@ pub fn match_impl_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool {
 }
 
 /// Check if the method call given in `expr` belongs to given trait.
-pub fn match_trait_method(cx: &LateContext, expr: &Expr, path: &[&str]) -> bool {
+pub fn match_trait_method(cx: &LateContext<'_, '_>, expr: &Expr, path: &[&str]) -> bool {
     let method_call = cx.tables.type_dependent_defs()[expr.hir_id];
     let trt_id = cx.tcx.trait_of_item(method_call.def_id());
     if let Some(trt_id) = trt_id {
@@ -244,7 +244,7 @@ pub fn match_path_ast(path: &ast::Path, segments: &[&str]) -> bool {
 }
 
 /// Get the definition associated to a path.
-pub fn path_to_def(cx: &LateContext, path: &[&str]) -> Option<def::Def> {
+pub fn path_to_def(cx: &LateContext<'_, '_>, path: &[&str]) -> Option<def::Def> {
     let crates = cx.tcx.crates();
     let krate = crates
         .iter()
@@ -280,7 +280,7 @@ pub fn path_to_def(cx: &LateContext, path: &[&str]) -> Option<def::Def> {
 }
 
 /// Convenience function to get the `DefId` of a trait by path.
-pub fn get_trait_def_id(cx: &LateContext, path: &[&str]) -> Option<DefId> {
+pub fn get_trait_def_id(cx: &LateContext<'_, '_>, path: &[&str]) -> Option<DefId> {
     let def = match path_to_def(cx, path) {
         Some(def) => def,
         None => return None,
@@ -308,7 +308,7 @@ pub fn implements_trait<'a, 'tcx>(
 }
 
 /// Check whether this type implements Drop.
-pub fn has_drop(cx: &LateContext, expr: &Expr) -> bool {
+pub fn has_drop(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
     let struct_ty = cx.tables.expr_ty(expr);
     match struct_ty.ty_adt_def() {
         Some(def) => def.has_dtor(cx.tcx),
@@ -317,7 +317,7 @@ pub fn has_drop(cx: &LateContext, expr: &Expr) -> bool {
 }
 
 /// Resolve the definition of a node from its `HirId`.
-pub fn resolve_node(cx: &LateContext, qpath: &QPath, id: HirId) -> def::Def {
+pub fn resolve_node(cx: &LateContext<'_, '_>, qpath: &QPath, id: HirId) -> def::Def {
     cx.tables.qpath_def(qpath, id)
 }
 
@@ -352,7 +352,7 @@ pub fn method_chain_args<'a>(expr: &'a Expr, methods: &[&str]) -> Option<Vec<&'a
 
 
 /// Get the name of the item the expression is in, if available.
-pub fn get_item_name(cx: &LateContext, expr: &Expr) -> Option<Name> {
+pub fn get_item_name(cx: &LateContext<'_, '_>, expr: &Expr) -> Option<Name> {
     let parent_id = cx.tcx.hir.get_parent(expr.id);
     match cx.tcx.hir.find(parent_id) {
         Some(Node::NodeItem(&Item { ref name, .. })) => Some(*name),
@@ -458,13 +458,13 @@ pub fn expr_block<'a, 'b, T: LintContext<'b>>(
 
 /// Trim indentation from a multiline string with possibility of ignoring the
 /// first line.
-pub fn trim_multiline(s: Cow<str>, ignore_first: bool) -> Cow<str> {
+pub fn trim_multiline(s: Cow<'_, str>, ignore_first: bool) -> Cow<'_, str> {
     let s_space = trim_multiline_inner(s, ignore_first, ' ');
     let s_tab = trim_multiline_inner(s_space, ignore_first, '\t');
     trim_multiline_inner(s_tab, ignore_first, ' ')
 }
 
-fn trim_multiline_inner(s: Cow<str>, ignore_first: bool, ch: char) -> Cow<str> {
+fn trim_multiline_inner(s: Cow<'_, str>, ignore_first: bool, ch: char) -> Cow<'_, str> {
     let x = s.lines()
         .skip(ignore_first as usize)
         .filter_map(|l| {
@@ -502,7 +502,7 @@ fn trim_multiline_inner(s: Cow<str>, ignore_first: bool, ch: char) -> Cow<str> {
 }
 
 /// Get a parent expressions if any – this is useful to constrain a lint.
-pub fn get_parent_expr<'c>(cx: &'c LateContext, e: &Expr) -> Option<&'c Expr> {
+pub fn get_parent_expr<'c>(cx: &'c LateContext<'_, '_>, e: &Expr) -> Option<&'c Expr> {
     let map = &cx.tcx.hir;
     let node_id: NodeId = e.id;
     let parent_id: NodeId = map.get_parent_node(node_id);
@@ -642,7 +642,7 @@ pub fn span_lint_and_sugg<'a, 'tcx: 'a, T: LintContext<'tcx>>(
 /// appear once per
 /// replacement. In human-readable format though, it only appears once before
 /// the whole suggestion.
-pub fn multispan_sugg<I>(db: &mut DiagnosticBuilder, help_msg: String, sugg: I)
+pub fn multispan_sugg<I>(db: &mut DiagnosticBuilder<'_>, help_msg: String, sugg: I)
 where
     I: IntoIterator<Item = (Span, String)>,
 {
@@ -675,7 +675,7 @@ pub fn walk_ptrs_hir_ty(ty: &hir::Ty) -> &hir::Ty {
 }
 
 /// Return the base type for references and raw pointers.
-pub fn walk_ptrs_ty(ty: Ty) -> Ty {
+pub fn walk_ptrs_ty(ty: Ty<'_>) -> Ty<'_> {
     match ty.sty {
         ty::TyRef(_, ty, _) => walk_ptrs_ty(ty),
         _ => ty,
@@ -684,8 +684,8 @@ pub fn walk_ptrs_ty(ty: Ty) -> Ty {
 
 /// Return the base type for references and raw pointers, and count reference
 /// depth.
-pub fn walk_ptrs_ty_depth(ty: Ty) -> (Ty, usize) {
-    fn inner(ty: Ty, depth: usize) -> (Ty, usize) {
+pub fn walk_ptrs_ty_depth(ty: Ty<'_>) -> (Ty<'_>, usize) {
+    fn inner(ty: Ty<'_>, depth: usize) -> (Ty<'_>, usize) {
         match ty.sty {
             ty::TyRef(_, ty, _) => inner(ty, depth + 1),
             _ => (ty, depth),
@@ -705,7 +705,7 @@ pub fn is_integer_literal(expr: &Expr, value: u128) -> bool {
     false
 }
 
-pub fn is_adjusted(cx: &LateContext, e: &Expr) -> bool {
+pub fn is_adjusted(cx: &LateContext<'_, '_>, e: &Expr) -> bool {
     cx.tables.adjustments().get(e.hir_id).is_some()
 }
 
@@ -898,15 +898,15 @@ pub fn is_copy<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>) -> bool {
 }
 
 /// Return whether a pattern is refutable.
-pub fn is_refutable(cx: &LateContext, pat: &Pat) -> bool {
-    fn is_enum_variant(cx: &LateContext, qpath: &QPath, id: HirId) -> bool {
+pub fn is_refutable(cx: &LateContext<'_, '_>, pat: &Pat) -> bool {
+    fn is_enum_variant(cx: &LateContext<'_, '_>, qpath: &QPath, id: HirId) -> bool {
         matches!(
             cx.tables.qpath_def(qpath, id),
             def::Def::Variant(..) | def::Def::VariantCtor(..)
         )
     }
 
-    fn are_refutable<'a, I: Iterator<Item = &'a Pat>>(cx: &LateContext, mut i: I) -> bool {
+    fn are_refutable<'a, I: Iterator<Item = &'a Pat>>(cx: &LateContext<'_, '_>, mut i: I) -> bool {
         i.any(|pat| is_refutable(cx, pat))
     }
 
@@ -1065,7 +1065,7 @@ pub fn is_try(expr: &Expr) -> Option<&Expr> {
 /// Returns true if the lint is allowed in the current context
 ///
 /// Useful for skipping long running code when it's unnecessary
-pub fn is_allowed(cx: &LateContext, lint: &'static Lint, id: NodeId) -> bool {
+pub fn is_allowed(cx: &LateContext<'_, '_>, lint: &'static Lint, id: NodeId) -> bool {
     cx.tcx.lint_level_at_node(lint, id).0 == Level::Allow
 }
 
@@ -1085,24 +1085,24 @@ pub fn get_arg_ident(pat: &Pat) -> Option<ast::Ident> {
     }
 }
 
-pub fn int_bits(tcx: TyCtxt, ity: ast::IntTy) -> u64 {
+pub fn int_bits(tcx: TyCtxt<'_, '_, '_>, ity: ast::IntTy) -> u64 {
     layout::Integer::from_attr(tcx, attr::IntType::SignedInt(ity)).size().bits()
 }
 
 /// Turn a constant int byte representation into an i128
-pub fn sext(tcx: TyCtxt, u: u128, ity: ast::IntTy) -> i128 {
+pub fn sext(tcx: TyCtxt<'_, '_, '_>, u: u128, ity: ast::IntTy) -> i128 {
     let amt = 128 - int_bits(tcx, ity);
     ((u as i128) << amt) >> amt
 }
 
 /// clip unused bytes
-pub fn unsext(tcx: TyCtxt, u: i128, ity: ast::IntTy) -> u128 {
+pub fn unsext(tcx: TyCtxt<'_, '_, '_>, u: i128, ity: ast::IntTy) -> u128 {
     let amt = 128 - int_bits(tcx, ity);
     ((u as u128) << amt) >> amt
 }
 
 /// clip unused bytes
-pub fn clip(tcx: TyCtxt, u: u128, ity: ast::UintTy) -> u128 {
+pub fn clip(tcx: TyCtxt<'_, '_, '_>, u: u128, ity: ast::UintTy) -> u128 {
     let bits = layout::Integer::from_attr(tcx, attr::IntType::UnsignedInt(ity)).size().bits();
     let amt = 128 - bits;
     (u << amt) >> amt
@@ -1141,7 +1141,7 @@ pub fn without_block_comments(lines: Vec<&str>) -> Vec<&str> {
     without
 }
 
-pub fn any_parent_is_automatically_derived(tcx: TyCtxt, node: NodeId) -> bool {
+pub fn any_parent_is_automatically_derived(tcx: TyCtxt<'_, '_, '_>, node: NodeId) -> bool {
     let map = &tcx.hir;
     let mut prev_enclosing_node = None;
     let mut enclosing_node = node;

--- a/clippy_lints/src/utils/ptr.rs
+++ b/clippy_lints/src/utils/ptr.rs
@@ -7,7 +7,7 @@ use syntax::codemap::Span;
 use crate::utils::{get_pat_name, match_var, snippet};
 
 pub fn get_spans(
-    cx: &LateContext,
+    cx: &LateContext<'_, '_>,
     opt_body_id: Option<BodyId>,
     idx: usize,
     replacements: &'static [(&'static str, &'static str)],

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -32,8 +32,8 @@ pub enum Sugg<'a> {
 /// Literal constant `1`, for convenience.
 pub const ONE: Sugg<'static> = Sugg::NonParen(Cow::Borrowed("1"));
 
-impl<'a> Display for Sugg<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+impl Display for Sugg<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match *self {
             Sugg::NonParen(ref s) | Sugg::MaybeParen(ref s) | Sugg::BinOp(_, ref s) => s.fmt(f),
         }
@@ -43,7 +43,7 @@ impl<'a> Display for Sugg<'a> {
 #[allow(wrong_self_convention)] // ok, because of the function `as_ty` method
 impl<'a> Sugg<'a> {
     /// Prepare a suggestion from an expression.
-    pub fn hir_opt(cx: &LateContext, expr: &hir::Expr) -> Option<Self> {
+    pub fn hir_opt(cx: &LateContext<'_, '_>, expr: &hir::Expr) -> Option<Self> {
         snippet_opt(cx, expr.span).map(|snippet| {
             let snippet = Cow::Owned(snippet);
             match expr.node {
@@ -82,12 +82,12 @@ impl<'a> Sugg<'a> {
 
     /// Convenience function around `hir_opt` for suggestions with a default
     /// text.
-    pub fn hir(cx: &LateContext, expr: &hir::Expr, default: &'a str) -> Self {
+    pub fn hir(cx: &LateContext<'_, '_>, expr: &hir::Expr, default: &'a str) -> Self {
         Self::hir_opt(cx, expr).unwrap_or_else(|| Sugg::NonParen(Cow::Borrowed(default)))
     }
 
     /// Prepare a suggestion from an expression.
-    pub fn ast(cx: &EarlyContext, expr: &ast::Expr, default: &'a str) -> Self {
+    pub fn ast(cx: &EarlyContext<'_>, expr: &ast::Expr, default: &'a str) -> Self {
         use syntax::ast::RangeLimits;
 
         let snippet = snippet(cx, expr.span, default);
@@ -241,7 +241,7 @@ impl<T> ParenHelper<T> {
 }
 
 impl<T: Display> Display for ParenHelper<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         if self.paren {
             write!(f, "({})", self.wrapped)
         } else {
@@ -255,7 +255,7 @@ impl<T: Display> Display for ParenHelper<T> {
 /// For convenience, the operator is taken as a string because all unary
 /// operators have the same
 /// precedence.
-pub fn make_unop(op: &str, expr: Sugg) -> Sugg<'static> {
+pub fn make_unop(op: &str, expr: Sugg<'_>) -> Sugg<'static> {
     Sugg::MaybeParen(format!("{}{}", op, expr.maybe_par()).into())
 }
 
@@ -264,7 +264,7 @@ pub fn make_unop(op: &str, expr: Sugg) -> Sugg<'static> {
 /// Precedence of shift operator relative to other arithmetic operation is
 /// often confusing so
 /// parenthesis will always be added for a mix of these.
-pub fn make_assoc(op: AssocOp, lhs: &Sugg, rhs: &Sugg) -> Sugg<'static> {
+pub fn make_assoc(op: AssocOp, lhs: &Sugg<'_>, rhs: &Sugg<'_>) -> Sugg<'static> {
     /// Whether the operator is a shift operator `<<` or `>>`.
     fn is_shift(op: &AssocOp) -> bool {
         matches!(*op, AssocOp::ShiftLeft | AssocOp::ShiftRight)
@@ -335,7 +335,7 @@ pub fn make_assoc(op: AssocOp, lhs: &Sugg, rhs: &Sugg) -> Sugg<'static> {
 }
 
 /// Convinience wrapper arround `make_assoc` and `AssocOp::from_ast_binop`.
-pub fn make_binop(op: ast::BinOpKind, lhs: &Sugg, rhs: &Sugg) -> Sugg<'static> {
+pub fn make_binop(op: ast::BinOpKind, lhs: &Sugg<'_>, rhs: &Sugg<'_>) -> Sugg<'static> {
     make_assoc(AssocOp::from_ast_binop(op), lhs, rhs)
 }
 

--- a/clippy_lints/src/utils/usage.rs
+++ b/clippy_lints/src/utils/usage.rs
@@ -44,7 +44,7 @@ struct MutVarsDelegate {
 }
 
 impl<'tcx> MutVarsDelegate {
-    fn update(&mut self, cat: &'tcx Categorization) {
+    fn update(&mut self, cat: &'tcx Categorization<'_>) {
         match *cat {
             Categorization::Local(id) => {
                 self.used_mutably.insert(id);
@@ -68,7 +68,7 @@ impl<'tcx> Delegate<'tcx> for MutVarsDelegate {
 
     fn consume_pat(&mut self, _: &Pat, _: &cmt_<'tcx>, _: ConsumeMode) {}
 
-    fn borrow(&mut self, _: NodeId, _: Span, cmt: &cmt_<'tcx>, _: ty::Region, bk: ty::BorrowKind, _: LoanCause) {
+    fn borrow(&mut self, _: NodeId, _: Span, cmt: &cmt_<'tcx>, _: ty::Region<'_>, bk: ty::BorrowKind, _: LoanCause) {
         if let ty::BorrowKind::MutBorrow = bk {
             self.update(&cmt.cat)
         }

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -94,7 +94,7 @@ fn check_vec_macro<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, vec_args: &higher::VecA
 }
 
 /// Return the item type of the vector (ie. the `T` in `Vec<T>`).
-fn vec_type(ty: Ty) -> Ty {
+fn vec_type(ty: Ty<'_>) -> Ty<'_> {
     if let ty::TyAdt(_, substs) = ty.sty {
         substs.type_at(0)
     } else {

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -168,7 +168,7 @@ impl LintPass for Pass {
 }
 
 impl EarlyLintPass for Pass {
-    fn check_mac(&mut self, cx: &EarlyContext, mac: &Mac) {
+    fn check_mac(&mut self, cx: &EarlyContext<'_>, mac: &Mac) {
         if mac.node.path == "println" {
             span_lint(cx, PRINT_STDOUT, mac.span, "use of `println!`");
             if let Some(fmtstr) = check_tts(cx, &mac.node.tts, false) {
@@ -261,7 +261,7 @@ fn check_tts(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> Op
             return Some(fmtstr);
         }
         let expr = parser.parse_expr().map_err(|mut err| err.cancel()).ok()?;
-        const SIMPLE: FormatSpec = FormatSpec {
+        const SIMPLE: FormatSpec<'_> = FormatSpec {
             fill: None,
             align: AlignUnknown,
             flags: 0,

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -1,15 +1,9 @@
-use rustc::hir::map::Node::{NodeImplItem, NodeItem};
-use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
-use if_chain::if_chain;
-use std::ops::Deref;
-use syntax::ast::LitKind;
-use syntax::ptr;
-use syntax::symbol::LocalInternedString;
-use syntax_pos::Span;
-use crate::utils::{is_expn_of, match_def_path, match_path, resolve_node, span_lint, span_lint_and_sugg};
-use crate::utils::{opt_def_id, paths, last_path_segment};
+use syntax::ast::*;
+use syntax::tokenstream::{ThinTokenStream, TokenStream};
+use syntax::parse::{token, parser};
+use crate::utils::{span_lint, span_lint_and_sugg};
 
 /// **What it does:** This lint warns when you use `println!("")` to
 /// print a newline.
@@ -173,317 +167,149 @@ impl LintPass for Pass {
     }
 }
 
-impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
-    fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
-        match expr.node {
-            // print!()
-            ExprKind::Call(ref fun, ref args) => {
-                if_chain! {
-                    if let ExprKind::Path(ref qpath) = fun.node;
-                    if let Some(fun_id) = opt_def_id(resolve_node(cx, qpath, fun.hir_id));
-                    then {
-                        check_print_variants(cx, expr, fun_id, args);
-                    }
+impl EarlyLintPass for Pass {
+    fn check_mac(&mut self, cx: &EarlyContext, mac: &Mac) {
+        if mac.node.path == "println" {
+            span_lint(cx, PRINT_STDOUT, mac.span, "use of `println!`");
+            if let Some(fmtstr) = check_tts(cx, &mac.node.tts, false) {
+                if fmtstr == "" {
+                    span_lint_and_sugg(
+                        cx,
+                        PRINTLN_EMPTY_STRING,
+                        mac.span,
+                        "using `println!(\"\")`",
+                        "replace it with",
+                        "println!()".to_string(),
+                    );
                 }
-            },
-            // write!()
-            ExprKind::MethodCall(ref fun, _, ref args) => {
-                if fun.ident.name == "write_fmt" {
-                    check_write_variants(cx, expr, args);
+            }
+        } else if mac.node.path == "print" {
+            span_lint(cx, PRINT_STDOUT, mac.span, "use of `print!`");
+            if let Some(fmtstr) = check_tts(cx, &mac.node.tts, false) {
+                if fmtstr.ends_with("\\n") {
+                    span_lint(cx, PRINT_WITH_NEWLINE, mac.span,
+                            "using `print!()` with a format string that ends in a \
+                            newline, consider using `println!()` instead");
                 }
-            },
-            _ => (),
+            }
+        } else if mac.node.path == "write" {
+            if let Some(fmtstr) = check_tts(cx, &mac.node.tts, true) {
+                if fmtstr.ends_with("\\n") {
+                    span_lint(cx, WRITE_WITH_NEWLINE, mac.span,
+                            "using `write!()` with a format string that ends in a \
+                            newline, consider using `writeln!()` instead");
+                }
+            }
+        } else if mac.node.path == "writeln" {
+            if let Some(fmtstr) = check_tts(cx, &mac.node.tts, true) {
+                if fmtstr == "" {
+                    span_lint_and_sugg(
+                        cx,
+                        WRITELN_EMPTY_STRING,
+                        mac.span,
+                        "using `writeln!(v, \"\")`",
+                        "replace it with",
+                        "writeln!(v)".to_string(),
+                    );
+                }
+            }
         }
     }
 }
 
-fn check_write_variants<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, write_args: &ptr::P<[Expr]>) {
-    // `writeln!` uses `write!`.
-    if let Some(span) = is_expn_of(expr.span, "write") {
-        let (span, name) = match is_expn_of(span, "writeln") {
-            Some(span) => (span, "writeln"),
-            None => (span, "write"),
+fn check_tts(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> Option<String> {
+    let tts = TokenStream::from(tts.clone());
+    let mut parser = parser::Parser::new(
+        &cx.sess.parse_sess,
+        tts,
+        None,
+        false,
+        false,
+    );
+    if is_write {
+        // skip the initial write target
+        parser.parse_expr().map_err(|mut err| err.cancel()).ok()?;
+        // might be `writeln!(foo)`
+        parser.expect(&token::Comma).map_err(|mut err| err.cancel()).ok()?;
+    }
+    let fmtstr = parser.parse_str().map_err(|mut err| err.cancel()).ok()?.0.to_string();
+    use fmt_macros::*;
+    let tmp = fmtstr.clone();
+    let mut args = vec![];
+    let mut fmt_parser = Parser::new(&tmp, None);
+    while let Some(piece) = fmt_parser.next() {
+        if !fmt_parser.errors.is_empty() {
+            return None;
+        }
+        if let Piece::NextArgument(arg) = piece {
+            if arg.format.ty == "?" {
+                // FIXME: modify rustc's fmt string parser to give us the current span
+                span_lint(cx, USE_DEBUG, parser.prev_span, "use of `Debug`-based formatting");
+            }
+            args.push(arg);
+        }
+    }
+    let lint = if is_write {
+        WRITE_LITERAL
+    } else {
+        PRINT_LITERAL
+    };
+    let mut idx = 0;
+    loop {
+        if !parser.eat(&token::Comma) {
+            assert!(parser.eat(&token::Eof));
+            return Some(fmtstr);
+        }
+        let expr = parser.parse_expr().map_err(|mut err| err.cancel()).ok()?;
+        const SIMPLE: FormatSpec = FormatSpec {
+            fill: None,
+            align: AlignUnknown,
+            flags: 0,
+            precision: CountImplied,
+            width: CountImplied,
+            ty: "",
         };
-
-        if_chain! {
-            // ensure we're calling Arguments::new_v1 or Arguments::new_v1_formatted
-            if write_args.len() == 2;
-            if let ExprKind::Call(ref args_fun, ref args_args) = write_args[1].node;
-            if let ExprKind::Path(ref qpath) = args_fun.node;
-            if let Some(const_def_id) = opt_def_id(resolve_node(cx, qpath, args_fun.hir_id));
-            if match_def_path(cx.tcx, const_def_id, &paths::FMT_ARGUMENTS_NEWV1) ||
-               match_def_path(cx.tcx, const_def_id, &paths::FMT_ARGUMENTS_NEWV1FORMATTED);
-            then {
-                // Check for literals in the write!/writeln! args
-                check_fmt_args_for_literal(cx, args_args, |span| {
-                    span_lint(cx, WRITE_LITERAL, span, "writing a literal with an empty format string");
-                });
-
-                if_chain! {
-                    if args_args.len() >= 2;
-                    if let ExprKind::AddrOf(_, ref match_expr) = args_args[1].node;
-                    if let ExprKind::Match(ref args, _, _) = match_expr.node;
-                    if let ExprKind::Tup(ref args) = args.node;
-                    if let Some((fmtstr, fmtlen)) = get_argument_fmtstr_parts(&args_args[0]);
-                    then {
-                        match name {
-                            "write" => if has_newline_end(args, fmtstr, fmtlen) {
-                                span_lint(cx, WRITE_WITH_NEWLINE, span,
-                                        "using `write!()` with a format string that ends in a \
-                                        newline, consider using `writeln!()` instead");
+        match &expr.node {
+            ExprKind::Lit(_) => {
+                let mut all_simple = true;
+                let mut seen = false;
+                for arg in &args {
+                    match arg.position {
+                        | ArgumentImplicitlyIs(n)
+                        | ArgumentIs(n)
+                        => if n == idx {
+                            all_simple &= arg.format == SIMPLE;
+                            seen = true;
+                        },
+                        ArgumentNamed(_) => {},
+                    }
+                }
+                if all_simple && seen {
+                    span_lint(cx, lint, expr.span, "literal with an empty format string");
+                }
+                idx += 1;
+            },
+            ExprKind::Assign(lhs, rhs) => {
+                if let ExprKind::Path(_, p) = &lhs.node {
+                    let mut all_simple = true;
+                    let mut seen = false;
+                    for arg in &args {
+                        match arg.position {
+                            | ArgumentImplicitlyIs(_)
+                            | ArgumentIs(_)
+                            => {},
+                            ArgumentNamed(name) => if *p == name {
+                                seen = true;
+                                all_simple &= arg.format == SIMPLE;
                             },
-                            "writeln" => if let Some(final_span) = has_empty_arg(cx, span, fmtstr, fmtlen) {
-                                span_lint_and_sugg(
-                                    cx,
-                                    WRITE_WITH_NEWLINE,
-                                    final_span,
-                                    "using `writeln!(v, \"\")`",
-                                    "replace it with",
-                                    "writeln!(v)".to_string(),
-                                );
-                            },
-                            _ => (),
                         }
                     }
-                }
-            }
-        }
-    }
-}
-
-fn check_print_variants<'a, 'tcx>(
-    cx: &LateContext<'a, 'tcx>,
-    expr: &'tcx Expr,
-    fun_id: def_id::DefId,
-    args: &ptr::P<[Expr]>,
-) {
-    // Search for `std::io::_print(..)` which is unique in a
-    // `print!` expansion.
-    if match_def_path(cx.tcx, fun_id, &paths::IO_PRINT) {
-        if let Some(span) = is_expn_of(expr.span, "print") {
-            // `println!` uses `print!`.
-            let (span, name) = match is_expn_of(span, "println") {
-                Some(span) => (span, "println"),
-                None => (span, "print"),
-            };
-
-            span_lint(cx, PRINT_STDOUT, span, &format!("use of `{}!`", name));
-            if_chain! {
-                // ensure we're calling Arguments::new_v1
-                if args.len() == 1;
-                if let ExprKind::Call(ref args_fun, ref args_args) = args[0].node;
-                then {
-                    // Check for literals in the print!/println! args
-                    check_fmt_args_for_literal(cx, args_args, |span| {
-                        span_lint(cx, PRINT_LITERAL, span, "printing a literal with an empty format string");
-                    });
-
-                    if_chain! {
-                        if let ExprKind::Path(ref qpath) = args_fun.node;
-                        if let Some(const_def_id) = opt_def_id(resolve_node(cx, qpath, args_fun.hir_id));
-                        if match_def_path(cx.tcx, const_def_id, &paths::FMT_ARGUMENTS_NEWV1);
-                        if args_args.len() == 2;
-                        if let ExprKind::AddrOf(_, ref match_expr) = args_args[1].node;
-                        if let ExprKind::Match(ref args, _, _) = match_expr.node;
-                        if let ExprKind::Tup(ref args) = args.node;
-                        if let Some((fmtstr, fmtlen)) = get_argument_fmtstr_parts(&args_args[0]);
-                        then {
-                            match name {
-                                "print" =>
-                                    if has_newline_end(args, fmtstr, fmtlen) {
-                                        span_lint(cx, PRINT_WITH_NEWLINE, span,
-                                                "using `print!()` with a format string that ends in a \
-                                                newline, consider using `println!()` instead");
-                                    },
-                                "println" =>
-                                    if let Some(final_span) = has_empty_arg(cx, span, fmtstr, fmtlen) {
-                                        span_lint_and_sugg(
-                                            cx,
-                                            PRINT_WITH_NEWLINE,
-                                            final_span,
-                                            "using `println!(\"\")`",
-                                            "replace it with",
-                                            "println!()".to_string(),
-                                        );
-                                    },
-                                _ => (),
-                            }
-                        }
+                    if all_simple && seen {
+                        span_lint(cx, lint, rhs.span, "literal with an empty format string");
                     }
                 }
-            }
+            },
+            _ => idx += 1,
         }
     }
-    // Search for something like
-    // `::std::fmt::ArgumentV1::new(__arg0, ::std::fmt::Debug::fmt)`
-    else if args.len() == 2 && match_def_path(cx.tcx, fun_id, &paths::FMT_ARGUMENTV1_NEW) {
-        if let ExprKind::Path(ref qpath) = args[1].node {
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, args[1].hir_id)) {
-                if match_def_path(cx.tcx, def_id, &paths::DEBUG_FMT_METHOD) && !is_in_debug_impl(cx, expr)
-                    && is_expn_of(expr.span, "panic").is_none()
-                {
-                    span_lint(cx, USE_DEBUG, args[0].span, "use of `Debug`-based formatting");
-                }
-            }
-        }
-    }
-}
-
-// Check for literals in write!/writeln! and print!/println! args
-// ensuring the format string for the literal is `DISPLAY_FMT_METHOD`
-// e.g., `writeln!(buf, "... {} ...", "foo")`
-//                                    ^ literal in `writeln!`
-// e.g., `println!("... {} ...", "foo")`
-//                                ^ literal in `println!`
-fn check_fmt_args_for_literal<'a, 'tcx, F>(cx: &LateContext<'a, 'tcx>, args: &HirVec<Expr>, lint_fn: F)
-where
-    F: Fn(Span),
-{
-    if_chain! {
-        if args.len() >= 2;
-
-        // the match statement
-        if let ExprKind::AddrOf(_, ref match_expr) = args[1].node;
-        if let ExprKind::Match(ref matchee, ref arms, _) = match_expr.node;
-        if let ExprKind::Tup(ref tup) = matchee.node;
-        if arms.len() == 1;
-        if let ExprKind::Array(ref arm_body_exprs) = arms[0].body.node;
-        then {
-            // it doesn't matter how many args there are in the `write!`/`writeln!`,
-            // if there's one literal, we should warn the user
-            for (idx, tup_arg) in tup.iter().enumerate() {
-                if_chain! {
-                    // first, make sure we're dealing with a literal (i.e., an ExprKind::Lit)
-                    if let ExprKind::AddrOf(_, ref tup_val) = tup_arg.node;
-                    if let ExprKind::Lit(_) = tup_val.node;
-
-                    // next, check the corresponding match arm body to ensure
-                    // this is DISPLAY_FMT_METHOD
-                    if let ExprKind::Call(_, ref body_args) = arm_body_exprs[idx].node;
-                    if body_args.len() == 2;
-                    if let ExprKind::Path(ref body_qpath) = body_args[1].node;
-                    if let Some(fun_def_id) = opt_def_id(resolve_node(cx, body_qpath, body_args[1].hir_id));
-                    if match_def_path(cx.tcx, fun_def_id, &paths::DISPLAY_FMT_METHOD);
-                    then {
-                        if args.len() == 2 {
-                            lint_fn(tup_val.span);
-                        }
-
-                        // ensure the format str has no options (e.g., width, precision, alignment, etc.)
-                        // and is just "{}"
-                        if_chain! {
-                            if args.len() == 3;
-                            if let ExprKind::AddrOf(_, ref format_expr) = args[2].node;
-                            if let ExprKind::Array(ref format_exprs) = format_expr.node;
-                            if format_exprs.len() >= 1;
-                            if let ExprKind::Struct(_, ref fields, _) = format_exprs[idx].node;
-                            if let Some(format_field) = fields.iter().find(|f| f.ident.name == "format");
-                            if check_unformatted(&format_field.expr);
-                            then {
-                                lint_fn(tup_val.span);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Check for fmtstr = "... \n"
-fn has_newline_end(args: &HirVec<Expr>, fmtstr: LocalInternedString, fmtlen: usize) -> bool {
-    if_chain! {
-        // check the final format string part
-        if let Some('\n') = fmtstr.chars().last();
-
-        // "foo{}bar" is made into two strings + one argument,
-        // if the format string starts with `{}` (eg. "{}foo"),
-        // the string array is prepended an empty string "".
-        // We only want to check the last string after any `{}`:
-        if args.len() < fmtlen;
-        then {
-            return true
-        }
-    }
-    false
-}
-
-/// Check for writeln!(v, "") / println!("")
-fn has_empty_arg<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, span: Span, fmtstr: LocalInternedString, fmtlen: usize) -> Option<Span> {
-    if_chain! {
-        // check that the string is empty
-        if fmtlen == 1;
-        if fmtstr.deref() == "\n";
-
-        // check the presence of that string
-        if let Ok(snippet) = cx.sess().codemap().span_to_snippet(span);
-        if snippet.contains("\"\"");
-        then {
-            if snippet.ends_with(';') {
-                return Some(cx.sess().codemap().span_until_char(span, ';'));
-            }
-            return Some(span)
-        }
-    }
-    None
-}
-
-/// Returns the slice of format string parts in an `Arguments::new_v1` call.
-fn get_argument_fmtstr_parts(expr: &Expr) -> Option<(LocalInternedString, usize)> {
-    if_chain! {
-        if let ExprKind::AddrOf(_, ref expr) = expr.node; // &["…", "…", …]
-        if let ExprKind::Array(ref exprs) = expr.node;
-        if let Some(expr) = exprs.last();
-        if let ExprKind::Lit(ref lit) = expr.node;
-        if let LitKind::Str(ref lit, _) = lit.node;
-        then {
-            return Some((lit.as_str(), exprs.len()));
-        }
-    }
-    None
-}
-
-fn is_in_debug_impl(cx: &LateContext, expr: &Expr) -> bool {
-    let map = &cx.tcx.hir;
-
-    // `fmt` method
-    if let Some(NodeImplItem(item)) = map.find(map.get_parent(expr.id)) {
-        // `Debug` impl
-        if let Some(NodeItem(item)) = map.find(map.get_parent(item.id)) {
-            if let ItemKind::Impl(_, _, _, _, Some(ref tr), _, _) = item.node {
-                return match_path(&tr.path, &["Debug"]);
-            }
-        }
-    }
-    false
-}
-
-/// Checks if the expression matches
-/// ```rust,ignore
-/// &[_ {
-///    format: _ {
-///         width: _::Implied,
-///         ...
-///    },
-///    ...,
-/// }]
-/// ```
-pub fn check_unformatted(format_field: &Expr) -> bool {
-    if_chain! {
-        if let ExprKind::Struct(_, ref fields, _) = format_field.node;
-        if let Some(width_field) = fields.iter().find(|f| f.ident.name == "width");
-        if let ExprKind::Path(ref qpath) = width_field.expr.node;
-        if last_path_segment(qpath).ident.name == "Implied";
-        if let Some(align_field) = fields.iter().find(|f| f.ident.name == "align");
-        if let ExprKind::Path(ref qpath) = align_field.expr.node;
-        if last_path_segment(qpath).ident.name == "Unknown";
-        if let Some(precision_field) = fields.iter().find(|f| f.ident.name == "precision");
-        if let ExprKind::Path(ref qpath_precision) = precision_field.expr.node;
-        if last_path_segment(qpath_precision).ident.name == "Implied";
-        then {
-            return true;
-        }
-    }
-
-    false
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -118,6 +118,7 @@ pub fn main() {
             for (name, to) in lint_groups {
                 ls.register_group(Some(sess), true, name, to);
             }
+            clippy_lints::register_pre_expansion_lints(sess, &mut ls);
 
             sess.plugin_llvm_passes.borrow_mut().extend(llvm_passes);
             sess.plugin_attributes.borrow_mut().extend(attributes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 use rustc_plugin::Registry;
 
 #[plugin_registrar]
-pub fn plugin_registrar(reg: &mut Registry) {
+pub fn plugin_registrar(reg: &mut Registry<'_>) {
     reg.sess.lint_store.with_read_lock(|lint_store| {
         for (lint, _, _) in lint_store.get_lint_groups() {
             reg.sess

--- a/tests/ui/excessive_precision.rs
+++ b/tests/ui/excessive_precision.rs
@@ -22,7 +22,7 @@ fn main() {
     const BAD64_3: f64 = 0.100_000_000_000_000_000_1;
 
     // Literal as param
-    println!("{}", 8.888_888_888_888_888_888_888);
+    println!("{:?}", 8.888_888_888_888_888_888_888);
 
     // // TODO add inferred type tests for f32
     // Locals

--- a/tests/ui/excessive_precision.stderr
+++ b/tests/ui/excessive_precision.stderr
@@ -43,10 +43,10 @@ error: float has excessive precision
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.1`
 
 error: float has excessive precision
-  --> $DIR/excessive_precision.rs:25:20
+  --> $DIR/excessive_precision.rs:25:22
    |
-25 |     println!("{}", 8.888_888_888_888_888_888_888);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `8.888_888_888_888_89`
+25 |     println!("{:?}", 8.888_888_888_888_888_888_888);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `8.888_888_888_888_89`
 
 error: float has excessive precision
   --> $DIR/excessive_precision.rs:36:22

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -26,6 +26,23 @@ help: instead of prefixing all patterns with `&`, you can dereference the expres
 32 |             None => println!("none"),
    |
 
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/matches.rs:40:5
+   |
+40 | /     match tup {
+41 | |         &(v, 1) => println!("{}", v),
+42 | |         _ => println!("none"),
+43 | |     }
+   | |_____^
+help: try this
+   |
+40 |     if let &(v, 1) = tup {
+41 | # [ cfg ( not ( stage0 ) ) ] {
+42 | ( $ crate :: io :: _print ( format_args_nl ! ( $ ( $ arg ) * ) ) ) ; } # [
+43 | cfg ( stage0 ) ] { print ! ( "{}/n" , format_args ! ( $ ( $ arg ) * ) ) } } else {
+44 | ( $ crate :: io :: _print ( format_args_nl ! ( $ ( $ arg ) * ) ) ) ; }
+   |
+
 error: you don't need to add `&` to all patterns
   --> $DIR/matches.rs:40:5
    |
@@ -350,5 +367,5 @@ error: use as_mut() instead
 221 | |     };
     | |_____^ help: try this: `mut_owned.as_mut()`
 
-error: aborting due to 25 previous errors
+error: aborting due to 26 previous errors
 

--- a/tests/ui/non_expressive_names.stderr
+++ b/tests/ui/non_expressive_names.stderr
@@ -1,3 +1,23 @@
+error: using `println!("")`
+  --> $DIR/non_expressive_names.rs:60:14
+   |
+60 |         _ => println!(""),
+   |              ^^^^^^^^^^^^ help: replace it with: `println!()`
+   |
+   = note: `-D println-empty-string` implied by `-D warnings`
+
+error: using `println!("")`
+   --> $DIR/non_expressive_names.rs:128:18
+    |
+128 |             1 => println!(""),
+    |                  ^^^^^^^^^^^^ help: replace it with: `println!()`
+
+error: using `println!("")`
+   --> $DIR/non_expressive_names.rs:132:18
+    |
+132 |             1 => println!(""),
+    |                  ^^^^^^^^^^^^ help: replace it with: `println!()`
+
 error: binding's name is too similar to existing binding
   --> $DIR/non_expressive_names.rs:18:9
    |
@@ -167,5 +187,5 @@ error: consider choosing a more descriptive name
 151 |         let __1___2 = 12;
     |             ^^^^^^^
 
-error: aborting due to 17 previous errors
+error: aborting due to 20 previous errors
 

--- a/tests/ui/print.stderr
+++ b/tests/ui/print.stderr
@@ -1,16 +1,22 @@
 error: use of `Debug`-based formatting
-  --> $DIR/print.rs:13:27
+  --> $DIR/print.rs:13:19
    |
 13 |         write!(f, "{:?}", 43.1415)
-   |                           ^^^^^^^
+   |                   ^^^^^^
    |
    = note: `-D use-debug` implied by `-D warnings`
+
+error: use of `Debug`-based formatting
+  --> $DIR/print.rs:20:19
+   |
+20 |         write!(f, "{:?}", 42.718)
+   |                   ^^^^^^
 
 error: use of `println!`
   --> $DIR/print.rs:25:5
    |
 25 |     println!("Hello");
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
    |
    = note: `-D print-stdout` implied by `-D warnings`
 
@@ -18,37 +24,37 @@ error: use of `print!`
   --> $DIR/print.rs:26:5
    |
 26 |     print!("Hello");
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: use of `print!`
   --> $DIR/print.rs:28:5
    |
 28 |     print!("Hello {}", "World");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of `print!`
   --> $DIR/print.rs:30:5
    |
 30 |     print!("Hello {:?}", "World");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of `Debug`-based formatting
-  --> $DIR/print.rs:30:26
+  --> $DIR/print.rs:30:12
    |
 30 |     print!("Hello {:?}", "World");
-   |                          ^^^^^^^
+   |            ^^^^^^^^^^^^
 
 error: use of `print!`
   --> $DIR/print.rs:32:5
    |
 32 |     print!("Hello {:#?}", "#orld");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of `Debug`-based formatting
-  --> $DIR/print.rs:32:27
+  --> $DIR/print.rs:32:12
    |
 32 |     print!("Hello {:#?}", "#orld");
-   |                           ^^^^^^^
+   |            ^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,4 +1,4 @@
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:23:71
    |
 23 |     println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
@@ -6,79 +6,79 @@ error: printing a literal with an empty format string
    |
    = note: `-D print-literal` implied by `-D warnings`
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:24:24
    |
 24 |     print!("Hello {}", "world");
    |                        ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:25:36
    |
 25 |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:26:26
    |
 26 |     println!("Hello {}", "world");
    |                          ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:27:30
    |
 27 |     println!("10 / 4 is {}", 2.5);
    |                              ^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:28:28
    |
 28 |     println!("2 + 1 = {}", 3);
    |                            ^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:33:25
    |
 33 |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:33:34
    |
 33 |     println!("{0} {1}", "hello", "world");
    |                                  ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:34:25
    |
 34 |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:34:34
    |
 34 |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:37:33
    |
 37 |     println!("{foo} {bar}", foo="hello", bar="world");
    |                                 ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:37:46
    |
 37 |     println!("{foo} {bar}", foo="hello", bar="world");
    |                                              ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:38:33
    |
 38 |     println!("{bar} {foo}", foo="hello", bar="world");
    |                                 ^^^^^^^
 
-error: printing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/print_literal.rs:38:46
    |
 38 |     println!("{bar} {foo}", foo="hello", bar="world");

--- a/tests/ui/print_with_newline.stderr
+++ b/tests/ui/print_with_newline.stderr
@@ -2,9 +2,27 @@ error: using `print!()` with a format string that ends in a newline, consider us
  --> $DIR/print_with_newline.rs:7:5
   |
 7 |     print!("Hello/n");
-  |     ^^^^^^^^^^^^^^^^^^
+  |     ^^^^^^^^^^^^^^^^^
   |
   = note: `-D print-with-newline` implied by `-D warnings`
 
-error: aborting due to previous error
+error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+ --> $DIR/print_with_newline.rs:8:5
+  |
+8 |     print!("Hello {}/n", "world");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+ --> $DIR/print_with_newline.rs:9:5
+  |
+9 |     print!("Hello {} {}/n/n", "world", "#2");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+  --> $DIR/print_with_newline.rs:10:5
+   |
+10 |     print!("{}/n", 1265);
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/println_empty_string.stderr
+++ b/tests/ui/println_empty_string.stderr
@@ -4,7 +4,7 @@ error: using `println!("")`
 3 |     println!("");
   |     ^^^^^^^^^^^^ help: replace it with: `println!()`
   |
-  = note: `-D print-with-newline` implied by `-D warnings`
+  = note: `-D println-empty-string` implied by `-D warnings`
 
 error: using `println!("")`
  --> $DIR/println_empty_string.rs:6:14

--- a/tests/ui/write_literal.stderr
+++ b/tests/ui/write_literal.stderr
@@ -1,4 +1,4 @@
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:26:79
    |
 26 |     writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
@@ -6,79 +6,79 @@ error: writing a literal with an empty format string
    |
    = note: `-D write-literal` implied by `-D warnings`
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:27:32
    |
 27 |     write!(&mut v, "Hello {}", "world");
    |                                ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:28:44
    |
 28 |     writeln!(&mut v, "Hello {} {}", world, "world");
    |                                            ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:29:34
    |
 29 |     writeln!(&mut v, "Hello {}", "world");
    |                                  ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:30:38
    |
 30 |     writeln!(&mut v, "10 / 4 is {}", 2.5);
    |                                      ^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:31:36
    |
 31 |     writeln!(&mut v, "2 + 1 = {}", 3);
    |                                    ^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:36:33
    |
 36 |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                 ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:36:42
    |
 36 |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                          ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:37:33
    |
 37 |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                 ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:37:42
    |
 37 |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                          ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:40:41
    |
 40 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
    |                                         ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:40:54
    |
 40 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
    |                                                      ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:41:41
    |
 41 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
    |                                         ^^^^^^^
 
-error: writing a literal with an empty format string
+error: literal with an empty format string
   --> $DIR/write_literal.rs:41:54
    |
 41 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");

--- a/tests/ui/write_with_newline.stderr
+++ b/tests/ui/write_with_newline.stderr
@@ -2,7 +2,7 @@ error: using `write!()` with a format string that ends in a newline, consider us
   --> $DIR/write_with_newline.rs:10:5
    |
 10 |     write!(&mut v, "Hello/n");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D write-with-newline` implied by `-D warnings`
 
@@ -10,19 +10,19 @@ error: using `write!()` with a format string that ends in a newline, consider us
   --> $DIR/write_with_newline.rs:11:5
    |
 11 |     write!(&mut v, "Hello {}/n", "world");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: using `write!()` with a format string that ends in a newline, consider using `writeln!()` instead
   --> $DIR/write_with_newline.rs:12:5
    |
 12 |     write!(&mut v, "Hello {} {}/n/n", "world", "#2");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: using `write!()` with a format string that ends in a newline, consider using `writeln!()` instead
   --> $DIR/write_with_newline.rs:13:5
    |
 13 |     write!(&mut v, "{}/n", 1265);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/writeln_empty_string.stderr
+++ b/tests/ui/writeln_empty_string.stderr
@@ -4,7 +4,7 @@ error: using `writeln!(v, "")`
 9 |     writeln!(&mut v, "");
   |     ^^^^^^^^^^^^^^^^^^^^ help: replace it with: `writeln!(v)`
   |
-  = note: `-D write-with-newline` implied by `-D warnings`
+  = note: `-D writeln-empty-string` implied by `-D warnings`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
there's still a bad error around match -> if let, but it's past midnight. I'll leave that for the future