### PR TITLE
Correct false positive in wrong_self_convention lint for to_mut

### DIFF
--- a/tests/ui/wrong_self_convention.rs
+++ b/tests/ui/wrong_self_convention.rs
@@ -59,4 +59,5 @@ impl Bar {
     fn is_(self) {}
     fn to_(self) {}
     fn from_(self) {}
+    fn to_mut(&mut self) {}
 }


### PR DESCRIPTION
Fixes #1530 

This assumes we want this lint to enforce that all `to_mut` functions take `&mut self`. 