### PR TITLE
Fix borrow warning for reg.sess.target

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -366,9 +366,10 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>) {
     reg.register_late_lint_pass(box large_enum_variant::LargeEnumVariant::new(conf.enum_variant_size_threshold));
     reg.register_late_lint_pass(box explicit_write::Pass);
     reg.register_late_lint_pass(box needless_pass_by_value::NeedlessPassByValue);
+    let target_usize = reg.sess.target.usize_ty;
     reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
             conf.trivial_copy_size_limit,
-            &reg.sess.target,
+            target_usize,
     ));
     reg.register_early_lint_pass(box literal_representation::LiteralDigitGrouping);
     reg.register_early_lint_pass(box literal_representation::LiteralRepresentation::new(

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -8,10 +8,9 @@ use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
 use if_chain::if_chain;
 use rustc::ty::TypeVariants;
-use rustc::session::config::Config as SessionConfig;
 use rustc_target::spec::abi::Abi;
 use rustc_target::abi::LayoutOf;
-use syntax::ast::NodeId;
+use syntax::ast::{NodeId, UintTy};
 use syntax_pos::Span;
 use crate::utils::{in_macro, is_copy, is_self, span_lint_and_sugg, snippet};
 
@@ -58,9 +57,9 @@ pub struct TriviallyCopyPassByRef {
 }
 
 impl TriviallyCopyPassByRef {
-    pub fn new(limit: Option<u64>, target: &SessionConfig) -> Self {
+    pub fn new(limit: Option<u64>, usize_ty : UintTy) -> Self {
         let limit = limit.unwrap_or_else(|| {
-            let bit_width = target.usize_ty.bit_width().expect("usize should have a width") as u64;
+            let bit_width = usize_ty.bit_width().expect("usize should have a width") as u64;
             // Cap the calculated bit width at 32-bits to reduce
             // portability problems between 32 and 64-bit targets
             let bit_width = cmp::min(bit_width, 32);


### PR DESCRIPTION
Addresses this issue seen from building clippy:

```
warning[E0502]: cannot borrow `reg.sess.target` as immutable because it is also borrowed as mutable
   --> clippy_lints/src/lib.rs:371:13
    |
369 |       reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
    |       ---
    |       |
    |  _____mutable borrow occurs here
    | |
370 | |             conf.trivial_copy_size_limit,
371 | |             &reg.sess.target,
    | |             ^^^^^^^^^^^^^^^^ immutable borrow occurs here
372 | |     ));
    | |______- borrow later used here
    |
    = warning: This error has been downgraded to a warning for backwards compatibility with previous releases.
            It represents potential unsoundness in your code.
            This warning will become a hard error in the future.
```