### PR TITLE
Fix clippy -> clippy::all warning in CI

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -13,13 +13,13 @@ cp target/debug/cargo-clippy ~/rust/cargo/bin/cargo-clippy
 cp target/debug/clippy-driver ~/rust/cargo/bin/clippy-driver
 rm ~/.cargo/bin/cargo-clippy
 # run clippy on its own codebase...
-PATH=$PATH:~/rust/cargo/bin cargo clippy --all-targets --all-features -- -D clippy
+PATH=$PATH:~/rust/cargo/bin cargo clippy --all-targets --all-features -- -D clippy::all
 # ... and some test directories
-cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ..
-cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
-cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../..
-cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy && cd ../../..
+cd clippy_workspace_tests && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy::all && cd ..
+cd clippy_workspace_tests/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy::all && cd ../..
+cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy::all && cd ../..
+cd clippy_workspace_tests/subcrate/src && PATH=$PATH:~/rust/cargo/bin cargo clippy -- -D clippy::all && cd ../../..
 # test --manifest-path
-PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy
-cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy && cd ../..
+PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy::all
+cd clippy_workspace_tests/subcrate && PATH=$PATH:~/rust/cargo/bin cargo clippy --manifest-path=../Cargo.toml -- -D clippy::all && cd ../..
 set +x


### PR DESCRIPTION
This should fix the following warning in CI:

```
warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all
  |
  = note: requested on the command line with `-D clippy`
```
https://travis-ci.org/rust-lang-nursery/rust-clippy/jobs/423789079#L1128