### PR TITLE
clippy_lints: enable crate_visibility_modifier since it is used but no longer part of 2018 edition.

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(macro_at_most_once_rep)]
 #![feature(tool_lints)]
 #![warn(rust_2018_idioms)]
+#![feature(crate_visibility_modifier)]
 
 use toml;
 use rustc_plugin;


### PR DESCRIPTION
Fixes build with https://github.com/rust-lang/rust/pull/53999