### PR TITLE
remove macro_vis_matcher feature gate since it is stable now.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // error-pattern:cargo-clippy
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]
-#![feature(macro_vis_matcher)]
 #![allow(unknown_lints)]
 #![allow(missing_docs_in_private_items)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
Warning was:
````
warning: the feature `macro_vis_matcher` has been stable since 1.29.0 and no longer requires an attribute to enable
 --> src/lib.rs:4:12
  |
4 | #![feature(macro_vis_matcher)]
  |            ^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(stable_features)] on by default
````