### PR TITLE
Remove unneeded check for method call

### DIFF
--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -250,10 +250,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         }
 
         if let hir::StmtKind::Semi(ref expr, _) = stmt.node {
-            if let hir::ExprKind::MethodCall(_, _, _) = expr.node {
-                if let Some(arglists) = method_chain_args(expr, &["map"]) {
-                    lint_map_unit_fn(cx, stmt, expr, arglists[0]);
-                }
+            if let Some(arglists) = method_chain_args(expr, &["map"]) {
+                lint_map_unit_fn(cx, stmt, expr, arglists[0]);
             }
         }
     }


### PR DESCRIPTION
The check can be removed because the call to `method_chains_args`
already performs this check.