### PR TITLE
print_with_newline / write_with_newline: don't warn about string with several `\n`s in them.

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -195,7 +195,10 @@ impl EarlyLintPass for Pass {
         } else if mac.node.path == "print" {
             span_lint(cx, PRINT_STDOUT, mac.span, "use of `print!`");
             if let Some(fmtstr) = check_tts(cx, &mac.node.tts, false).0 {
-                if fmtstr.ends_with("\\n") && !fmtstr.ends_with("\\n\\n") {
+                if fmtstr.ends_with("\\n") &&
+                   // don't warn about strings with several `\n`s (#3126)
+                   fmtstr.matches("\\n").count() == 1
+                {
                     span_lint(
                         cx,
                         PRINT_WITH_NEWLINE,
@@ -207,7 +210,10 @@ impl EarlyLintPass for Pass {
             }
         } else if mac.node.path == "write" {
             if let Some(fmtstr) = check_tts(cx, &mac.node.tts, true).0 {
-                if fmtstr.ends_with("\\n") && !fmtstr.ends_with("\\n\\n") {
+                if fmtstr.ends_with("\\n") &&
+                   // don't warn about strings with several `\n`s (#3126)
+                   fmtstr.matches("\\n").count() == 1
+                {
                     span_lint(
                         cx,
                         WRITE_WITH_NEWLINE,

--- a/tests/ui/print_with_newline.rs
+++ b/tests/ui/print_with_newline.rs
@@ -21,4 +21,6 @@ fn main() {
     print!("\n\n");
     print!("like eof\n\n");
     print!("Hello {} {}\n\n", "world", "#2");
+    println!("\ndon't\nwarn\nfor\nmultiple\nnewlines\n"); // #3126
+    println!("\nbla\n\n"); // #3126
 }

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -26,4 +26,6 @@ fn main() {
     write!(&mut v, "\n\n");
     write!(&mut v, "like eof\n\n");
     write!(&mut v, "Hello {} {}\n\n", "world", "#2");
+    writeln!(&mut v, "\ndon't\nwarn\nfor\nmultiple\nnewlines\n"); // #3126
+    writeln!(&mut v, "\nbla\n\n"); // #3126
 }


### PR DESCRIPTION
Fixes #3126