### PR TITLE
readme: remove "Updating rustc" paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,6 @@ transparently:
 #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
 ```
 
-## Updating rustc
-
-Sometimes, rustc moves forward without Clippy catching up. Therefore updating
-rustc may leave Clippy a non-functional state until we fix the resulting
-breakage.
-
-You can use the [rust-update](rust-update) script to update rustc only if
-Clippy would also update correctly.
-
 ## License
 
 Licensed under [MPL](https://www.mozilla.org/MPL/2.0/).


### PR DESCRIPTION
rustc nightly is blocked on broken clippy now, so techincally it should no longer happen that a rustc version "moves forward without Clippy catching up".
However it may still occur that fixes getting pushed to the Clippy repo target a nightly version that has not been deployed yet, making it seem like Clippy build is broken.
You should be able to check out and build an older Clippy commit then.