### PR TITLE
fix invalid travis-yaml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,20 @@ Be sure that Clippy was compiled with the same version of rustc that cargo invok
 You can add Clippy to Travis CI in the same way you use it locally:
 
 ```yml
-- rust: stable
-- rust: beta
-  before_script:
-    - rustup component add clippy-preview
-  script:
-    - cargo clippy
-# if you want the build job to fail when encountering warnings, use
-    - cargo clippy -- -D warnings
-# in order to also check tests and none-default crate features, use
-    - cargo clippy --all-targets --all-features -- -D warnings
-    - cargo test
-    # etc.
+language: rust
+rust:
+  - stable
+  - beta
+before_script:
+  - rustup component add clippy-preview
+script:
+  - cargo clippy
+  # if you want the build job to fail when encountering warnings, use
+  - cargo clippy -- -D warnings
+  # in order to also check tests and none-default crate features, use
+  - cargo clippy --all-targets --all-features -- -D warnings
+  - cargo test
+  # etc.
 ```
 
 ## Configuration


### PR DESCRIPTION
Hi, maybe there are some mistakes in the travis yaml of README.