### PR TITLE
Disable dogfood under windows until rust-lang-nursery/rustup.rs#1499 is merged

### DIFF
--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -1,6 +1,6 @@
 #[test]
 fn dogfood() {
-    if option_env!("RUSTC_TEST_SUITE").is_some() {
+    if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
         return;
     }
     let root_dir = std::env::current_dir().unwrap();


### PR DESCRIPTION
Should we do this? It would allow Appveyor to pass again and the dogfood test isn't working under windows anyway.

cc #3118 