### PR TITLE
rustup, fix breakage introduced by https://github.com/rust-lang/rust/pull/53581

### DIFF
--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -65,7 +65,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
                                 _ => { return; }
                             }
                         };
-                        if ty::TyUint(UintTy::U8) != walk_ptrs_ty(cx.tables.expr_ty(needle)).sty {
+                        if ty::Uint(UintTy::U8) != walk_ptrs_ty(cx.tables.expr_ty(needle)).sty {
                             return;
                         }
                         let haystack = if let ExprKind::MethodCall(ref path, _, ref args) =

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -123,12 +123,12 @@ impl Hash for Constant {
 }
 
 impl Constant {
-    pub fn partial_cmp(tcx: TyCtxt<'_, '_, '_>, cmp_type: &ty::TypeVariants<'_>, left: &Self, right: &Self) -> Option<Ordering> {
+    pub fn partial_cmp(tcx: TyCtxt<'_, '_, '_>, cmp_type: &ty::TyKind<'_>, left: &Self, right: &Self) -> Option<Ordering> {
         match (left, right) {
             (&Constant::Str(ref ls), &Constant::Str(ref rs)) => Some(ls.cmp(rs)),
             (&Constant::Char(ref l), &Constant::Char(ref r)) => Some(l.cmp(r)),
             (&Constant::Int(l), &Constant::Int(r)) => {
-                if let ty::TyInt(int_ty) = *cmp_type {
+                if let ty::Int(int_ty) = *cmp_type {
                     Some(sext(tcx, l, int_ty).cmp(&sext(tcx, r, int_ty)))
                 } else {
                     Some(l.cmp(&r))
@@ -166,8 +166,8 @@ pub fn lit_to_constant<'tcx>(lit: &LitKind, ty: Ty<'tcx>) -> Constant {
         LitKind::Int(n, _) => Constant::Int(n),
         LitKind::Float(ref is, _) |
         LitKind::FloatUnsuffixed(ref is) => match ty.sty {
-            ty::TyFloat(FloatTy::F32) => Constant::F32(is.as_str().parse().unwrap()),
-            ty::TyFloat(FloatTy::F64) => Constant::F64(is.as_str().parse().unwrap()),
+            ty::Float(FloatTy::F32) => Constant::F32(is.as_str().parse().unwrap()),
+            ty::Float(FloatTy::F64) => Constant::F64(is.as_str().parse().unwrap()),
             _ => bug!(),
         },
         LitKind::Bool(b) => Constant::Bool(b),
@@ -220,7 +220,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
             ExprKind::Tup(ref tup) => self.multi(tup).map(Constant::Tuple),
             ExprKind::Repeat(ref value, _) => {
                 let n = match self.tables.expr_ty(e).sty {
-                    ty::TyArray(_, n) => n.assert_usize(self.tcx).expect("array length"),
+                    ty::Array(_, n) => n.assert_usize(self.tcx).expect("array length"),
                     _ => span_bug!(e.span, "typeck error"),
                 };
                 self.expr(value).map(|v| Constant::Repeat(Box::new(v), n as u64))
@@ -243,8 +243,8 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
             Int(value) => {
                 let value = !value;
                 match ty.sty {
-                    ty::TyInt(ity) => Some(Int(unsext(self.tcx, value as i128, ity))),
-                    ty::TyUint(ity) => Some(Int(clip(self.tcx, value, ity))),
+                    ty::Int(ity) => Some(Int(unsext(self.tcx, value as i128, ity))),
+                    ty::Uint(ity) => Some(Int(clip(self.tcx, value, ity))),
                     _ => None,
                 }
             },
@@ -257,7 +257,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
         match *o {
             Int(value) => {
                 let ity = match ty.sty {
-                    ty::TyInt(ity) => ity,
+                    ty::Int(ity) => ity,
                     _ => return None,
                 };
                 // sign extend
@@ -336,7 +336,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
         match (l, r) {
             (Constant::Int(l), Some(Constant::Int(r))) => {
                 match self.tables.expr_ty(left).sty {
-                    ty::TyInt(ity) => {
+                    ty::Int(ity) => {
                         let l = sext(self.tcx, l, ity);
                         let r = sext(self.tcx, r, ity);
                         let zext = |n: i128| Constant::Int(unsext(self.tcx, n, ity));
@@ -360,7 +360,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
                             _ => None,
                         }
                     }
-                    ty::TyUint(_) => {
+                    ty::Uint(_) => {
                         match op.node {
                             BinOpKind::Add => l.checked_add(r).map(Constant::Int),
                             BinOpKind::Sub => l.checked_sub(r).map(Constant::Int),
@@ -429,18 +429,18 @@ pub fn miri_to_const<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, result: &ty::Const<'
     use rustc::mir::interpret::{Scalar, ScalarMaybeUndef, ConstValue};
     match result.val {
         ConstValue::Scalar(Scalar::Bits{ bits: b, ..}) => match result.ty.sty {
-            ty::TyBool => Some(Constant::Bool(b == 1)),
-            ty::TyUint(_) | ty::TyInt(_) => Some(Constant::Int(b)),
-            ty::TyFloat(FloatTy::F32) => Some(Constant::F32(f32::from_bits(b as u32))),
-            ty::TyFloat(FloatTy::F64) => Some(Constant::F64(f64::from_bits(b as u64))),
+            ty::Bool => Some(Constant::Bool(b == 1)),
+            ty::Uint(_) | ty::Int(_) => Some(Constant::Int(b)),
+            ty::Float(FloatTy::F32) => Some(Constant::F32(f32::from_bits(b as u32))),
+            ty::Float(FloatTy::F64) => Some(Constant::F64(f64::from_bits(b as u64))),
             // FIXME: implement other conversion
             _ => None,
         },
         ConstValue::ScalarPair(Scalar::Ptr(ptr),
                                ScalarMaybeUndef::Scalar(
                                 Scalar::Bits { bits: n, .. })) => match result.ty.sty {
-            ty::TyRef(_, tam, _) => match tam.sty {
-                ty::TyStr => {
+            ty::Ref(_, tam, _) => match tam.sty {
+                ty::Str => {
                     let alloc = tcx
                         .alloc_map
                         .lock()

--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -159,9 +159,9 @@ impl<'a, 'tcx> Visitor<'tcx> for CCHelper<'a, 'tcx> {
                 walk_expr(self, e);
                 let ty = self.cx.tables.node_id_to_type(callee.hir_id);
                 match ty.sty {
-                    ty::TyFnDef(..) | ty::TyFnPtr(_) => {
+                    ty::FnDef(..) | ty::FnPtr(_) => {
                         let sig = ty.fn_sig(self.cx.tcx);
-                        if sig.skip_binder().output().sty == ty::TyNever {
+                        if sig.skip_binder().output().sty == ty::Never {
                             self.divergence += 1;
                         }
                     },

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -2,7 +2,7 @@ use rustc::hir::*;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
 use if_chain::if_chain;
-use rustc::ty::TypeVariants;
+use rustc::ty::TyKind;
 
 use crate::utils::{any_parent_is_automatically_derived, match_def_path, opt_def_id, paths, span_lint_and_sugg};
 
@@ -51,7 +51,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
                         // TODO: Work out a way to put "whatever the imported way of referencing
                         // this type in this file" rather than a fully-qualified type.
                         let expr_ty = cx.tables.expr_ty(expr);
-                        if let TypeVariants::TyAdt(..) = expr_ty.sty {
+                        if let TyKind::Adt(..) = expr_ty.sty {
                             let replacement = format!("{}::default()", expr_ty);
                             span_lint_and_sugg(
                                 cx,

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -141,18 +141,18 @@ fn check_copy_clone<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, item: &Item, trait_ref
         }
 
         match ty.sty {
-            ty::TyAdt(def, _) if def.is_union() => return,
+            ty::Adt(def, _) if def.is_union() => return,
 
             // Some types are not Clone by default but could be cloned “by hand” if necessary
-            ty::TyAdt(def, substs) => for variant in &def.variants {
+            ty::Adt(def, substs) => for variant in &def.variants {
                 for field in &variant.fields {
-                    if let ty::TyFnDef(..) = field.ty(cx.tcx, substs).sty {
+                    if let ty::FnDef(..) = field.ty(cx.tcx, substs).sty {
                         return;
                     }
                 }
                 for subst in substs {
                     if let ty::subst::UnpackedKind::Type(subst) = subst.unpack() {
-                        if let ty::TyParam(_) = subst.sty {
+                        if let ty::Param(_) = subst.sty {
                             return;
                         }
                     }

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -128,7 +128,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                 let arg = &args[0];
                 let arg_ty = cx.tables.expr_ty(arg);
 
-                if let ty::TyRef(..) = arg_ty.sty {
+                if let ty::Ref(..) = arg_ty.sty {
                     if match_def_path(cx.tcx, def_id, &paths::DROP) {
                         lint = DROP_REF;
                         msg = DROP_REF_SUMMARY.to_string();

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -63,19 +63,19 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnportableVariant {
                     let constant = cx.tcx.const_eval(param_env.and(cid)).ok();
                     if let Some(Constant::Int(val)) = constant.and_then(|c| miri_to_const(cx.tcx, c)) {
                         let mut ty = cx.tcx.type_of(did);
-                        if let ty::TyAdt(adt, _) = ty.sty {
+                        if let ty::Adt(adt, _) = ty.sty {
                             if adt.is_enum() {
                                 ty = adt.repr.discr_type().to_ty(cx.tcx);
                             }
                         }
                         match ty.sty {
-                            ty::TyInt(IntTy::Isize) => {
+                            ty::Int(IntTy::Isize) => {
                                 let val = ((val as i128) << 64) >> 64;
                                 if val <= i128::from(i32::max_value()) && val >= i128::from(i32::min_value()) {
                                     continue;
                                 }
                             }
-                            ty::TyUint(UintTy::Usize) if val > u128::from(u32::max_value()) => {},
+                            ty::Uint(UintTy::Usize) if val > u128::from(u32::max_value()) => {},
                             _ => continue,
                         }
                         span_lint(

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -67,9 +67,9 @@ fn check_closure(cx: &LateContext<'_, '_>, expr: &Expr) {
             let fn_ty = cx.tables.expr_ty(caller);
             match fn_ty.sty {
                 // Is it an unsafe function? They don't implement the closure traits
-                ty::TyFnDef(..) | ty::TyFnPtr(_) => {
+                ty::FnDef(..) | ty::FnPtr(_) => {
                     let sig = fn_ty.fn_sig(cx.tcx);
-                    if sig.skip_binder().unsafety == Unsafety::Unsafe || sig.skip_binder().output().sty == ty::TyNever {
+                    if sig.skip_binder().unsafety == Unsafety::Unsafe || sig.skip_binder().output().sty == ty::Never {
                         return;
                     }
                 },

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -130,9 +130,9 @@ impl<'a, 'tcx> Visitor<'tcx> for DivergenceVisitor<'a, 'tcx> {
             ExprKind::Call(ref func, _) => {
                 let typ = self.cx.tables.expr_ty(func);
                 match typ.sty {
-                    ty::TyFnDef(..) | ty::TyFnPtr(_) => {
+                    ty::FnDef(..) | ty::FnPtr(_) => {
                         let sig = typ.fn_sig(self.cx.tcx);
-                        if let ty::TyNever = self.cx.tcx.erase_late_bound_regions(&sig).output().sty {
+                        if let ty::Never = self.cx.tcx.erase_late_bound_regions(&sig).output().sty {
                             self.report_diverging_sub_expr(e);
                         }
                     },

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -2,7 +2,7 @@ use rustc::hir;
 use rustc::lint::*;
 use rustc::{declare_lint, lint_array};
 use if_chain::if_chain;
-use rustc::ty::TypeVariants;
+use rustc::ty::TyKind;
 use std::f32;
 use std::f64;
 use std::fmt;
@@ -46,7 +46,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {
         if_chain! {
             let ty = cx.tables.expr_ty(expr);
-            if let TypeVariants::TyFloat(fty) = ty.sty;
+            if let TyKind::Float(fty) = ty.sty;
             if let hir::ExprKind::Lit(ref lit) = expr.node;
             if let LitKind::Float(sym, _) | LitKind::FloatUnsuffixed(sym) = lit.node;
             if let Some(sugg) = self.check(sym, fty);

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -130,7 +130,7 @@ fn lint_impl_body<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, impl_span: Span, impl_it
 
 fn match_type(tcx: ty::TyCtxt<'_, '_, '_>, ty: ty::Ty<'_>, path: &[&str]) -> bool {
     match ty.sty {
-        ty::TyAdt(adt, _) => match_def_path(tcx, adt.did, path),
+        ty::Adt(adt, _) => match_def_path(tcx, adt.did, path),
         _ => false,
     }
 }

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -122,7 +122,7 @@ fn get_single_string_arg(cx: &LateContext<'_, '_>, expr: &Expr) -> Option<Span> 
         if match_def_path(cx.tcx, fun_def_id, &paths::DISPLAY_FMT_METHOD);
         then {
             let ty = walk_ptrs_ty(cx.tables.pat_ty(&pat[0]));
-            if ty.sty == ty::TyStr || match_type(cx, ty, &paths::STRING) {
+            if ty.sty == ty::Str || match_type(cx, ty, &paths::STRING) {
                 if let ExprKind::Tup(ref values) = match_expr.node {
                     return Some(values[0].span);
                 }

--- a/clippy_lints/src/identity_op.rs
+++ b/clippy_lints/src/identity_op.rs
@@ -63,8 +63,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityOp {
 fn check(cx: &LateContext<'_, '_>, e: &Expr, m: i8, span: Span, arg: Span) {
     if let Some(Constant::Int(v)) = constant_simple(cx, cx.tables, e) {
         let check = match cx.tables.expr_ty(e).sty {
-            ty::TyInt(ity) => unsext(cx.tcx, -1_i128, ity),
-            ty::TyUint(uty) => clip(cx.tcx, !0, uty),
+            ty::Int(ity) => unsext(cx.tcx, -1_i128, ity),
+            ty::Uint(uty) => clip(cx.tcx, !0, uty),
             _ => return,
         };
         if match m {

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -99,7 +99,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IndexingSlicing {
             let ty = cx.tables.expr_ty(array);
             if let Some(range) = higher::range(cx, index) {
                 // Ranged indexes, i.e. &x[n..m], &x[n..], &x[..n] and &x[..]
-                if let ty::TyArray(_, s) = ty.sty {
+                if let ty::Array(_, s) = ty.sty {
                     let size: u128 = s.assert_usize(cx.tcx).unwrap().into();
                     // Index is a constant range.
                     if let Some((start, end)) = to_const_range(cx, range, size) {
@@ -131,7 +131,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IndexingSlicing {
                 );
             } else {
                 // Catchall non-range index, i.e. [n] or [n << m]
-                if let ty::TyArray(..) = ty.sty {
+                if let ty::Array(..) = ty.sty {
                     // Index is a constant uint.
                     if let Some(..) = constant(cx, cx.tables, index) {
                         // Let rustc's `const_err` lint handle constant `usize` indexing on arrays.

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -40,7 +40,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidRef {
             if let ExprKind::Call(ref path, ref args) = expr.node;
             if let ExprKind::Path(ref qpath) = path.node;
             if args.len() == 0;
-            if let ty::TyRef(..) = cx.tables.expr_ty(expr).sty;
+            if let ty::Ref(..) = cx.tables.expr_ty(expr).sty;
             if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, path.hir_id));
             then {
                 let msg = if match_def_path(cx.tcx, def_id, &paths::MEM_ZEROED) |

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -265,12 +265,12 @@ fn has_is_empty(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
 
     let ty = &walk_ptrs_ty(cx.tables.expr_ty(expr));
     match ty.sty {
-        ty::TyDynamic(ref tt, ..) => cx.tcx
+        ty::Dynamic(ref tt, ..) => cx.tcx
             .associated_items(tt.principal().expect("trait impl not found").def_id())
             .any(|item| is_is_empty(cx, &item)),
-        ty::TyProjection(ref proj) => has_is_empty_impl(cx, proj.item_def_id),
-        ty::TyAdt(id, _) => has_is_empty_impl(cx, id.did),
-        ty::TyArray(..) | ty::TySlice(..) | ty::TyStr => true,
+        ty::Projection(ref proj) => has_is_empty_impl(cx, proj.item_def_id),
+        ty::Adt(id, _) => has_is_empty_impl(cx, id.did),
+        ty::Array(..) | ty::Slice(..) | ty::Str => true,
         _ => false,
     }
 }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(slice_patterns)]
 #![feature(stmt_expr_attributes)]
 #![feature(range_contains)]
-#![feature(macro_vis_matcher)]
 #![allow(unknown_lints, shadow_reuse, missing_docs_in_private_items)]
 #![recursion_limit = "256"]
 #![feature(iterator_find_map)]

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -8,10 +8,8 @@
 #![feature(macro_vis_matcher)]
 #![allow(unknown_lints, shadow_reuse, missing_docs_in_private_items)]
 #![recursion_limit = "256"]
-#![allow(stable_features)]
 #![feature(iterator_find_map)]
 #![feature(macro_at_most_once_rep)]
-#![feature(tool_attributes)]
 #![warn(rust_2018_idioms)]
 
 use toml;

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -54,7 +54,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                                     walk_ptrs_ty_depth(cx.tables.pat_ty(&first_arg.pat)).1 == 1
                                 {
                                     // the argument is not an &mut T
-                                    if let ty::TyRef(_, _, mutbl) = ty.sty {
+                                    if let ty::Ref(_, _, mutbl) = ty.sty {
                                         if mutbl == MutImmutable {
                                             span_help_and_lint(cx, MAP_CLONE, expr.span, &format!(
                                                 "you seem to be using .map() to clone the contents of an {}, consider \

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -86,8 +86,8 @@ impl LintPass for Pass {
 
 fn is_unit_type(ty: ty::Ty<'_>) -> bool {
     match ty.sty {
-        ty::TyTuple(slice) => slice.is_empty(),
-        ty::TyNever => true,
+        ty::Tuple(slice) => slice.is_empty(),
+        ty::Never => true,
         _ => false,
     }
 }
@@ -95,7 +95,7 @@ fn is_unit_type(ty: ty::Ty<'_>) -> bool {
 fn is_unit_function(cx: &LateContext<'_, '_>, expr: &hir::Expr) -> bool {
     let ty = cx.tables.expr_ty(expr);
 
-    if let ty::TyFnDef(id, _) = ty.sty {
+    if let ty::FnDef(id, _) = ty.sty {
         if let Some(fn_type) = cx.tcx.fn_sig(id).no_late_bound_regions() {
             return is_unit_type(fn_type.output());
         }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -224,7 +224,7 @@ fn check_single_match(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &
             return;
         };
         let ty = cx.tables.expr_ty(ex);
-        if ty.sty != ty::TyBool || is_allowed(cx, MATCH_BOOL, ex.id) {
+        if ty.sty != ty::Bool || is_allowed(cx, MATCH_BOOL, ex.id) {
             check_single_match_single_pattern(cx, ex, arms, expr, els);
             check_single_match_opt_like(cx, ex, arms, expr, ty, els);
         }
@@ -295,7 +295,7 @@ fn check_single_match_opt_like(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm]
 
 fn check_match_bool(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     // type of expression == bool
-    if cx.tables.expr_ty(ex).sty == ty::TyBool {
+    if cx.tables.expr_ty(ex).sty == ty::Bool {
         span_lint_and_then(
             cx,
             MATCH_BOOL,

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -465,7 +465,7 @@ fn is_allowed<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> bool {
 }
 
 fn is_float(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
-    matches!(walk_ptrs_ty(cx.tables.expr_ty(expr)).sty, ty::TyFloat(_))
+    matches!(walk_ptrs_ty(cx.tables.expr_ty(expr)).sty, ty::Float(_))
 }
 
 fn check_to_owned(cx: &LateContext<'_, '_>, expr: &Expr, other: &Expr) {

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -71,7 +71,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
                     expr.span,
                     "generally you want to avoid `&mut &mut _` if possible",
                 );
-            } else if let ty::TyRef(
+            } else if let ty::Ref(
                 _,
                 _,
                 hir::MutMutable,

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -58,16 +58,16 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnnecessaryMutPassed {
 
 fn check_arguments<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, arguments: &[Expr], type_definition: Ty<'tcx>, name: &str) {
     match type_definition.sty {
-        ty::TyFnDef(..) | ty::TyFnPtr(_) => {
+        ty::FnDef(..) | ty::FnPtr(_) => {
             let parameters = type_definition.fn_sig(cx.tcx).skip_binder().inputs();
             for (argument, parameter) in arguments.iter().zip(parameters.iter()) {
                 match parameter.sty {
-                    ty::TyRef(
+                    ty::Ref(
                         _,
                         _,
                         MutImmutable,
                     ) |
-                    ty::TyRawPtr(ty::TypeAndMut {
+                    ty::RawPtr(ty::TypeAndMut {
                         mutbl: MutImmutable,
                         ..
                     }) => if let ExprKind::AddrOf(MutMutable, _) = argument.node {

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -60,7 +60,7 @@ pub struct MutexAtomic;
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutexAtomic {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         let ty = cx.tables.expr_ty(expr);
-        if let ty::TyAdt(_, subst) = ty.sty {
+        if let ty::Adt(_, subst) = ty.sty {
             if match_type(cx, ty, &paths::MUTEX) {
                 let mutex_param = subst.type_at(0);
                 if let Some(atomic_name) = get_atomic_name(mutex_param) {
@@ -70,8 +70,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutexAtomic {
                         atomic_name
                     );
                     match mutex_param.sty {
-                        ty::TyUint(t) if t != ast::UintTy::Usize => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
-                        ty::TyInt(t) if t != ast::IntTy::Isize => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
+                        ty::Uint(t) if t != ast::UintTy::Usize => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
+                        ty::Int(t) if t != ast::IntTy::Isize => span_lint(cx, MUTEX_INTEGER, expr.span, &msg),
                         _ => span_lint(cx, MUTEX_ATOMIC, expr.span, &msg),
                     };
                 }
@@ -82,10 +82,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutexAtomic {
 
 fn get_atomic_name(ty: Ty<'_>) -> Option<(&'static str)> {
     match ty.sty {
-        ty::TyBool => Some("AtomicBool"),
-        ty::TyUint(_) => Some("AtomicUsize"),
-        ty::TyInt(_) => Some("AtomicIsize"),
-        ty::TyRawPtr(_) => Some("AtomicPtr"),
+        ty::Bool => Some("AtomicBool"),
+        ty::Uint(_) => Some("AtomicUsize"),
+        ty::Int(_) => Some("AtomicIsize"),
+        ty::RawPtr(_) => Some("AtomicPtr"),
         _ => None,
     }
 }

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -54,7 +54,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
             return;
         }
         if let ExprKind::AddrOf(MutImmutable, ref inner) = e.node {
-            if let ty::TyRef(..) = cx.tables.expr_ty(inner).sty {
+            if let ty::Ref(..) = cx.tables.expr_ty(inner).sty {
                 for adj3 in cx.tables.expr_adjustments(e).windows(3) {
                     if let [Adjustment {
                         kind: Adjust::Deref(_),
@@ -90,9 +90,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
         }
         if_chain! {
             if let PatKind::Binding(BindingAnnotation::Ref, _, name, _) = pat.node;
-            if let ty::TyRef(_, tam, mutbl) = cx.tables.pat_ty(pat).sty;
+            if let ty::Ref(_, tam, mutbl) = cx.tables.pat_ty(pat).sty;
             if mutbl == MutImmutable;
-            if let ty::TyRef(_, _, mutbl) = tam.sty;
+            if let ty::Ref(_, _, mutbl) = tam.sty;
             // only lint immutable refs, because borrowed `&mut T` cannot be moved out
             if mutbl == MutImmutable;
             then {

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -205,7 +205,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
 
                     // Dereference suggestion
                     let sugg = |db: &mut DiagnosticBuilder<'_>| {
-                        if let ty::TypeVariants::TyAdt(def, ..) = ty.sty {
+                        if let ty::TyKind::Adt(def, ..) = ty.sty {
                             if let Some(span) = cx.tcx.hir.span_if_local(def.did) {
                                 if cx.param_env.can_type_implement_copy(cx.tcx, ty).is_ok() {
                                     db.span_help(span, "consider marking this type as Copy");

--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -35,7 +35,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         if let ExprKind::Struct(_, ref fields, Some(ref base)) = expr.node {
             let ty = cx.tables.expr_ty(expr);
-            if let ty::TyAdt(def, _) = ty.sty {
+            if let ty::Adt(def, _) = ty.sty {
                 if fields.len() == def.non_enum_variant().fields.len() {
                     span_lint(
                         cx,

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -169,7 +169,7 @@ fn create_new_without_default_suggest_msg(ty: Ty<'_>) -> String {
 
 fn can_derive_default<'t, 'c>(ty: Ty<'t>, cx: &LateContext<'c, 't>, default_trait_id: DefId) -> Option<Span> {
     match ty.sty {
-        ty::TyAdt(adt_def, substs) if adt_def.is_struct() => {
+        ty::Adt(adt_def, substs) if adt_def.is_struct() => {
             for field in adt_def.all_fields() {
                 let f_ty = field.ty(cx.tcx, substs);
                 if !implements_trait(cx, f_ty, default_trait_id, &[]) {

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -152,7 +152,7 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl, fn_id: NodeId, opt_body_id:
     let fn_ty = sig.skip_binder();
 
     for (idx, (arg, ty)) in decl.inputs.iter().zip(fn_ty.inputs()).enumerate() {
-        if let ty::TyRef(
+        if let ty::Ref(
             _,
             ty,
             MutImmutable

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -155,7 +155,7 @@ fn check_decl<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, decl: &'tcx Decl, bindings: 
 fn is_binding(cx: &LateContext<'_, '_>, pat_id: HirId) -> bool {
     let var_ty = cx.tables.node_id_to_type(pat_id);
     match var_ty.sty {
-        ty::TyAdt(..) => false,
+        ty::Adt(..) => false,
         _ => true,
     }
 }

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -93,8 +93,8 @@ fn check_manual_swap(cx: &LateContext<'_, '_>, block: &Block) {
                             if SpanlessEq::new(cx).ignore_fn().eq_expr(lhs1, lhs2) {
                                 let ty = walk_ptrs_ty(cx.tables.expr_ty(lhs1));
 
-                                if matches!(ty.sty, ty::TySlice(_)) ||
-                                    matches!(ty.sty, ty::TyArray(_, _)) ||
+                                if matches!(ty.sty, ty::Slice(_)) ||
+                                    matches!(ty.sty, ty::Array(_, _)) ||
                                     match_type(cx, ty, &paths::VEC) ||
                                     match_type(cx, ty, &paths::VEC_DEQUE) {
                                         return Some((lhs1, idx1, idx2));

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -550,7 +550,7 @@ fn is_questionmark_desugar_marked_call(expr: &Expr) -> bool {
 
 fn is_unit(ty: Ty<'_>) -> bool {
     match ty.sty {
-        ty::TyTuple(slice) if slice.is_empty() => true,
+        ty::Tuple(slice) if slice.is_empty() => true,
         _ => false,
     }
 }
@@ -755,7 +755,7 @@ declare_clippy_lint! {
 /// Will return 0 if the type is not an int or uint variant
 fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_, '_, '_>) -> u64 {
     match typ.sty {
-        ty::TyInt(i) => match i {
+        ty::Int(i) => match i {
             IntTy::Isize => tcx.data_layout.pointer_size.bits(),
             IntTy::I8 => 8,
             IntTy::I16 => 16,
@@ -763,7 +763,7 @@ fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_, '_, '_>) -> u64 {
             IntTy::I64 => 64,
             IntTy::I128 => 128,
         },
-        ty::TyUint(i) => match i {
+        ty::Uint(i) => match i {
             UintTy::Usize => tcx.data_layout.pointer_size.bits(),
             UintTy::U8 => 8,
             UintTy::U16 => 16,
@@ -777,7 +777,7 @@ fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_, '_, '_>) -> u64 {
 
 fn is_isize_or_usize(typ: Ty<'_>) -> bool {
     match typ.sty {
-        ty::TyInt(IntTy::Isize) | ty::TyUint(UintTy::Usize) => true,
+        ty::Int(IntTy::Isize) | ty::Uint(UintTy::Usize) => true,
         _ => false,
     }
 }
@@ -973,7 +973,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                 match (cast_from.is_integral(), cast_to.is_integral()) {
                     (true, false) => {
                         let from_nbits = int_ty_to_nbits(cast_from, cx.tcx);
-                        let to_nbits = if let ty::TyFloat(FloatTy::F32) = cast_to.sty {
+                        let to_nbits = if let ty::Float(FloatTy::F32) = cast_to.sty {
                             32
                         } else {
                             64
@@ -1014,7 +1014,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                         check_lossless(cx, expr, ex, cast_from, cast_to);
                     },
                     (false, false) => {
-                        if let (&ty::TyFloat(FloatTy::F64), &ty::TyFloat(FloatTy::F32)) = (&cast_from.sty, &cast_to.sty)
+                        if let (&ty::Float(FloatTy::F64), &ty::Float(FloatTy::F32)) = (&cast_from.sty, &cast_to.sty)
                         {
                             span_lint(
                                 cx,
@@ -1023,7 +1023,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
                                 "casting f64 to f32 may truncate the value",
                             );
                         }
-                        if let (&ty::TyFloat(FloatTy::F32), &ty::TyFloat(FloatTy::F64)) = (&cast_from.sty, &cast_to.sty)
+                        if let (&ty::Float(FloatTy::F32), &ty::Float(FloatTy::F64)) = (&cast_from.sty, &cast_to.sty)
                         {
                             span_lossless_lint(cx, expr, ex, cast_from, cast_to);
                         }
@@ -1032,9 +1032,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
             }
 
             match &cast_from.sty {
-                ty::TyFnDef(..) |
-                ty::TyFnPtr(..) => {
-                    if cast_to.is_numeric() && cast_to.sty != ty::TyUint(UintTy::Usize){
+                ty::FnDef(..) |
+                ty::FnPtr(..) => {
+                    if cast_to.is_numeric() && cast_to.sty != ty::Uint(UintTy::Usize){
                         let to_nbits = int_ty_to_nbits(cast_to, cx.tcx);
                         let pointer_nbits = cx.tcx.data_layout.pointer_size.bits();
                         if to_nbits < pointer_nbits || (to_nbits == pointer_nbits && cast_to.is_signed()) {
@@ -1063,8 +1063,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CastPass {
             }
 
             if_chain!{
-                if let ty::TyRawPtr(from_ptr_ty) = &cast_from.sty;
-                if let ty::TyRawPtr(to_ptr_ty) = &cast_to.sty;
+                if let ty::RawPtr(from_ptr_ty) = &cast_from.sty;
+                if let ty::RawPtr(to_ptr_ty) = &cast_to.sty;
                 if let Some(from_align) = cx.layout_of(from_ptr_ty.ty).ok().map(|a| a.align.abi());
                 if let Some(to_align) = cx.layout_of(to_ptr_ty.ty).ok().map(|a| a.align.abi());
                 if from_align < to_align;
@@ -1294,7 +1294,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CharLitAsU8 {
         if let ExprKind::Cast(ref e, _) = expr.node {
             if let ExprKind::Lit(ref l) = e.node {
                 if let LitKind::Char(_) = l.node {
-                    if ty::TyUint(UintTy::U8) == cx.tables.expr_ty(expr).sty && !in_macro(expr.span) {
+                    if ty::Uint(UintTy::U8) == cx.tables.expr_ty(expr).sty && !in_macro(expr.span) {
                         let msg = "casting character literal to u8. `char`s \
                                    are 4 bytes wide in rust, so casting to u8 \
                                    truncates them";
@@ -1434,13 +1434,13 @@ fn detect_extreme_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -
     let cv = constant(cx, cx.tables, expr)?.0;
 
     let which = match (&ty.sty, cv) {
-        (&ty::TyBool, Constant::Bool(false)) |
-        (&ty::TyUint(_), Constant::Int(0)) => Minimum,
-        (&ty::TyInt(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::min_value() >> (128 - int_bits(cx.tcx, ity)), ity) => Minimum,
+        (&ty::Bool, Constant::Bool(false)) |
+        (&ty::Uint(_), Constant::Int(0)) => Minimum,
+        (&ty::Int(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::min_value() >> (128 - int_bits(cx.tcx, ity)), ity) => Minimum,
 
-        (&ty::TyBool, Constant::Bool(true)) => Maximum,
-        (&ty::TyInt(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::max_value() >> (128 - int_bits(cx.tcx, ity)), ity) => Maximum,
-        (&ty::TyUint(uty), Constant::Int(i)) if clip(cx.tcx, u128::max_value(), uty) == i => Maximum,
+        (&ty::Bool, Constant::Bool(true)) => Maximum,
+        (&ty::Int(ity), Constant::Int(i)) if i == unsext(cx.tcx, i128::max_value() >> (128 - int_bits(cx.tcx, ity)), ity) => Maximum,
+        (&ty::Uint(uty), Constant::Int(i)) if clip(cx.tcx, u128::max_value(), uty) == i => Maximum,
 
         _ => return None,
     };
@@ -1574,7 +1574,7 @@ fn numeric_cast_precast_bounds<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> 
             return None;
         }
         match pre_cast_ty.sty {
-            ty::TyInt(int_ty) => Some(match int_ty {
+            ty::Int(int_ty) => Some(match int_ty {
                 IntTy::I8 => (FullInt::S(i128::from(i8::min_value())), FullInt::S(i128::from(i8::max_value()))),
                 IntTy::I16 => (
                     FullInt::S(i128::from(i16::min_value())),
@@ -1591,7 +1591,7 @@ fn numeric_cast_precast_bounds<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> 
                 IntTy::I128 => (FullInt::S(i128::min_value() as i128), FullInt::S(i128::max_value() as i128)),
                 IntTy::Isize => (FullInt::S(isize::min_value() as i128), FullInt::S(isize::max_value() as i128)),
             }),
-            ty::TyUint(uint_ty) => Some(match uint_ty {
+            ty::Uint(uint_ty) => Some(match uint_ty {
                 UintTy::U8 => (FullInt::U(u128::from(u8::min_value())), FullInt::U(u128::from(u8::max_value()))),
                 UintTy::U16 => (
                     FullInt::U(u128::from(u16::min_value())),
@@ -1619,8 +1619,8 @@ fn node_as_const_fullint<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr)
     let val = constant(cx, cx.tables, expr)?.0;
     if let Constant::Int(const_int) = val {
         match cx.tables.expr_ty(expr).sty {
-            ty::TyInt(ity) => Some(FullInt::S(sext(cx.tcx, const_int, ity))),
-            ty::TyUint(_) => Some(FullInt::U(const_int)),
+            ty::Int(ity) => Some(FullInt::S(sext(cx.tcx, const_int, ity))),
+            ty::Uint(_) => Some(FullInt::U(const_int)),
             _ => None,
         }
     } else {

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -48,7 +48,7 @@ pub struct Range<'a> {
 pub fn range<'a, 'b, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'b hir::Expr) -> Option<Range<'b>> {
 
     let def_path = match cx.tables.expr_ty(expr).sty {
-        ty::TyAdt(def, _) => cx.tcx.def_path(def.did),
+        ty::Adt(def, _) => cx.tcx.def_path(def.did),
         _ => return None,
     };
 

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -101,7 +101,7 @@ pub fn match_def_path(tcx: TyCtxt<'_, '_, '_>, def_id: DefId, path: &[&str]) -> 
 /// Check if type is struct, enum or union type with given def path.
 pub fn match_type(cx: &LateContext<'_, '_>, ty: Ty<'_>, path: &[&str]) -> bool {
     match ty.sty {
-        ty::TyAdt(adt, _) => match_def_path(cx.tcx, adt.did, path),
+        ty::Adt(adt, _) => match_def_path(cx.tcx, adt.did, path),
         _ => false,
     }
 }
@@ -631,7 +631,7 @@ pub fn walk_ptrs_hir_ty(ty: &hir::Ty) -> &hir::Ty {
 /// Return the base type for references and raw pointers.
 pub fn walk_ptrs_ty(ty: Ty<'_>) -> Ty<'_> {
     match ty.sty {
-        ty::TyRef(_, ty, _) => walk_ptrs_ty(ty),
+        ty::Ref(_, ty, _) => walk_ptrs_ty(ty),
         _ => ty,
     }
 }
@@ -641,7 +641,7 @@ pub fn walk_ptrs_ty(ty: Ty<'_>) -> Ty<'_> {
 pub fn walk_ptrs_ty_depth(ty: Ty<'_>) -> (Ty<'_>, usize) {
     fn inner(ty: Ty<'_>, depth: usize) -> (Ty<'_>, usize) {
         match ty.sty {
-            ty::TyRef(_, ty, _) => inner(ty, depth + 1),
+            ty::Ref(_, ty, _) => inner(ty, depth + 1),
             _ => (ty, depth),
         }
     }
@@ -842,7 +842,7 @@ pub fn same_tys<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) 
 /// Return whether the given type is an `unsafe` function.
 pub fn type_is_unsafe_function<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>) -> bool {
     match ty.sty {
-        ty::TyFnDef(..) | ty::TyFnPtr(_) => ty.fn_sig(cx.tcx).unsafety() == Unsafety::Unsafe,
+        ty::FnDef(..) | ty::FnPtr(_) => ty.fn_sig(cx.tcx).unsafety() == Unsafety::Unsafe,
         _ => false,
     }
 }
@@ -927,7 +927,7 @@ pub fn opt_def_id(def: Def) -> Option<DefId> {
         Def::TyAlias(id) |
         Def::AssociatedTy(id) |
         Def::TyParam(id) |
-        Def::TyForeign(id) |
+        Def::ForeignTy(id) |
         Def::Struct(id) |
         Def::StructCtor(id, ..) |
         Def::Union(id) |

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -37,8 +37,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         // search for `&vec![_]` expressions where the adjusted type is `&[_]`
         if_chain! {
-            if let ty::TyRef(_, ty, _) = cx.tables.expr_ty_adjusted(expr).sty;
-            if let ty::TySlice(..) = ty.sty;
+            if let ty::Ref(_, ty, _) = cx.tables.expr_ty_adjusted(expr).sty;
+            if let ty::Slice(..) = ty.sty;
             if let ExprKind::AddrOf(_, ref addressee) = expr.node;
             if let Some(vec_args) = higher::vec_macro(cx, addressee);
             then {
@@ -95,7 +95,7 @@ fn check_vec_macro<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, vec_args: &higher::VecA
 
 /// Return the item type of the vector (ie. the `T` in `Vec<T>`).
 fn vec_type(ty: Ty<'_>) -> Ty<'_> {
-    if let ty::TyAdt(_, substs) = ty.sty {
+    if let ty::Adt(_, substs) = ty.sty {
         substs.type_at(0)
     } else {
         panic!("The type of `vec!` is a not a struct?");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // error-pattern:cargo-clippy
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]
-#![feature(macro_vis_matcher)]
 #![allow(unknown_lints)]
 #![allow(missing_docs_in_private_items)]
 #![warn(rust_2018_idioms)]

--- a/tests/needless_continue_helpers.rs
+++ b/tests/needless_continue_helpers.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes)]
+
 
 // Tests for the various helper functions used by the needless_continue
 // lint that don't belong in utils.

--- a/tests/trim_multiline.rs
+++ b/tests/trim_multiline.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes)]
+
 
 /// test the multiline-trim function
 extern crate clippy_lints;

--- a/tests/ui/author.rs
+++ b/tests/ui/author.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes)]
+
 
 fn main() {
 

--- a/tests/ui/author/call.rs
+++ b/tests/ui/author/call.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes)]
+
 
 fn main() {
     #[clippy::author]

--- a/tests/ui/author/for_loop.rs
+++ b/tests/ui/author/for_loop.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes, stmt_expr_attributes)]
+#![feature(stmt_expr_attributes)]
 
 fn main() {
     #[clippy::author]

--- a/tests/ui/cyclomatic_complexity.rs
+++ b/tests/ui/cyclomatic_complexity.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes)]
+
 
 #![allow(clippy)]
 #![warn(cyclomatic_complexity)]

--- a/tests/ui/cyclomatic_complexity_attr_used.rs
+++ b/tests/ui/cyclomatic_complexity_attr_used.rs
@@ -1,4 +1,4 @@
-#![feature(tool_attributes)]
+
 
 #![warn(cyclomatic_complexity)]
 #![warn(unused)]

--- a/tests/ui/trailing_zeros.rs
+++ b/tests/ui/trailing_zeros.rs
@@ -1,4 +1,4 @@
-#![feature(stmt_expr_attributes, tool_attributes)]
+#![feature(stmt_expr_attributes)]
 
 #![allow(unused_parens)]
 


### PR DESCRIPTION
Is there a way to run the tests from the rustc repos clippy_lints package? 