### PR TITLE
Allow to debug rustc_driver via logs.

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -21,6 +21,7 @@ fn show_version() {
 }
 
 pub fn main() {
+    rustc_driver::init_rustc_env_logger();
     exit(rustc_driver::run(move || {
         use std::env;
 


### PR DESCRIPTION
Initializes rustc_driver's env_logger so it will possible to debug via logs.