### PR TITLE
Reintroduce `extern crate` for non-Cargo dependencies, in tests.

### DIFF
--- a/tests/matches.rs
+++ b/tests/matches.rs
@@ -7,7 +7,7 @@ use std::collections::Bound;
 #[test]
 fn test_overlapping() {
     use clippy_lints::matches::overlapping;
-    use syntax::source_map::DUMMY_SP;
+    use crate::syntax::source_map::DUMMY_SP;
 
     let sp = |s, e| clippy_lints::matches::SpannedRange {
         span: DUMMY_SP,


### PR DESCRIPTION
This is part 2, turns out #3189 wasn't enough, since I only built clippy, not ran its tests.