### PR TITLE
Allow pass by ref when returning ADT with ref

### DIFF
--- a/tests/ui/trivially_copy_pass_by_ref.rs
+++ b/tests/ui/trivially_copy_pass_by_ref.rs
@@ -6,6 +6,10 @@ struct Foo(u32);
 #[derive(Copy, Clone)]
 struct Bar([u8; 24]);
 
+struct FooRef<'a> {
+    foo: &'a Foo,
+}
+
 type Baz = u32;
 
 fn good(a: &mut u32, b: u32, c: &Bar) {
@@ -18,6 +22,19 @@ fn good_return_implicit_lt_ref(foo: &Foo) -> &u32 {
 #[allow(needless_lifetimes)]
 fn good_return_explicit_lt_ref<'a>(foo: &'a Foo) -> &'a u32 {
     &foo.0
+}
+
+fn good_return_implicit_lt_struct(foo: &Foo) -> FooRef {
+    FooRef {
+        foo,
+    }
+}
+
+#[allow(needless_lifetimes)]
+fn good_return_explicit_lt_struct<'a>(foo: &'a Foo) -> FooRef<'a> {
+    FooRef {
+        foo,
+    }
 }
 
 fn bad(x: &u32, y: &Foo, z: &Baz) {

--- a/tests/ui/trivially_copy_pass_by_ref.stderr
+++ b/tests/ui/trivially_copy_pass_by_ref.stderr
@@ -1,81 +1,81 @@
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:23:11
+  --> $DIR/trivially_copy_pass_by_ref.rs:40:11
    |
-23 | fn bad(x: &u32, y: &Foo, z: &Baz) {
+40 | fn bad(x: &u32, y: &Foo, z: &Baz) {
    |           ^^^^ help: consider passing by value instead: `u32`
    |
    = note: `-D trivially-copy-pass-by-ref` implied by `-D warnings`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:23:20
+  --> $DIR/trivially_copy_pass_by_ref.rs:40:20
    |
-23 | fn bad(x: &u32, y: &Foo, z: &Baz) {
+40 | fn bad(x: &u32, y: &Foo, z: &Baz) {
    |                    ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:23:29
+  --> $DIR/trivially_copy_pass_by_ref.rs:40:29
    |
-23 | fn bad(x: &u32, y: &Foo, z: &Baz) {
+40 | fn bad(x: &u32, y: &Foo, z: &Baz) {
    |                             ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:33:12
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:12
    |
-33 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+50 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
    |            ^^^^^ help: consider passing by value instead: `self`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:33:22
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:22
    |
-33 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+50 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
    |                      ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:33:31
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:31
    |
-33 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+50 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
    |                               ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:33:40
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:40
    |
-33 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
+50 |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {
    |                                        ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:36:16
+  --> $DIR/trivially_copy_pass_by_ref.rs:53:16
    |
-36 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+53 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
    |                ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:36:25
+  --> $DIR/trivially_copy_pass_by_ref.rs:53:25
    |
-36 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+53 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
    |                         ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:36:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:53:34
    |
-36 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+53 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
    |                                  ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:50:16
+  --> $DIR/trivially_copy_pass_by_ref.rs:67:16
    |
-50 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+67 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
    |                ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:50:25
+  --> $DIR/trivially_copy_pass_by_ref.rs:67:25
    |
-50 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+67 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
    |                         ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument is passed by reference, but would be more efficient if passed by value
-  --> $DIR/trivially_copy_pass_by_ref.rs:50:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:67:34
    |
-50 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
+67 |     fn bad2(x: &u32, y: &Foo, z: &Baz) {
    |                                  ^^^^ help: consider passing by value instead: `Baz`
 
 error: aborting due to 13 previous errors


### PR DESCRIPTION
This is a follow-up to #2951 that extends the logic to allow for
returning references inside structs/enums/unions. This was a simple
oversight in the first version and it's surprisingly easy to handle.