### PR TITLE
remove cargo edition 2018 feature gate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "clippy"
 version = "0.0.212"

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "clippy_dev"
 version = "0.0.1"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "clippy_lints"
 # begin automatic update

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "rustc_tools_util"
 version = "0.1.0"


### PR DESCRIPTION
Rust and the cargo used to bootstrap nightly was updated in https://github.com/rust-lang/rust/pull/54601 and now has the 2018 edition stabilized.