### PR TITLE
Fix error in `CrateType` in latest Rust

### DIFF
--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -87,7 +87,7 @@ fn is_executable<'a, 'tcx>(cx: &LateContext<'a, 'tcx>) -> bool {
 
     cx.tcx.sess.crate_types.get().iter().any(|t: &CrateType| {
         match t {
-            CrateType::CrateTypeExecutable => true,
+            CrateType::Executable => true,
             _ => false,
         }
     })


### PR DESCRIPTION
Required to get Clippy and RLS building again in the Rust repo.

Builds and passes tests locally.