### PR TITLE
Remove incorrect note from string_add_assign docs

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -9,8 +9,7 @@ use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, sp
 /// `let`!).
 ///
 /// **Why is this bad?** It's not really bad, but some people think that the
-/// `.push_str(_)` method is more readable. Also creates a new heap allocation and throws
-/// away the old one.
+/// `.push_str(_)` method is more readable.
 ///
 /// **Known problems:** None.
 ///


### PR DESCRIPTION
The docs claim that `String::push_str` is better than `String::add` because `add` allocates a new string and drops the old one, but this is not true.  In fact, `add` reuses the existing string and grows it only if its capacity is exceeded, exactly like `push_str`.  Their performance is identical since `add` is just a wrapper for `push_str`:

```
    fn add(mut self, other: &str) -> String {
        self.push_str(other);
        self
    }
```

https://github.com/rust-lang/rust/blob/35bf1ae25799a4e62131159f052e0a3cbd27c960/src/liballoc/string.rs#L1922-L1925