### PR TITLE
Fix regression in print_literal

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -290,22 +290,24 @@ fn check_tts(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> Op
                 idx += 1;
             },
             ExprKind::Assign(lhs, rhs) => {
-                if let ExprKind::Path(_, p) = &lhs.node {
-                    let mut all_simple = true;
-                    let mut seen = false;
-                    for arg in &args {
-                        match arg.position {
-                            | ArgumentImplicitlyIs(_)
-                            | ArgumentIs(_)
-                            => {},
-                            ArgumentNamed(name) => if *p == name {
-                                seen = true;
-                                all_simple &= arg.format == SIMPLE;
-                            },
+                if let ExprKind::Lit(_) = rhs.node {
+                    if let ExprKind::Path(_, p) = &lhs.node {
+                        let mut all_simple = true;
+                        let mut seen = false;
+                        for arg in &args {
+                            match arg.position {
+                                | ArgumentImplicitlyIs(_)
+                                | ArgumentIs(_)
+                                => {},
+                                ArgumentNamed(name) => if *p == name {
+                                    seen = true;
+                                    all_simple &= arg.format == SIMPLE;
+                                },
+                            }
                         }
-                    }
-                    if all_simple && seen {
-                        span_lint(cx, lint, rhs.span, "literal with an empty format string");
+                        if all_simple && seen {
+                            span_lint(cx, lint, rhs.span, "literal with an empty format string");
+                        }
                     }
                 }
             },

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -8,6 +8,7 @@ fn main() {
     println!("Hello");
     let world = "world";
     println!("Hello {}", world);
+    println!("Hello {world}", world=world);
     println!("3 in hex is {:X}", 3);
     println!("2 + 1 = {:.4}", 3);
     println!("2 + 1 = {:5.4}", 3);

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,5 +1,5 @@
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:23:71
+  --> $DIR/print_literal.rs:24:71
    |
 24 |     println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
    |                                                                       ^
@@ -7,79 +7,79 @@ error: literal with an empty format string
    = note: `-D print-literal` implied by `-D warnings`
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:24:24
+  --> $DIR/print_literal.rs:25:24
    |
 25 |     print!("Hello {}", "world");
    |                        ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:25:36
+  --> $DIR/print_literal.rs:26:36
    |
 26 |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:26:26
+  --> $DIR/print_literal.rs:27:26
    |
 27 |     println!("Hello {}", "world");
    |                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:27:30
+  --> $DIR/print_literal.rs:28:30
    |
 28 |     println!("10 / 4 is {}", 2.5);
    |                              ^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:28:28
+  --> $DIR/print_literal.rs:29:28
    |
 29 |     println!("2 + 1 = {}", 3);
    |                            ^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:33:25
-   |
-34 |     println!("{0} {1}", "hello", "world");
-   |                         ^^^^^^^
-
-error: literal with an empty format string
-  --> $DIR/print_literal.rs:33:34
-   |
-34 |     println!("{0} {1}", "hello", "world");
-   |                                  ^^^^^^^
-
-error: literal with an empty format string
   --> $DIR/print_literal.rs:34:25
    |
-35 |     println!("{1} {0}", "hello", "world");
+34 |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:34:34
    |
+34 |     println!("{0} {1}", "hello", "world");
+   |                                  ^^^^^^^
+
+error: literal with an empty format string
+  --> $DIR/print_literal.rs:35:25
+   |
+35 |     println!("{1} {0}", "hello", "world");
+   |                         ^^^^^^^
+
+error: literal with an empty format string
+  --> $DIR/print_literal.rs:35:34
+   |
 35 |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:37:33
+  --> $DIR/print_literal.rs:38:33
    |
 38 |     println!("{foo} {bar}", foo="hello", bar="world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:37:46
+  --> $DIR/print_literal.rs:38:46
    |
 38 |     println!("{foo} {bar}", foo="hello", bar="world");
    |                                              ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:38:33
+  --> $DIR/print_literal.rs:39:33
    |
 39 |     println!("{bar} {foo}", foo="hello", bar="world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:38:46
+  --> $DIR/print_literal.rs:39:46
    |
 39 |     println!("{bar} {foo}", foo="hello", bar="world");
    |                                              ^^^^^^^

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,7 +1,7 @@
 error: literal with an empty format string
   --> $DIR/print_literal.rs:23:71
    |
-23 |     println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
+24 |     println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
    |                                                                       ^
    |
    = note: `-D print-literal` implied by `-D warnings`
@@ -9,79 +9,79 @@ error: literal with an empty format string
 error: literal with an empty format string
   --> $DIR/print_literal.rs:24:24
    |
-24 |     print!("Hello {}", "world");
+25 |     print!("Hello {}", "world");
    |                        ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:25:36
    |
-25 |     println!("Hello {} {}", world, "world");
+26 |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:26:26
    |
-26 |     println!("Hello {}", "world");
+27 |     println!("Hello {}", "world");
    |                          ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:27:30
    |
-27 |     println!("10 / 4 is {}", 2.5);
+28 |     println!("10 / 4 is {}", 2.5);
    |                              ^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:28:28
    |
-28 |     println!("2 + 1 = {}", 3);
+29 |     println!("2 + 1 = {}", 3);
    |                            ^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:33:25
    |
-33 |     println!("{0} {1}", "hello", "world");
+34 |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:33:34
    |
-33 |     println!("{0} {1}", "hello", "world");
+34 |     println!("{0} {1}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:34:25
    |
-34 |     println!("{1} {0}", "hello", "world");
+35 |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:34:34
    |
-34 |     println!("{1} {0}", "hello", "world");
+35 |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:37:33
    |
-37 |     println!("{foo} {bar}", foo="hello", bar="world");
+38 |     println!("{foo} {bar}", foo="hello", bar="world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:37:46
    |
-37 |     println!("{foo} {bar}", foo="hello", bar="world");
+38 |     println!("{foo} {bar}", foo="hello", bar="world");
    |                                              ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:38:33
    |
-38 |     println!("{bar} {foo}", foo="hello", bar="world");
+39 |     println!("{bar} {foo}", foo="hello", bar="world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:38:46
    |
-38 |     println!("{bar} {foo}", foo="hello", bar="world");
+39 |     println!("{bar} {foo}", foo="hello", bar="world");
    |                                              ^^^^^^^
 
 error: aborting due to 14 previous errors

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -11,6 +11,7 @@ fn main() {
     writeln!(&mut v, "Hello");
     let world = "world";
     writeln!(&mut v, "Hello {}", world);
+    writeln!(&mut v, "Hello {world}", world);
     writeln!(&mut v, "3 in hex is {:X}", 3);
     writeln!(&mut v, "2 + 1 = {:.4}", 3);
     writeln!(&mut v, "2 + 1 = {:5.4}", 3);

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -11,7 +11,7 @@ fn main() {
     writeln!(&mut v, "Hello");
     let world = "world";
     writeln!(&mut v, "Hello {}", world);
-    writeln!(&mut v, "Hello {world}", world);
+    writeln!(&mut v, "Hello {world}", world=world);
     writeln!(&mut v, "3 in hex is {:X}", 3);
     writeln!(&mut v, "2 + 1 = {:.4}", 3);
     writeln!(&mut v, "2 + 1 = {:5.4}", 3);

--- a/tests/ui/write_literal.stderr
+++ b/tests/ui/write_literal.stderr
@@ -1,5 +1,5 @@
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:26:79
+  --> $DIR/write_literal.rs:27:79
    |
 27 |     writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
    |                                                                               ^
@@ -7,79 +7,79 @@ error: literal with an empty format string
    = note: `-D write-literal` implied by `-D warnings`
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:27:32
+  --> $DIR/write_literal.rs:28:32
    |
 28 |     write!(&mut v, "Hello {}", "world");
    |                                ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:28:44
+  --> $DIR/write_literal.rs:29:44
    |
 29 |     writeln!(&mut v, "Hello {} {}", world, "world");
    |                                            ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:29:34
+  --> $DIR/write_literal.rs:30:34
    |
 30 |     writeln!(&mut v, "Hello {}", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:30:38
+  --> $DIR/write_literal.rs:31:38
    |
 31 |     writeln!(&mut v, "10 / 4 is {}", 2.5);
    |                                      ^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:31:36
+  --> $DIR/write_literal.rs:32:36
    |
 32 |     writeln!(&mut v, "2 + 1 = {}", 3);
    |                                    ^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:36:33
-   |
-37 |     writeln!(&mut v, "{0} {1}", "hello", "world");
-   |                                 ^^^^^^^
-
-error: literal with an empty format string
-  --> $DIR/write_literal.rs:36:42
-   |
-37 |     writeln!(&mut v, "{0} {1}", "hello", "world");
-   |                                          ^^^^^^^
-
-error: literal with an empty format string
   --> $DIR/write_literal.rs:37:33
    |
-38 |     writeln!(&mut v, "{1} {0}", "hello", "world");
+37 |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:37:42
    |
+37 |     writeln!(&mut v, "{0} {1}", "hello", "world");
+   |                                          ^^^^^^^
+
+error: literal with an empty format string
+  --> $DIR/write_literal.rs:38:33
+   |
+38 |     writeln!(&mut v, "{1} {0}", "hello", "world");
+   |                                 ^^^^^^^
+
+error: literal with an empty format string
+  --> $DIR/write_literal.rs:38:42
+   |
 38 |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:40:41
+  --> $DIR/write_literal.rs:41:41
    |
 41 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
    |                                         ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:40:54
+  --> $DIR/write_literal.rs:41:54
    |
 41 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
    |                                                      ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:41:41
+  --> $DIR/write_literal.rs:42:41
    |
 42 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
    |                                         ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:41:54
+  --> $DIR/write_literal.rs:42:54
    |
 42 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
    |                                                      ^^^^^^^

--- a/tests/ui/write_literal.stderr
+++ b/tests/ui/write_literal.stderr
@@ -1,7 +1,7 @@
 error: literal with an empty format string
   --> $DIR/write_literal.rs:26:79
    |
-26 |     writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
+27 |     writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
    |                                                                               ^
    |
    = note: `-D write-literal` implied by `-D warnings`
@@ -9,79 +9,79 @@ error: literal with an empty format string
 error: literal with an empty format string
   --> $DIR/write_literal.rs:27:32
    |
-27 |     write!(&mut v, "Hello {}", "world");
+28 |     write!(&mut v, "Hello {}", "world");
    |                                ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:28:44
    |
-28 |     writeln!(&mut v, "Hello {} {}", world, "world");
+29 |     writeln!(&mut v, "Hello {} {}", world, "world");
    |                                            ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:29:34
    |
-29 |     writeln!(&mut v, "Hello {}", "world");
+30 |     writeln!(&mut v, "Hello {}", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:30:38
    |
-30 |     writeln!(&mut v, "10 / 4 is {}", 2.5);
+31 |     writeln!(&mut v, "10 / 4 is {}", 2.5);
    |                                      ^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:31:36
    |
-31 |     writeln!(&mut v, "2 + 1 = {}", 3);
+32 |     writeln!(&mut v, "2 + 1 = {}", 3);
    |                                    ^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:36:33
    |
-36 |     writeln!(&mut v, "{0} {1}", "hello", "world");
+37 |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:36:42
    |
-36 |     writeln!(&mut v, "{0} {1}", "hello", "world");
+37 |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:37:33
    |
-37 |     writeln!(&mut v, "{1} {0}", "hello", "world");
+38 |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:37:42
    |
-37 |     writeln!(&mut v, "{1} {0}", "hello", "world");
+38 |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:40:41
    |
-40 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
+41 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
    |                                         ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:40:54
    |
-40 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
+41 |     writeln!(&mut v, "{foo} {bar}", foo="hello", bar="world");
    |                                                      ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:41:41
    |
-41 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
+42 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
    |                                         ^^^^^^^
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:41:54
    |
-41 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
+42 |     writeln!(&mut v, "{bar} {foo}", foo="hello", bar="world");
    |                                                      ^^^^^^^
 
 error: aborting due to 14 previous errors


### PR DESCRIPTION
This hopefully addresses #2956 by checking only when the rhs is a literal.