### PR TITLE
Fix string_lit_as_bytes lint for macros

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -171,7 +171,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
             if path.ident.name == "as_bytes" {
                 if let ExprKind::Lit(ref lit) = args[0].node {
                     if let LitKind::Str(ref lit_content, _) = lit.node {
-                        let callsite = snippet(cx, args[0].span.source_callsite(), "");
+                        let callsite = snippet(cx, args[0].span.source_callsite(), r#""foo""#);
                         let expanded = format!("\"{}\"", lit_content.as_str());
                         if callsite.starts_with("include_str!") {
                             span_lint_and_sugg(

--- a/tests/ui/strings.rs
+++ b/tests/ui/strings.rs
@@ -59,6 +59,8 @@ fn both() {
 fn str_lit_as_bytes() {
     let bs = "hello there".as_bytes();
 
+    let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
+
     // no warning, because this cannot be written as a byte string literal:
     let ubs = "☃".as_bytes();
 
@@ -67,6 +69,7 @@ fn str_lit_as_bytes() {
     let includestr = include_str!("entry.rs").as_bytes();
 }
 
+#[allow(clippy::assign_op_pattern)]
 fn main() {
     add_only();
     add_assign_only();
@@ -74,6 +77,6 @@ fn main() {
 
     // the add is only caught for `String`
     let mut x = 1;
-;    x = x + 1;
+    x = x + 1;
     assert_eq!(2, x);
 }

--- a/tests/ui/strings.rs
+++ b/tests/ui/strings.rs
@@ -10,10 +10,10 @@
 
 
 
-
 #[warn(clippy::string_add)]
 #[allow(clippy::string_add_assign)]
-fn add_only() { // ignores assignment distinction
+fn add_only() {
+    // ignores assignment distinction
     let mut x = "".to_owned();
 
     for _ in 1..3 {
@@ -63,6 +63,8 @@ fn str_lit_as_bytes() {
     let ubs = "☃".as_bytes();
 
     let strify = stringify!(foobar).as_bytes();
+
+    let includestr = include_str!("entry.rs").as_bytes();
 }
 
 fn main() {
@@ -72,6 +74,6 @@ fn main() {
 
     // the add is only caught for `String`
     let mut x = 1;
-    ; x = x + 1;
+;    x = x + 1;
     assert_eq!(2, x);
 }

--- a/tests/ui/strings.stderr
+++ b/tests/ui/strings.stderr
@@ -60,3 +60,17 @@ error: calling `as_bytes()` on a string literal
    |
    = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
 
+error: calling `as_bytes()` on a string literal
+  --> $DIR/strings.rs:62:14
+   |
+62 |     let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with three ### in it and some " ""###`
+
+error: calling `as_bytes()` on `include_str!(..)`
+  --> $DIR/strings.rs:69:22
+   |
+69 |     let includestr = include_str!("entry.rs").as_bytes();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry.rs")`
+
+error: aborting due to 11 previous errors
+

--- a/tests/ui/strings.stderr
+++ b/tests/ui/strings.stderr
@@ -60,5 +60,3 @@ error: calling `as_bytes()` on a string literal
    |
    = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
 
-error: aborting due to 11 previous errors
-

--- a/tests/ui/strings.stderr
+++ b/tests/ui/strings.stderr
@@ -60,17 +60,5 @@ error: calling `as_bytes()` on a string literal
    |
    = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
 
-error: calling `as_bytes()` on a string literal
-  --> $DIR/strings.rs:65:18
-   |
-65 |     let strify = stringify!(foobar).as_bytes();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `bstringify!(foobar)`
-
-error: manual implementation of an assign operation
-  --> $DIR/strings.rs:75:7
-   |
-75 |     ; x = x + 1;
-   |       ^^^^^^^^^ help: replace it with: `x += 1`
-
 error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Prior to this change, string_lit_as_bytes would trigger for constructs
like `include_str!("filename").as_bytes()` and would recommend fixing it
by rewriting as `binclude_str!("filename")`.

This change updates the lint to act as an EarlyLintPass lint. It then
differentiates between string literals and macros that have bytes
yielding alternatives.

Closes #3205