### PR TITLE
Cargo.toml: remove clippy-dev entry referencing src/main.rs as its main.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,6 @@ name = "clippy-driver"
 test = false
 path = "src/driver.rs"
 
-[[bin]]
-name = "clippy-dev"
-test = false
-path = "src/main.rs"
-
 [dependencies]
 # begin automatic update
 clippy_lints = { version = "0.0.212", path = "clippy_lints" }


### PR DESCRIPTION
Resolves warning:
warning: file found to be present in multiple build targets: ./src/main.rs

Is this ok @phansch  ?
I didn't find any attempts to build clippy-dev from the root crate while skipping through the code.
Maybe it was some leftover snippet?