### PR TITLE
tests: dogfood: extend to run with --all-features and clippy::internal enabled.

### DIFF
--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -4,14 +4,16 @@ fn dogfood() {
         return;
     }
     let root_dir = std::env::current_dir().unwrap();
-    for d in &[".", "clippy_lints"] {
+    for d in &[".", "clippy_lints", "rustc_tools_util", "clippy_dev"] {
         std::env::set_current_dir(root_dir.join(d)).unwrap();
         let output = std::process::Command::new("cargo")
             .arg("run")
             .arg("--bin")
             .arg("cargo-clippy")
+            .arg("--all-features")
             .arg("--manifest-path")
             .arg(root_dir.join("Cargo.toml"))
+            .args(&["--", "-W clippy::internal"])
             .env("CLIPPY_DOGFOOD", "true")
             .output()
             .unwrap();


### PR DESCRIPTION
Run it on `rustc_tools_util` and `clippy_dev` as well.