### PR TITLE
Cleanup old min_version stuff

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -2,7 +2,6 @@ Steps to publish a new Clippy version
 
 - Bump `package.version` in `./Cargo.toml` (no need to manually bump `dependencies.clippy_lints.version`).
 - Write a changelog entry.
-- If a nightly update is needed, update `min_version.txt` using `rustc -vV > min_version.txt`
 - Run `./pre_publish.sh`
 - Review and commit all changed files
 - `git push`

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,3 @@
-//! This build script ensures that Clippy is not compiled with an
-//! incompatible version of rust. It will panic with a descriptive
-//! error message instead.
-//!
-//! We specifially want to ensure that Clippy is only built with a
-//! rustc version that is newer or equal to the one specified in the
-//! `min_version.txt` file.
-//!
-//! `min_version.txt` is in the repo but also in the `.gitignore` to
-//! make sure that it is not updated manually by accident. Only CI
-//! should update that file.
-//!
-//! This build script was originally taken from the Rocket web framework:
-//! https://github.com/SergioBenitez/Rocket
-
 use std::env;
 
 fn main() {


### PR DESCRIPTION
This cleans up a few leftover things after https://github.com/rust-lang-nursery/rust-clippy/pull/3018