### PR TITLE
new_ret_no_self

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -934,7 +934,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         if let hir::ImplItemKind::Method(ref sig, id) = implitem.node {
             let ret_ty = return_ty(cx, implitem.id);
             if name == "new" &&
-                !ret_ty.walk().any(|t| same_tys(cx, t, ty)) {
+                !same_tys(cx, ret_ty, ty) &&
+                !ret_ty.is_impl_trait() {
                 span_lint(cx,
                           NEW_RET_NO_SELF,
                           implitem.span,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -931,13 +931,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             }
         }
 
-        let ret_ty = return_ty(cx, implitem.id);
-        if name == "new" &&
-            !ret_ty.walk().any(|t| same_tys(cx, t, ty)) {
-            span_lint(cx,
-                      NEW_RET_NO_SELF,
-                      implitem.span,
-                      "methods called `new` usually return `Self`");
+        if let hir::ImplItemKind::Method(ref sig, id) = implitem.node {
+            let ret_ty = return_ty(cx, implitem.id);
+            if name == "new" &&
+                !ret_ty.walk().any(|t| same_tys(cx, t, ty)) {
+                span_lint(cx,
+                          NEW_RET_NO_SELF,
+                          implitem.span,
+                          "methods called `new` usually return `Self`");
+            }
         }
     }
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -931,7 +931,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             }
         }
 
-        if let hir::ImplItemKind::Method(ref sig, id) = implitem.node {
+        if let hir::ImplItemKind::Method(_, _) = implitem.node {
             let ret_ty = return_ty(cx, implitem.id);
             if name == "new" &&
                 !same_tys(cx, ret_ty, ty) &&

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1920,6 +1920,7 @@ enum ImplicitHasherType<'tcx> {
 
 impl<'tcx> ImplicitHasherType<'tcx> {
     /// Checks that `ty` is a target type without a BuildHasher.
+    #[allow(clippy::new_ret_no_self)]
     fn new<'a>(cx: &LateContext<'a, 'tcx>, hir_ty: &hir::Ty) -> Option<Self> {
         if let TyKind::Path(QPath::Resolved(None, ref path)) = hir_ty.node {
             let params: Vec<_> = path.segments.last().as_ref()?.args.as_ref()?

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -14,7 +14,7 @@
 #![warn(clippy::all, clippy::pedantic, clippy::option_unwrap_used)]
 #![allow(clippy::blacklisted_name, unused, clippy::print_stdout, clippy::non_ascii_literal, clippy::new_without_default,
     clippy::new_without_default_derive, clippy::missing_docs_in_private_items, clippy::needless_pass_by_value,
-    clippy::default_trait_access, clippy::use_self, clippy::useless_format)]
+    clippy::default_trait_access, clippy::use_self, clippy::new_ret_no_self, clippy::useless_format)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -43,7 +43,7 @@ impl T {
 
     fn to_something(self) -> u32 { 0 }
 
-    fn new(self) {}
+    fn new(self) -> Self { unimplemented!(); }
 }
 
 struct Lt<'a> {

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -23,16 +23,8 @@ error: methods called `to_*` usually take self by reference; consider choosing a
 error: methods called `new` usually take no self; consider choosing a less ambiguous name
   --> $DIR/methods.rs:46:12
    |
-46 |     fn new(self) {}
+46 |     fn new(self) -> Self { unimplemented!(); }
    |            ^^^^
-
-error: methods called `new` usually return `Self`
-  --> $DIR/methods.rs:46:5
-   |
-46 |     fn new(self) {}
-   |     ^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
    --> $DIR/methods.rs:114:13
@@ -465,5 +457,5 @@ error: used unwrap() on an Option value. If you don't want to handle the None ca
     |
     = note: `-D clippy::option-unwrap-used` implied by `-D warnings`
 
-error: aborting due to 58 previous errors
+error: aborting due to 57 previous errors
 

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -5,44 +5,44 @@
 
 fn main(){}
 
-//trait R {
-//    type Item;
-//}
-//
-//struct S;
-//
-//impl R for S {
-//    type Item = Self;
-//}
-//
-//impl S {
-//    // should not trigger the lint
-//    pub fn new() -> impl R<Item = Self> {
-//        S
-//    }
-//}
-//
-//struct S2;
-//
-//impl R for S2 {
-//    type Item = Self;
-//}
-//
-//impl S2 {
-//    // should not trigger the lint
-//    pub fn new(_: String) -> impl R<Item = Self> {
-//        S2
-//    }
-//}
-//
-//struct T;
-//
-//impl T {
-//    // should not trigger lint
-//    pub fn new() -> Self {
-//        unimplemented!();
-//    }
-//}
+trait R {
+    type Item;
+}
+
+struct S;
+
+impl R for S {
+    type Item = Self;
+}
+
+impl S {
+    // should not trigger the lint
+    pub fn new() -> impl R<Item = Self> {
+        S
+    }
+}
+
+struct S2;
+
+impl R for S2 {
+    type Item = Self;
+}
+
+impl S2 {
+    // should not trigger the lint
+    pub fn new(_: String) -> impl R<Item = Self> {
+        S2
+    }
+}
+
+struct T;
+
+impl T {
+    // should not trigger lint
+    pub fn new() -> Self {
+        unimplemented!();
+    }
+}
 
 struct U;
 

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -35,6 +35,19 @@ impl S2 {
     }
 }
 
+struct S3;
+
+impl R for S3 {
+    type Item = u32;
+}
+
+impl S3 {
+    // should trigger the lint, but currently does not
+    pub fn new(_: String) -> impl R<Item = u32> {
+        S3
+    }
+}
+
 struct T;
 
 impl T {

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -1,5 +1,3 @@
-#![feature(tool_lints)]
-
 #![warn(clippy::new_ret_no_self)]
 #![allow(dead_code, clippy::trivially_copy_pass_by_ref)]
 

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -9,6 +9,11 @@ trait R {
     type Item;
 }
 
+trait Q {
+    type Item;
+    type Item2;
+}
+
 struct S;
 
 impl R for S {
@@ -42,9 +47,23 @@ impl R for S3 {
 }
 
 impl S3 {
-    // should trigger the lint, but currently does not
+    // should trigger the lint
     pub fn new(_: String) -> impl R<Item = u32> {
         S3
+    }
+}
+
+struct S4;
+
+impl Q for S4 {
+    type Item = u32;
+    type Item2 = Self;
+}
+
+impl S4 {
+    // should not trigger the lint
+    pub fn new(_: String) -> impl Q<Item = u32, Item2 = Self> {
+        S4
     }
 }
 

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -1,0 +1,63 @@
+#![feature(tool_lints)]
+
+#![warn(clippy::new_ret_no_self)]
+#![allow(dead_code, clippy::trivially_copy_pass_by_ref)]
+
+fn main(){}
+
+//trait R {
+//    type Item;
+//}
+//
+//struct S;
+//
+//impl R for S {
+//    type Item = Self;
+//}
+//
+//impl S {
+//    // should not trigger the lint
+//    pub fn new() -> impl R<Item = Self> {
+//        S
+//    }
+//}
+//
+//struct S2;
+//
+//impl R for S2 {
+//    type Item = Self;
+//}
+//
+//impl S2 {
+//    // should not trigger the lint
+//    pub fn new(_: String) -> impl R<Item = Self> {
+//        S2
+//    }
+//}
+//
+//struct T;
+//
+//impl T {
+//    // should not trigger lint
+//    pub fn new() -> Self {
+//        unimplemented!();
+//    }
+//}
+
+struct U;
+
+impl U {
+    // should trigger lint
+    pub fn new() -> u32 {
+        unimplemented!();
+    }
+}
+
+struct V;
+
+impl V {
+    // should trigger lint
+    pub fn new(_: String) -> u32 {
+        unimplemented!();
+    }
+}

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -1,27 +1,27 @@
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:51:5
+  --> $DIR/new_ret_no_self.rs:49:5
    |
-51 | /     pub fn new(_: String) -> impl R<Item = u32> {
-52 | |         S3
-53 | |     }
+49 | /     pub fn new(_: String) -> impl R<Item = u32> {
+50 | |         S3
+51 | |     }
    | |_____^
    |
    = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:83:5
+  --> $DIR/new_ret_no_self.rs:81:5
    |
-83 | /     pub fn new() -> u32 {
-84 | |         unimplemented!();
-85 | |     }
+81 | /     pub fn new() -> u32 {
+82 | |         unimplemented!();
+83 | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:92:5
+  --> $DIR/new_ret_no_self.rs:90:5
    |
-92 | /     pub fn new(_: String) -> u32 {
-93 | |         unimplemented!();
-94 | |     }
+90 | /     pub fn new(_: String) -> u32 {
+91 | |         unimplemented!();
+92 | |     }
    | |_____^
 
 error: aborting due to 3 previous errors

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -1,20 +1,28 @@
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:64:5
+  --> $DIR/new_ret_no_self.rs:51:5
    |
-64 | /     pub fn new() -> u32 {
-65 | |         unimplemented!();
-66 | |     }
+51 | /     pub fn new(_: String) -> impl R<Item = u32> {
+52 | |         S3
+53 | |     }
    | |_____^
    |
    = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:73:5
+  --> $DIR/new_ret_no_self.rs:83:5
    |
-73 | /     pub fn new(_: String) -> u32 {
-74 | |         unimplemented!();
-75 | |     }
+83 | /     pub fn new() -> u32 {
+84 | |         unimplemented!();
+85 | |     }
    | |_____^
 
-error: aborting due to 2 previous errors
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self.rs:92:5
+   |
+92 | /     pub fn new(_: String) -> u32 {
+93 | |         unimplemented!();
+94 | |     }
+   | |_____^
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -1,17 +1,19 @@
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:51:5
+  --> $DIR/new_ret_no_self.rs:64:5
    |
-51 | /     pub fn new() -> u32 {
-52 | |         unimplemented!();
-53 | |     }
+64 | /     pub fn new() -> u32 {
+65 | |         unimplemented!();
+66 | |     }
    | |_____^
+   |
+   = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:60:5
+  --> $DIR/new_ret_no_self.rs:73:5
    |
-60 | /     pub fn new(_: String) -> u32 {
-61 | |         unimplemented!();
-62 | |     }
+73 | /     pub fn new(_: String) -> u32 {
+74 | |         unimplemented!();
+75 | |     }
    | |_____^
 
 error: aborting due to 2 previous errors

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -1,0 +1,18 @@
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self.rs:51:5
+   |
+51 | /     pub fn new() -> u32 {
+52 | |         unimplemented!();
+53 | |     }
+   | |_____^
+
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self.rs:60:5
+   |
+60 | /     pub fn new(_: String) -> u32 {
+61 | |         unimplemented!();
+62 | |     }
+   | |_____^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #3220 

This adds test coverage for the `new_ret_no_self` lint, corrects the false positive reported in #3220, and corrects a false negative when the `new` function takes no arguments and doesn't return self. 

However, to correct the false positive from #3220, I am simply disabling the lint if the return type is `impl trait`. This causes a different false negative as shown in the following case.

```rust
// should trigger the lint, but currently does not
pub fn new(_: String) -> impl R<Item = u32> {
    S3
}
```

I was not able to figure out how to inspect the associated types of the returned `impl trait`, but if that is possible then we could check for the type of `self` (S3 in the example above) in the associated types and correct this false negative as well.