### PR TITLE
WIP: Fix ICE with 'while let (..) = x.iter()'

### DIFF
--- a/tests/run-pass/ice-2965.rs
+++ b/tests/run-pass/ice-2965.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut iter = [1].iter();
+    while let Some(..) = iter.next() {
+    }
+}


### PR DESCRIPTION
Testing first if this makes the testsuite crash, because locally I had to run `cargo test` twice to get the crash.

Fixes #2965 