### PR TITLE
Revert "Fix E0502 warnings"

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -375,11 +375,9 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box large_enum_variant::LargeEnumVariant::new(conf.enum_variant_size_threshold));
     reg.register_late_lint_pass(box explicit_write::Pass);
     reg.register_late_lint_pass(box needless_pass_by_value::NeedlessPassByValue);
-
-    let target = &reg.sess.target;
     reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
             conf.trivial_copy_size_limit,
-            target,
+            &reg.sess.target,
     ));
     reg.register_early_lint_pass(box literal_representation::LiteralDigitGrouping);
     reg.register_early_lint_pass(box literal_representation::LiteralRepresentation::new(

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -448,8 +448,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                     CaptureClause::CaptureByValue => 0,
                     CaptureClause::CaptureByRef => 1,
                 }.hash(&mut self.s);
-                let value = &self.cx.tcx.hir.body(eid).value;
-                self.hash_expr(value);
+                self.hash_expr(&self.cx.tcx.hir.body(eid).value);
             },
             ExprKind::Field(ref e, ref f) => {
                 let c: fn(_, _) -> _ = ExprKind::Field;
@@ -516,8 +515,7 @@ impl<'a, 'tcx: 'a> SpanlessHash<'a, 'tcx> {
                 self.hash_expr(e);
                 let full_table = self.tables;
                 self.tables = self.cx.tcx.body_tables(l_id.body);
-                let value = &self.cx.tcx.hir.body(l_id.body).value;
-                self.hash_expr(value);
+                self.hash_expr(&self.cx.tcx.hir.body(l_id.body).value);
                 self.tables = full_table;
             },
             ExprKind::Ret(ref e) => {


### PR DESCRIPTION
This reverts commit 98dbce4fe4a6f63a4d1f9e2fdd6b2752ed097af4.

The compiler no longer emits the warnings in #2982 with the original
code.