### PR TITLE
Add match on StructCtor

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -864,7 +864,8 @@ pub fn opt_def_id(def: Def) -> Option<DefId> {
         Def::AssociatedConst(id) |
         Def::Macro(id, ..) |
         Def::Existential(id) |
-        Def::AssociatedExistential(id)
+        Def::AssociatedExistential(id) |
+        Def::SelfCtor(id)
         => Some(id),
 
         Def::Upvar(..) | Def::Local(_) | Def::Label(..) | Def::PrimTy(..) | Def::SelfTy(..) |


### PR DESCRIPTION
breakage caused by https://github.com/rust-lang/rust/commits/6ff0b2ed163dab4389d88b14b5729514c11c682e

fixes #3183