### PR TITLE
Removed colon in documentation

### DIFF
--- a/clippy_lints/src/methods.rs
+++ b/clippy_lints/src/methods.rs
@@ -383,7 +383,7 @@ declare_clippy_lint! {
 /// (`Rc`, `Arc`, `rc::Weak`, or `sync::Weak`), and suggests calling Clone via unified
 /// function syntax instead (e.g. `Rc::clone(foo)`).
 ///
-/// **Why is this bad?**: Calling '.clone()' on an Rc, Arc, or Weak
+/// **Why is this bad?** Calling '.clone()' on an Rc, Arc, or Weak
 /// can obscure the fact that only the pointer is being cloned, not the underlying
 /// data.
 ///


### PR DESCRIPTION
The unnecessary colon looks out of place in the [rendered documentation](https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#clone_on_ref_ptr).

> ### Why is this bad
> **:** Calling ‘.clone()’ on an Rc, Arc, or Weak can obscure the fact that only the pointer is being cloned, not the underlying data.