### PR TITLE
Fix the build after rust PR 53016

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -217,7 +217,7 @@ impl EarlyLintPass for Pass {
     }
 }
 
-fn check_tts(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> Option<String> {
+fn check_tts<'a>(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> Option<String> {
     let tts = TokenStream::from(tts.clone());
     let mut parser = parser::Parser::new(
         &cx.sess.parse_sess,


### PR DESCRIPTION
In-band lifetimes are no longer in the edition, so update the one place that was using them.

cc https://github.com/rust-lang/rust/pull/53016
toolstate break https://github.com/rust-lang-nursery/rust-toolstate/commit/cb6a4188e5de29aa83ce8fd44f17467e6002ed84