### PR TITLE
travis: run tests of external projects with --all-targets --all-features, increase coverage

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -1,17 +1,24 @@
 set -ex
+
+echo "Running clippy base tests"
+
 PATH=$PATH:./node_modules/.bin
 remark -f *.md > /dev/null
+# build clippy in debug mode and run tests
 cargo build --features debugging
 cargo test --features debugging
 mkdir -p ~/rust/cargo/bin
 cp target/debug/cargo-clippy ~/rust/cargo/bin/cargo-clippy
 cp target/debug/clippy-driver ~/rust/cargo/bin/clippy-driver
 rm ~/.cargo/bin/cargo-clippy
-PATH=$PATH:~/rust/cargo/bin cargo clippy --all-targets --all-features -- --cap-lints warn -D clippy
+# run clippy on its own codebase...
+PATH=$PATH:~/rust/cargo/bin cargo clippy --all-targets --all-features -- -D clippy
+# ... and some test directories
 cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ..
 cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
 cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
 cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../../..
+# test --manifest-path
 PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy
 cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy && cd ../..
 set +x

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -7,7 +7,7 @@ mkdir -p ~/rust/cargo/bin
 cp target/debug/cargo-clippy ~/rust/cargo/bin/cargo-clippy
 cp target/debug/clippy-driver ~/rust/cargo/bin/clippy-driver
 rm ~/.cargo/bin/cargo-clippy
-PATH=$PATH:~/rust/cargo/bin cargo clippy --all -- -D clippy
+PATH=$PATH:~/rust/cargo/bin cargo clippy --all-targets --all-features -- --cap-lints warn -D clippy
 cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ..
 cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
 cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -8,7 +8,8 @@ git clone --depth=1 https://github.com/${INTEGRATION}.git checkout
 cd checkout
 
 function check() {
-  RUST_BACKTRACE=full cargo clippy --all-targets --all-features -- --cap-lints warn &> clippy_output
+# run clippy on a project, try to be verbose and trigger as many warnings as possible for greater coverage
+  RUST_BACKTRACE=full cargo clippy --all-targets --all-features -- --cap-lints warn -W clippy_pedantic -W clippy_nursery  &> clippy_output
   cat clippy_output
   ! cat clippy_output | grep -q "internal compiler error\|query stack during panic"
   if [[ $? != 0 ]]; then

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -8,9 +8,9 @@ git clone --depth=1 https://github.com/${INTEGRATION}.git checkout
 cd checkout
 
 function check() {
-  RUST_BACKTRACE=full cargo clippy --all &> clippy_output
+  RUST_BACKTRACE=full cargo clippy --all-targets --all-features -- --cap-lints warn &> clippy_output
   cat clippy_output
-  ! cat clippy_output | grep -q "internal compiler error"
+  ! cat clippy_output | grep -q "internal compiler error\|query stack during panic"
   if [[ $? != 0 ]]; then
     return 1
   fi


### PR DESCRIPTION
when running clippy as part of ci/integration tests, run it with 
--all-targets --all-features for greater coverage
ignore #[deny(warnings) via --cap-lints warn
try to increase clippy coverage via -W clippy_pedantic -W clippy_nursery
also add some comments to the ci scripts
