### PR TITLE
Fixes #3180, suppress excessive_precision lint for floats with no decimal part

### DIFF
--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -98,8 +98,9 @@ impl ExcessivePrecision {
     }
 }
 
-/// Should we exclude the float because it has a .0 suffix
+/// Should we exclude the float because it has a `.0` or `.` suffix
 /// Ex 1_000_000_000.0
+/// Ex 1_000_000_000.
 fn dot_zero_exclusion(s: &str) -> bool {
     if let Some(after_dec) = s.split('.').nth(1) {
         let mut decpart = after_dec
@@ -108,7 +109,8 @@ fn dot_zero_exclusion(s: &str) -> bool {
 
         match decpart.next() {
             Some('0') => decpart.count() == 0,
-            _ => false,
+            Some(_) => false,
+            None => true,
         }
     } else {
         false

--- a/tests/ui/excessive_precision.rs
+++ b/tests/ui/excessive_precision.rs
@@ -54,4 +54,7 @@ fn main() {
 
     let good_bige32: f32 = 1E-10;
     let bad_bige32: f32 = 1.123_456_788_888E-10;
+
+    // Inferred type
+    let good_inferred: f32 = 1f32 * 1_000_000_000.;
 }


### PR DESCRIPTION
Fixes #3180

Let me know if there are any additional test cases that should be added for this. 