### PR TITLE
fix warnings about trivial casts, mostly {i,u}128 -> {i,u}128, such as "i128::min_value() as i128"

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -206,7 +206,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
                     ty::Array(_, n) => n.assert_usize(self.tcx).expect("array length"),
                     _ => span_bug!(e.span, "typeck error"),
                 };
-                self.expr(value).map(|v| Constant::Repeat(Box::new(v), n as u64))
+                self.expr(value).map(|v| Constant::Repeat(Box::new(v), n))
             },
             ExprKind::Unary(op, ref operand) => self.expr(operand).and_then(|o| match op {
                 UnNot => self.constant_not(&o, self.tables.expr_ty(e)),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -9,7 +9,7 @@
 #![recursion_limit = "256"]
 #![feature(macro_at_most_once_rep)]
 #![feature(tool_lints)]
-#![warn(rust_2018_idioms)]
+#![warn(rust_2018_idioms, trivial_casts, trivial_numeric_casts)]
 #![feature(crate_visibility_modifier)]
 
 use toml;

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1588,7 +1588,7 @@ fn numeric_cast_precast_bounds<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> 
                     FullInt::S(i128::from(i64::min_value())),
                     FullInt::S(i128::from(i64::max_value())),
                 ),
-                IntTy::I128 => (FullInt::S(i128::min_value() as i128), FullInt::S(i128::max_value() as i128)),
+                IntTy::I128 => (FullInt::S(i128::min_value()), FullInt::S(i128::max_value())),
                 IntTy::Isize => (FullInt::S(isize::min_value() as i128), FullInt::S(isize::max_value() as i128)),
             }),
             ty::Uint(uint_ty) => Some(match uint_ty {
@@ -1605,7 +1605,7 @@ fn numeric_cast_precast_bounds<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> 
                     FullInt::U(u128::from(u64::min_value())),
                     FullInt::U(u128::from(u64::max_value())),
                 ),
-                UintTy::U128 => (FullInt::U(u128::min_value() as u128), FullInt::U(u128::max_value() as u128)),
+                UintTy::U128 => (FullInt::U(u128::min_value()), FullInt::U(u128::max_value())),
                 UintTy::Usize => (FullInt::U(usize::min_value() as u128), FullInt::U(usize::max_value() as u128)),
             }),
             _ => None,


### PR DESCRIPTION
also makes it warn by default.