### PR TITLE
Fix 'impossible case reached' ICE

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -174,15 +174,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                 (
                     preds.iter().any(|t| t.def_id() == borrow_trait),
                     !preds.is_empty() && preds.iter().all(|t| {
+                        let ty_params = &t.skip_binder().trait_ref.substs.iter().skip(1)
+                            .cloned()
+                            .collect::<Vec<_>>();
                         implements_trait(
                             cx,
                             cx.tcx.mk_imm_ref(&RegionKind::ReErased, ty),
                             t.def_id(),
-                            &t.skip_binder()
-                                .input_types()
-                                .skip(1)
-                                .map(|ty| ty.into())
-                                .collect::<Vec<_>>(),
+                            ty_params
                         )
                     }),
                 )

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -134,4 +134,14 @@ fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
     println!("{}", t);
 }
 
+// The following 3 lines should not cause an ICE. See #2831
+trait Bar<'a, A> {}
+impl<'b, T> Bar<'b, T> for T {}
+fn some_fun<'b, S: Bar<'b, ()>>(_item: S) {}
+
+// Also this should not cause an ICE. See #2831
+trait Club<'a, A> {}
+impl<T> Club<'static, T> for T {}
+fn more_fun(_item: impl Club<'static, i32>) {}
+
 fn main() {}

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -184,5 +184,17 @@ help: consider taking a reference instead
 129 |     let CopyWrapper(s) = *z; // moved
     |
 
-error: aborting due to 20 previous errors
+error: this argument is passed by value, but not consumed in the function body
+   --> $DIR/needless_pass_by_value.rs:140:40
+    |
+140 | fn some_fun<'b, S: Bar<'b, ()>>(_item: S) {}
+    |                                        ^ help: consider taking a reference instead: `&S`
+
+error: this argument is passed by value, but not consumed in the function body
+   --> $DIR/needless_pass_by_value.rs:145:20
+    |
+145 | fn more_fun(_item: impl Club<'static, i32>) {}
+    |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&impl Club<'static, i32>`
+
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
This fixes the ICE by using `substs` directly and creating the type+lifetime parameter list that way.

@arielb1 Was correct in that `input_types` drops the lifetime parameters and only keeps the type parameters ([nightly docs](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc/ty/mod.rs.html#1206-1208))

Fixes #2831 