### PR TITLE
driver: Improve check for rustc arg

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -47,7 +47,7 @@ pub fn main() {
         if orig_args.len() <= 1 {
             std::process::exit(1);
         }
-        if orig_args[1] == "rustc" {
+        if orig_args[1].ends_with("rustc") || orig_args[1].ends_with("rustc.exe") {
             // we still want to be able to invoke it normally though
             orig_args.remove(1);
         }


### PR DESCRIPTION
The rustc arg might not be exactly "rustc". It may be any path to a rustc
executable (especially if the RUSTC environment variable is set when
executing cargo). Rather check that it ends in `rustc` or `rust.exe`.