### PR TITLE
Fix 3145

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -284,7 +284,6 @@ fn check_tts<'a>(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -
     let mut idx = 0;
     loop {
         if !parser.eat(&token::Comma) {
-            assert!(parser.eat(&token::Eof));
             return (Some(fmtstr), expr);
         }
         let token_expr = match parser.parse_expr().map_err(|mut err| err.cancel()) {

--- a/tests/ui/issue-3145.rs
+++ b/tests/ui/issue-3145.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}" a); //~ERROR expected token: `,`
+}

--- a/tests/ui/issue-3145.stderr
+++ b/tests/ui/issue-3145.stderr
@@ -1,0 +1,8 @@
+error: expected token: `,`
+ --> $DIR/issue-3145.rs:2:19
+  |
+2 |     println!("{}" a); //~ERROR expected token: `,`
+  |                   ^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #3145

This error originates on this assert:
https://github.com/rust-lang-nursery/rust-clippy/blob/63a46b1e1a9a4cc3d78e1cf7a628421051c21167/clippy_lints/src/write.rs#L286-L289

The `check_tts` function gets the arguments of the macro call as a `ThinTokenStream`:
```rust
writeln!(v, "{}", "foo"); => ThinTokenStream <v, "{}", "foo"> 
```
The thought behind this assertion is that if no `Comma` is found after a parsed `expr` the parser has reached the end of the`ThinTokenStream`, because `expr`s need to be seperated by a `Comma`. But with a syntax error like `println!("{}" a);` this is not the case. Removing the assertion is a simple fix, that shouldn't break anything.

r? @oli-obk 