### PR TITLE
rustc_tools_util: don't require test feature.

### DIFF
--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(test)]
-#![feature(tool_lints)]
-
 use std::env;
 
 #[macro_export]


### PR DESCRIPTION
The features are actually not needed.

Fixes build when using the crate with none-nightly compiler versions.