### PR TITLE
Add dummy clippy crate for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
 build = "build.rs"
 edition = "2018"
+publish = false
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/rust-clippy" }

--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "clippy_dummy" # rename to clippy before publishing
+version = "0.0.301"
+authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+edition = "2018"
+readme = "crates-readme.md"
+description = "A bunch of helpful lints to avoid common pitfalls in Rust."
+build = 'build.rs'
+
+repository = "https://github.com/rust-lang-nursery/rust-clippy"
+
+license = "MPL-2.0"
+keywords = ["clippy", "lint", "plugin"]
+categories = ["development-tools", "development-tools::cargo-plugins"]
+
+[build-dependencies]
+term = "0.5.1"

--- a/clippy_dummy/PUBLISH.md
+++ b/clippy_dummy/PUBLISH.md
@@ -1,0 +1,4 @@
+This is a dummy crate to publish to crates.io. It primarily exists to ensure that folks trying to install clippy from crates.io get redirected to the `rustup` technique.
+
+Before publishing, be sure to rename `clippy_dummy` to `clippy` in `Cargo.toml`, it has a different name to avoid workspace issues.
+ 

--- a/clippy_dummy/build.rs
+++ b/clippy_dummy/build.rs
@@ -1,0 +1,42 @@
+extern crate term;
+
+fn main() {
+    if let Err(_) = foo() {
+        eprintln!("error: Clippy is no longer available via crates.io\n");
+        eprintln!("help: please run `rustup component add clippy-preview` instead");
+    }
+    std::process::exit(1);
+}
+
+fn foo() -> Result<(), ()> {
+    let mut t = term::stderr().ok_or(())?;
+
+    t.attr(term::Attr::Bold).map_err(|_| ())?;
+    t.fg(term::color::RED).map_err(|_| ())?;
+    write!(t, "\nerror: ").map_err(|_| ())?;
+
+
+    t.reset().map_err(|_| ())?;
+    t.fg(term::color::WHITE).map_err(|_| ())?;
+    writeln!(t, "Clippy is no longer available via crates.io\n").map_err(|_| ())?;
+
+
+    t.attr(term::Attr::Bold).map_err(|_| ())?;
+    t.fg(term::color::GREEN).map_err(|_| ())?;
+    write!(t, "help: ").map_err(|_| ())?;
+
+
+    t.reset().map_err(|_| ())?;
+    t.fg(term::color::WHITE).map_err(|_| ())?;
+    write!(t, "please run `").map_err(|_| ())?;
+
+    t.attr(term::Attr::Bold).map_err(|_| ())?;
+    write!(t, "rustup component add clippy-preview").map_err(|_| ())?;
+
+    t.reset().map_err(|_| ())?;
+    t.fg(term::color::WHITE).map_err(|_| ())?;
+    writeln!(t, "` instead").map_err(|_| ())?;
+
+    t.reset().map_err(|_| ())?;
+    Ok(())
+}

--- a/clippy_dummy/crates-readme.md
+++ b/clippy_dummy/crates-readme.md
@@ -1,0 +1,9 @@
+Installing clippy via crates.io is deprecated. Please use the following:
+
+```terminal
+rustup component add clippy-preview
+```
+
+on a Rust version 1.29 or later. You may need to run `rustup self update` if it complains about a missing clippy binary.
+
+See [the homepage](https://github.com/rust-lang-nursery/rust-clippy/#clippy) for more information

--- a/clippy_dummy/src/main.rs
+++ b/clippy_dummy/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    panic!("This shouldn't even compile")
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rust-clippy/issues/3246

r? @oli-obk @phansch

Please don't hit merge, I want to publish after i get approval (before merging)