### PR TITLE
Fix single_char_pattern crash (#3204)

### DIFF
--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -45,4 +45,8 @@ fn main() {
 
     x.replace(";", ",").split(","); // issue #2978
     x.starts_with("\x03"); // issue #2996
+
+    // Issue #3204
+    const S: &str = "#";
+    x.find(S);
 }


### PR DESCRIPTION
This commit fixes the crash by removing constant checking from the lint.

Closes #3204.