### PR TITLE
Remove #[allow(rust_2018_idioms)] workaround

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -77,15 +77,6 @@ lazy_static! {
 macro_rules! define_Conf {
     ($(#[$doc: meta] ($rust_name: ident, $rust_name_str: expr, $default: expr => $($ty: tt)+),)+) => {
         pub use self::helpers::Conf;
-        // FIXME(mati865): remove #[allow(rust_2018_idioms)] when it's fixed:
-        //
-        // warning: `extern crate` is not idiomatic in the new edition
-        //    --> src/utils/conf.rs:82:22
-        //     |
-        // 82  |               #[derive(Deserialize)]
-        //     |                        ^^^^^^^^^^^ help: convert it to a `use`
-        //
-        #[allow(rust_2018_idioms)]
         mod helpers {
             use serde_derive::Deserialize;
             /// Type used to store lint configuration.


### PR DESCRIPTION
Saw this when browsing the Clippy codebase.
From a quick local test this seems to be no longer necessary?