### PR TITLE
Allow print/write with multiple newlines

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     pub PRINT_WITH_NEWLINE,
     style,
-    "using `print!()` with a format string that ends in a newline"
+    "using `print!()` with a format string that ends in a single newline"
 }
 
 /// **What it does:** Checks for printing on *stdout*. The purpose of this lint
@@ -127,7 +127,7 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     pub WRITE_WITH_NEWLINE,
     style,
-    "using `write!()` with a format string that ends in a newline"
+    "using `write!()` with a format string that ends in a single newline"
 }
 
 /// **What it does:** This lint warns about the use of literals as `write!`/`writeln!` args.
@@ -186,18 +186,18 @@ impl EarlyLintPass for Pass {
         } else if mac.node.path == "print" {
             span_lint(cx, PRINT_STDOUT, mac.span, "use of `print!`");
             if let Some(fmtstr) = check_tts(cx, &mac.node.tts, false) {
-                if fmtstr.ends_with("\\n") {
+                if fmtstr.ends_with("\\n") && !fmtstr.ends_with("\\n\\n") {
                     span_lint(cx, PRINT_WITH_NEWLINE, mac.span,
                             "using `print!()` with a format string that ends in a \
-                            newline, consider using `println!()` instead");
+                            single newline, consider using `println!()` instead");
                 }
             }
         } else if mac.node.path == "write" {
             if let Some(fmtstr) = check_tts(cx, &mac.node.tts, true) {
-                if fmtstr.ends_with("\\n") {
+                if fmtstr.ends_with("\\n") && !fmtstr.ends_with("\\n\\n") {
                     span_lint(cx, WRITE_WITH_NEWLINE, mac.span,
                             "using `write!()` with a format string that ends in a \
-                            newline, consider using `writeln!()` instead");
+                            single newline, consider using `writeln!()` instead");
                 }
             }
         } else if mac.node.path == "writeln" {

--- a/tests/ui/print_with_newline.rs
+++ b/tests/ui/print_with_newline.rs
@@ -6,7 +6,7 @@
 fn main() {
     print!("Hello\n");
     print!("Hello {}\n", "world");
-    print!("Hello {} {}\n\n", "world", "#2");
+    print!("Hello {} {}\n", "world", "#2");
     print!("{}\n", 1265);
 
     // these are all fine
@@ -18,4 +18,7 @@ fn main() {
     print!("Issue\n{}", 1265);
     print!("{}", 1265);
     print!("\n{}", 1275);
+    print!("\n\n");
+    print!("like eof\n\n");
+    print!("Hello {} {}\n\n", "world", "#2");
 }

--- a/tests/ui/print_with_newline.stderr
+++ b/tests/ui/print_with_newline.stderr
@@ -1,4 +1,4 @@
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
  --> $DIR/print_with_newline.rs:7:5
   |
 7 |     print!("Hello/n");
@@ -6,19 +6,19 @@ error: using `print!()` with a format string that ends in a newline, consider us
   |
   = note: `-D print-with-newline` implied by `-D warnings`
 
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
  --> $DIR/print_with_newline.rs:8:5
   |
 8 |     print!("Hello {}/n", "world");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
  --> $DIR/print_with_newline.rs:9:5
   |
-9 |     print!("Hello {} {}/n/n", "world", "#2");
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+9 |     print!("Hello {} {}/n", "world", "#2");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `print!()` with a format string that ends in a newline, consider using `println!()` instead
+error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
   --> $DIR/print_with_newline.rs:10:5
    |
 10 |     print!("{}/n", 1265);

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -9,7 +9,7 @@ fn main() {
     // These should fail
     write!(&mut v, "Hello\n");
     write!(&mut v, "Hello {}\n", "world");
-    write!(&mut v, "Hello {} {}\n\n", "world", "#2");
+    write!(&mut v, "Hello {} {}\n", "world", "#2");
     write!(&mut v, "{}\n", 1265);
 
     // These should be fine
@@ -21,5 +21,7 @@ fn main() {
     write!(&mut v, "Issue\n{}", 1265);
     write!(&mut v, "{}", 1265);
     write!(&mut v, "\n{}", 1275);
-
+    write!(&mut v, "\n\n");
+    write!(&mut v, "like eof\n\n");
+    write!(&mut v, "Hello {} {}\n\n", "world", "#2");
 }

--- a/tests/ui/write_with_newline.stderr
+++ b/tests/ui/write_with_newline.stderr
@@ -1,4 +1,4 @@
-error: using `write!()` with a format string that ends in a newline, consider using `writeln!()` instead
+error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
   --> $DIR/write_with_newline.rs:10:5
    |
 10 |     write!(&mut v, "Hello/n");
@@ -6,19 +6,19 @@ error: using `write!()` with a format string that ends in a newline, consider us
    |
    = note: `-D write-with-newline` implied by `-D warnings`
 
-error: using `write!()` with a format string that ends in a newline, consider using `writeln!()` instead
+error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
   --> $DIR/write_with_newline.rs:11:5
    |
 11 |     write!(&mut v, "Hello {}/n", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `write!()` with a format string that ends in a newline, consider using `writeln!()` instead
+error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
   --> $DIR/write_with_newline.rs:12:5
    |
-12 |     write!(&mut v, "Hello {} {}/n/n", "world", "#2");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+12 |     write!(&mut v, "Hello {} {}/n", "world", "#2");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `write!()` with a format string that ends in a newline, consider using `writeln!()` instead
+error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
   --> $DIR/write_with_newline.rs:13:5
    |
 13 |     write!(&mut v, "{}/n", 1265);


### PR DESCRIPTION
This PR resolves #2990.
It should now still disallow the single case and allow the case where there are more than one trailing newlines. Also, I updated the message for the lint to specify that it is for single newlines.