### PR TITLE
Fix #2293 - ptr_arg

### DIFF
--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -77,3 +77,10 @@ fn test_cow_with_ref(c: &Cow<[i32]>) {
 fn test_cow(c: Cow<[i32]>) {
     let _c = c;
 }
+
+trait Foo2 {
+    fn do_string(&self);
+}
+
+// no error for &self references where self is of type String (#2293)
+impl Foo2 for String { fn do_string(&self) {} }


### PR DESCRIPTION
Hello, I am new to the clippy codebase and I was hoping to help by fixing #2293. 

I've added a test case to the test file for `ptr_arg`, which I believe matches what the original issue said to do to recreate the bug, but running `TESTNAME=ui/ptr_arg cargo test --test compile-test` after making this change did not cause a test failure. I would have expected the tests to fail here, because the issue description said that clippy would incorrectly warn in this situation. 

Am I missing something? Or perhaps was this issue resolved with some other change? 