### PR TITLE
[do not merge] Stabilize tool_lints

### DIFF
--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![allow(clippy::default_hash_types)]
 
 use itertools::Itertools;

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1,16 +1,15 @@
 // error-pattern:cargo-clippy
 
 #![feature(box_syntax)]
+#![feature(crate_visibility_modifier)]
+#![feature(macro_at_most_once_rep)]
+#![feature(range_contains)]
 #![feature(rustc_private)]
 #![feature(slice_patterns)]
 #![feature(stmt_expr_attributes)]
-#![feature(range_contains)]
-#![allow(unknown_lints, clippy::shadow_reuse, clippy::missing_docs_in_private_items)]
 #![recursion_limit = "256"]
-#![feature(macro_at_most_once_rep)]
-
+#![allow(clippy::shadow_reuse, clippy::missing_docs_in_private_items)]
 #![warn(rust_2018_idioms, trivial_casts, trivial_numeric_casts)]
-#![feature(crate_visibility_modifier)]
 
 // FIXME: switch to something more ergonomic here, once available.
 // (currently there is no way to opt into sysroot crates w/o `extern crate`)

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -8,7 +8,7 @@
 #![allow(unknown_lints, clippy::shadow_reuse, clippy::missing_docs_in_private_items)]
 #![recursion_limit = "256"]
 #![feature(macro_at_most_once_rep)]
-#![feature(tool_lints)]
+
 #![warn(rust_2018_idioms, trivial_casts, trivial_numeric_casts)]
 #![feature(crate_visibility_modifier)]
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,7 +1,7 @@
 // error-pattern:yummy
 #![feature(box_syntax)]
 #![feature(rustc_private)]
-#![feature(tool_lints)]
+
 #![allow(unknown_lints, clippy::missing_docs_in_private_items)]
 
 // FIXME: switch to something more ergonomic here, once available.

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,8 +1,7 @@
 // error-pattern:yummy
 #![feature(box_syntax)]
 #![feature(rustc_private)]
-
-#![allow(unknown_lints, clippy::missing_docs_in_private_items)]
+#![allow(clippy::missing_docs_in_private_items)]
 
 // FIXME: switch to something more ergonomic here, once available.
 // (currently there is no way to opt into sysroot crates w/o `extern crate`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // error-pattern:cargo-clippy
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]
-#![feature(tool_lints)]
+
 #![allow(unknown_lints)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![warn(rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 // error-pattern:cargo-clippy
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]
-
-#![allow(unknown_lints)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![warn(rust_2018_idioms)]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 // error-pattern:yummy
 #![feature(box_syntax)]
 #![feature(rustc_private)]
-
-#![allow(unknown_lints, clippy::missing_docs_in_private_items)]
+#![allow(clippy::missing_docs_in_private_items)]
 
 use rustc_tools_util::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // error-pattern:yummy
 #![feature(box_syntax)]
 #![feature(rustc_private)]
-#![feature(tool_lints)]
+
 #![allow(unknown_lints, clippy::missing_docs_in_private_items)]
 
 use rustc_tools_util::*;

--- a/tests/run-pass/enum-glob-import-crate.rs
+++ b/tests/run-pass/enum-glob-import-crate.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::all)]
 #![allow(unused_imports)]

--- a/tests/run-pass/ice-1588.rs
+++ b/tests/run-pass/ice-1588.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::all)]
 

--- a/tests/run-pass/ice-1969.rs
+++ b/tests/run-pass/ice-1969.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::all)]
 

--- a/tests/run-pass/ice-2499.rs
+++ b/tests/run-pass/ice-2499.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(dead_code, clippy::char_lit_as_u8, clippy::needless_bool)]
 

--- a/tests/run-pass/ice-2760.rs
+++ b/tests/run-pass/ice-2760.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused_variables, clippy::blacklisted_name,
          clippy::needless_pass_by_value, dead_code)]

--- a/tests/run-pass/ice-2774.rs
+++ b/tests/run-pass/ice-2774.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 use std::collections::HashSet;
 

--- a/tests/run-pass/ice-700.rs
+++ b/tests/run-pass/ice-700.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::all)]
 

--- a/tests/run-pass/ice_exacte_size.rs
+++ b/tests/run-pass/ice_exacte_size.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::all)]
 

--- a/tests/run-pass/if_same_then_else.rs
+++ b/tests/run-pass/if_same_then_else.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::if_same_then_else)]
 

--- a/tests/run-pass/match_same_arms_const.rs
+++ b/tests/run-pass/match_same_arms_const.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::match_same_arms)]
 

--- a/tests/run-pass/mut_mut_macro.rs
+++ b/tests/run-pass/mut_mut_macro.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::mut_mut, clippy::zero_ptr, clippy::cmp_nan)]
 #![allow(dead_code)]

--- a/tests/run-pass/needless_borrow_fp.rs
+++ b/tests/run-pass/needless_borrow_fp.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[deny(clippy::all)]
 

--- a/tests/run-pass/needless_lifetimes_impl_trait.rs
+++ b/tests/run-pass/needless_lifetimes_impl_trait.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::needless_lifetimes)]
 #![allow(dead_code)]

--- a/tests/run-pass/regressions.rs
+++ b/tests/run-pass/regressions.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::blacklisted_name)]
 

--- a/tests/run-pass/single-match-else.rs
+++ b/tests/run-pass/single-match-else.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::single_match_else)]
 

--- a/tests/run-pass/used_underscore_binding_macro.rs
+++ b/tests/run-pass/used_underscore_binding_macro.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::useless_attribute)] //issue #2910
 

--- a/tests/ui-toml/toml_blacklist/conf_french_blacklisted_name.rs
+++ b/tests/ui-toml/toml_blacklist/conf_french_blacklisted_name.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code)]

--- a/tests/ui-toml/toml_trivially_copy/test.rs
+++ b/tests/ui-toml/toml_trivially_copy/test.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![allow(clippy::many_single_char_names)]
 
 #[derive(Copy, Clone)]

--- a/tests/ui/absurd-extreme-comparisons.rs
+++ b/tests/ui/absurd-extreme-comparisons.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::absurd_extreme_comparisons)]

--- a/tests/ui/approx_const.rs
+++ b/tests/ui/approx_const.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::approx_constant)]

--- a/tests/ui/arithmetic.rs
+++ b/tests/ui/arithmetic.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::integer_arithmetic, clippy::float_arithmetic)]

--- a/tests/ui/assign_ops.rs
+++ b/tests/ui/assign_ops.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[allow(dead_code, unused_assignments)]
 #[warn(clippy::assign_op_pattern)]

--- a/tests/ui/assign_ops2.rs
+++ b/tests/ui/assign_ops2.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[allow(unused_assignments)]

--- a/tests/ui/attrs.rs
+++ b/tests/ui/attrs.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::inline_always, clippy::deprecated_semver)]

--- a/tests/ui/bit_masks.rs
+++ b/tests/ui/bit_masks.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 const THREE_BITS : i64 = 7;

--- a/tests/ui/blacklisted_name.rs
+++ b/tests/ui/blacklisted_name.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code, clippy::similar_names, clippy::single_match, clippy::toplevel_ref_arg, unused_mut, unused_variables)]

--- a/tests/ui/block_in_if_condition.rs
+++ b/tests/ui/block_in_if_condition.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::block_in_if_condition_expr)]

--- a/tests/ui/bool_comparison.rs
+++ b/tests/ui/bool_comparison.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::bool_comparison)]

--- a/tests/ui/booleans.rs
+++ b/tests/ui/booleans.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::nonminimal_bool, clippy::logic_bug)]
 

--- a/tests/ui/borrow_box.rs
+++ b/tests/ui/borrow_box.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![deny(clippy::borrowed_box)]

--- a/tests/ui/box_vec.rs
+++ b/tests/ui/box_vec.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/builtin-type-shadow.rs
+++ b/tests/ui/builtin-type-shadow.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::builtin_type_shadow)]
 

--- a/tests/ui/bytecount.rs
+++ b/tests/ui/bytecount.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[deny(clippy::naive_bytecount)]

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap, clippy::cast_lossless)]

--- a/tests/ui/cast_alignment.rs
+++ b/tests/ui/cast_alignment.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 //! Test casts for alignment issues
 

--- a/tests/ui/cast_lossless_float.rs
+++ b/tests/ui/cast_lossless_float.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[warn(clippy::cast_lossless)]
 #[allow(clippy::no_effect, clippy::unnecessary_operation)]

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #[warn(clippy::cast_lossless)]
 #[allow(clippy::no_effect, clippy::unnecessary_operation)]
 fn main() {

--- a/tests/ui/cast_size.rs
+++ b/tests/ui/cast_size.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[warn(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap, clippy::cast_lossless)]
 #[allow(clippy::no_effect, clippy::unnecessary_operation)]

--- a/tests/ui/char_lit_as_u8.rs
+++ b/tests/ui/char_lit_as_u8.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::char_lit_as_u8)]

--- a/tests/ui/checked_unwrap.rs
+++ b/tests/ui/checked_unwrap.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
 #![allow(clippy::if_same_then_else)]

--- a/tests/ui/clone_on_copy_mut.rs
+++ b/tests/ui/clone_on_copy_mut.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 pub fn dec_read_dec(i: &mut i32) -> i32 {
     *i -= 1;

--- a/tests/ui/cmp_nan.rs
+++ b/tests/ui/cmp_nan.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::cmp_nan)]

--- a/tests/ui/cmp_null.rs
+++ b/tests/ui/cmp_null.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::cmp_null)]
 #![allow(unused_mut)]

--- a/tests/ui/cmp_owned.rs
+++ b/tests/ui/cmp_owned.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::cmp_owned)]

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::collapsible_if)]

--- a/tests/ui/complex_types.rs
+++ b/tests/ui/complex_types.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::all)]
 #![allow(unused, clippy::needless_pass_by_value)]

--- a/tests/ui/copies.rs
+++ b/tests/ui/copies.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::blacklisted_name, clippy::collapsible_if, clippy::cyclomatic_complexity, clippy::eq_op, clippy::needless_continue,
          clippy::needless_return, clippy::never_loop, clippy::no_effect, clippy::zero_divided_by_zero)]

--- a/tests/ui/copy_iterator.rs
+++ b/tests/ui/copy_iterator.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::copy_iterator)]
 

--- a/tests/ui/cstring.rs
+++ b/tests/ui/cstring.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 fn main() {}
 

--- a/tests/ui/cyclomatic_complexity.rs
+++ b/tests/ui/cyclomatic_complexity.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::all)]
 #![warn(clippy::cyclomatic_complexity)]

--- a/tests/ui/cyclomatic_complexity_attr_used.rs
+++ b/tests/ui/cyclomatic_complexity_attr_used.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::cyclomatic_complexity)]
 #![warn(unused)]

--- a/tests/ui/decimal_literal_representation.rs
+++ b/tests/ui/decimal_literal_representation.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::decimal_literal_representation)]

--- a/tests/ui/default_trait_access.rs
+++ b/tests/ui/default_trait_access.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::default_trait_access)]
 

--- a/tests/ui/derive.rs
+++ b/tests/ui/derive.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(untagged_unions)]
 

--- a/tests/ui/diverging_sub_expression.rs
+++ b/tests/ui/diverging_sub_expression.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(never_type)]
 

--- a/tests/ui/dlist.rs
+++ b/tests/ui/dlist.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(alloc)]
 #![feature(associated_type_defaults)]

--- a/tests/ui/doc.rs
+++ b/tests/ui/doc.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 //! This file tests for the DOC_MARKDOWN lint
 

--- a/tests/ui/double_neg.rs
+++ b/tests/ui/double_neg.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::double_neg)]

--- a/tests/ui/double_parens.rs
+++ b/tests/ui/double_parens.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::double_parens)]

--- a/tests/ui/drop_forget_copy.rs
+++ b/tests/ui/drop_forget_copy.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::drop_copy, clippy::forget_copy)]

--- a/tests/ui/drop_forget_ref.rs
+++ b/tests/ui/drop_forget_ref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::drop_ref, clippy::forget_ref)]

--- a/tests/ui/duplicate_underscore_argument.rs
+++ b/tests/ui/duplicate_underscore_argument.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::duplicate_underscore_argument)]

--- a/tests/ui/duration_subsec.rs
+++ b/tests/ui/duration_subsec.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::duration_subsec)]
 

--- a/tests/ui/else_if_without_else.rs
+++ b/tests/ui/else_if_without_else.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::all)]
 #![warn(clippy::else_if_without_else)]

--- a/tests/ui/empty_enum.rs
+++ b/tests/ui/empty_enum.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code)]

--- a/tests/ui/empty_line_after_outer_attribute.rs
+++ b/tests/ui/empty_line_after_outer_attribute.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![warn(clippy::empty_line_after_outer_attr)]
 
 // This should produce a warning

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused, clippy::needless_pass_by_value)]
 

--- a/tests/ui/enum_glob_use.rs
+++ b/tests/ui/enum_glob_use.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(unused_imports, dead_code, clippy::missing_docs_in_private_items)]

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(non_ascii_idents)]
 

--- a/tests/ui/enums_clike.rs
+++ b/tests/ui/enums_clike.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 // ignore-x86
 

--- a/tests/ui/eq_op.rs
+++ b/tests/ui/eq_op.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::eq_op)]

--- a/tests/ui/erasing_op.rs
+++ b/tests/ui/erasing_op.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[allow(clippy::no_effect)]

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unknown_lints, unused, clippy::no_effect, clippy::redundant_closure_call, clippy::many_single_char_names, clippy::needless_pass_by_value, clippy::option_map_unit_fn, clippy::trivially_copy_pass_by_ref)]
 #![warn(clippy::redundant_closure, clippy::needless_borrow)]

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -1,6 +1,6 @@
 
 
-#![allow(unknown_lints, unused, clippy::no_effect, clippy::redundant_closure_call, clippy::many_single_char_names, clippy::needless_pass_by_value, clippy::option_map_unit_fn, clippy::trivially_copy_pass_by_ref)]
+#![allow(unused, clippy::no_effect, clippy::redundant_closure_call, clippy::many_single_char_names, clippy::needless_pass_by_value, clippy::option_map_unit_fn, clippy::trivially_copy_pass_by_ref)]
 #![warn(clippy::redundant_closure, clippy::needless_borrow)]
 
 fn main() {

--- a/tests/ui/eval_order_dependence.rs
+++ b/tests/ui/eval_order_dependence.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::eval_order_dependence)]

--- a/tests/ui/excessive_precision.rs
+++ b/tests/ui/excessive_precision.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![warn(clippy::excessive_precision)]
 #![allow(clippy::print_literal)]
 

--- a/tests/ui/explicit_write.rs
+++ b/tests/ui/explicit_write.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::explicit_write)]
 

--- a/tests/ui/fallible_impl_from.rs
+++ b/tests/ui/fallible_impl_from.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::fallible_impl_from)]
 

--- a/tests/ui/filter_methods.rs
+++ b/tests/ui/filter_methods.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all, clippy::pedantic)]

--- a/tests/ui/float_cmp.rs
+++ b/tests/ui/float_cmp.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::float_cmp)]

--- a/tests/ui/float_cmp_const.rs
+++ b/tests/ui/float_cmp_const.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::float_cmp_const)]

--- a/tests/ui/fn_to_numeric_cast.rs
+++ b/tests/ui/fn_to_numeric_cast.rs
@@ -1,5 +1,5 @@
 // only-64bit
-#![feature(tool_lints)]
+
 
 #![warn(clippy::fn_to_numeric_cast, clippy::fn_to_numeric_cast_with_truncation)]
 

--- a/tests/ui/for_loop.rs
+++ b/tests/ui/for_loop.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 use std::collections::*;

--- a/tests/ui/format.rs
+++ b/tests/ui/format.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![allow(clippy::print_literal)]
 #![warn(clippy::useless_format)]
 

--- a/tests/ui/formatting.rs
+++ b/tests/ui/formatting.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/functions.rs
+++ b/tests/ui/functions.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/fxhash.rs
+++ b/tests/ui/fxhash.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::default_hash_types)]
 #![feature(rustc_private)]

--- a/tests/ui/identity_conversion.rs
+++ b/tests/ui/identity_conversion.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::identity_conversion)]
 

--- a/tests/ui/identity_op.rs
+++ b/tests/ui/identity_op.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 const ONE : i64 = 1;

--- a/tests/ui/if_let_redundant_pattern_matching.rs
+++ b/tests/ui/if_let_redundant_pattern_matching.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/if_not_else.rs
+++ b/tests/ui/if_not_else.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::all)]
 #![warn(clippy::if_not_else)]

--- a/tests/ui/impl.rs
+++ b/tests/ui/impl.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(dead_code)]
 #![warn(clippy::multiple_inherent_impl)]

--- a/tests/ui/inconsistent_digit_grouping.rs
+++ b/tests/ui/inconsistent_digit_grouping.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[warn(clippy::inconsistent_digit_grouping)]
 #[allow(unused_variables)]

--- a/tests/ui/indexing_slicing.rs
+++ b/tests/ui/indexing_slicing.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(plugin)]
 #![warn(clippy::indexing_slicing)]

--- a/tests/ui/infallible_destructuring_match.rs
+++ b/tests/ui/infallible_destructuring_match.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(exhaustive_patterns, never_type)]
 #![allow(clippy::let_and_return)]

--- a/tests/ui/infinite_iter.rs
+++ b/tests/ui/infinite_iter.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 use std::iter::repeat;
 #[allow(clippy::trivially_copy_pass_by_ref)]

--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::trivially_copy_pass_by_ref)]
 

--- a/tests/ui/inline_fn_without_body.rs
+++ b/tests/ui/inline_fn_without_body.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::inline_fn_without_body)]

--- a/tests/ui/int_plus_one.rs
+++ b/tests/ui/int_plus_one.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[allow(clippy::no_effect, clippy::unnecessary_operation)]

--- a/tests/ui/invalid_upcast_comparisons.rs
+++ b/tests/ui/invalid_upcast_comparisons.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::invalid_upcast_comparisons)]

--- a/tests/ui/issue_2356.rs
+++ b/tests/ui/issue_2356.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::while_let_on_iterator)]
 

--- a/tests/ui/item_after_statement.rs
+++ b/tests/ui/item_after_statement.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::items_after_statements)]
 

--- a/tests/ui/large_digit_groups.rs
+++ b/tests/ui/large_digit_groups.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[warn(clippy::large_digit_groups)]
 #[allow(unused_variables)]

--- a/tests/ui/large_enum_variant.rs
+++ b/tests/ui/large_enum_variant.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code)]

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::len_without_is_empty, clippy::len_zero)]
 #![allow(dead_code, unused)]

--- a/tests/ui/let_if_seq.rs
+++ b/tests/ui/let_if_seq.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(unused_variables, unused_assignments, clippy::similar_names, clippy::blacklisted_name)]

--- a/tests/ui/let_return.rs
+++ b/tests/ui/let_return.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused)]
 

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::let_unit_value)]

--- a/tests/ui/lifetimes.rs
+++ b/tests/ui/lifetimes.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::needless_lifetimes, clippy::extra_unused_lifetimes)]

--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::mixed_case_hex_literals)]
 #![warn(clippy::unseparated_literal_suffix)]

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::missing_docs_in_private_items)]
 
@@ -7,3 +7,4 @@ fn main() {
     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
 }
+

--- a/tests/ui/map_flatten.rs
+++ b/tests/ui/map_flatten.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::missing_docs_in_private_items)]
 

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![feature(exclusive_range_pattern)]
 
 

--- a/tests/ui/mem_forget.rs
+++ b/tests/ui/mem_forget.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 

--- a/tests/ui/mem_replace.rs
+++ b/tests/ui/mem_replace.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![warn(clippy::all, clippy::style, clippy::mem_replace_option_with_none)]
 
 use std::mem;

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all, clippy::pedantic, clippy::option_unwrap_used)]

--- a/tests/ui/min_max.rs
+++ b/tests/ui/min_max.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/missing-doc.rs
+++ b/tests/ui/missing-doc.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 /* This file incorporates work covered by the following copyright and
  * permission notice:

--- a/tests/ui/missing_inline.rs
+++ b/tests/ui/missing_inline.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 /* This file incorporates work covered by the following copyright and
  * permission notice:

--- a/tests/ui/module_inception.rs
+++ b/tests/ui/module_inception.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::module_inception)]
 

--- a/tests/ui/modulo_one.rs
+++ b/tests/ui/modulo_one.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::modulo_one)]
 #![allow(clippy::no_effect, clippy::unnecessary_operation)]

--- a/tests/ui/mut_from_ref.rs
+++ b/tests/ui/mut_from_ref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused, clippy::trivially_copy_pass_by_ref)]
 #![warn(clippy::mut_from_ref)]

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(unused, clippy::no_effect, clippy::unnecessary_operation)]

--- a/tests/ui/mut_reference.rs
+++ b/tests/ui/mut_reference.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(unused_variables, clippy::trivially_copy_pass_by_ref)]

--- a/tests/ui/mutex_atomic.rs
+++ b/tests/ui/mutex_atomic.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/needless_bool.rs
+++ b/tests/ui/needless_bool.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::needless_bool)]
 

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 use std::borrow::Cow;
 

--- a/tests/ui/needless_borrowed_ref.rs
+++ b/tests/ui/needless_borrowed_ref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::needless_borrowed_reference)]

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 use std::collections::{HashMap, HashSet, BTreeSet};
 

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 macro_rules! zero {

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::needless_pass_by_value)]
 #![allow(dead_code, clippy::single_match, clippy::if_let_redundant_pattern_matching, clippy::many_single_char_names, clippy::option_option)]

--- a/tests/ui/needless_pass_by_value_proc_macro.rs
+++ b/tests/ui/needless_pass_by_value_proc_macro.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![crate_type = "proc-macro"]
 #![warn(clippy::needless_pass_by_value)]

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::needless_return)]

--- a/tests/ui/needless_update.rs
+++ b/tests/ui/needless_update.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::needless_update)]

--- a/tests/ui/neg_cmp_op_on_partial_ord.rs
+++ b/tests/ui/neg_cmp_op_on_partial_ord.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 //! This test case utilizes `f64` an easy example for `PartialOrd` only types
 //! but the lint itself actually validates any expression where the left

--- a/tests/ui/neg_multiply.rs
+++ b/tests/ui/neg_multiply.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::neg_multiply)]

--- a/tests/ui/never_loop.rs
+++ b/tests/ui/never_loop.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::single_match, unused_assignments, unused_variables, clippy::while_immutable_condition)]
 

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(const_fn)]
 

--- a/tests/ui/no_effect.rs
+++ b/tests/ui/no_effect.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(box_syntax)]
 

--- a/tests/ui/non_copy_const.rs
+++ b/tests/ui/non_copy_const.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(const_string_new, const_vec_new)]
 #![allow(clippy::ref_in_deref, dead_code)]

--- a/tests/ui/non_expressive_names.rs
+++ b/tests/ui/non_expressive_names.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::all,clippy::similar_names)]
 #![allow(unused, clippy::println_empty_string)]

--- a/tests/ui/ok_if_let.rs
+++ b/tests/ui/ok_if_let.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::if_let_some_result)]

--- a/tests/ui/op_ref.rs
+++ b/tests/ui/op_ref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(unused_variables, clippy::blacklisted_name)]

--- a/tests/ui/open_options.rs
+++ b/tests/ui/open_options.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 use std::fs::OpenOptions;
 

--- a/tests/ui/option_map_unit_fn.rs
+++ b/tests/ui/option_map_unit_fn.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::option_map_unit_fn)]
 #![allow(unused)]

--- a/tests/ui/overflow_check_conditional.rs
+++ b/tests/ui/overflow_check_conditional.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(clippy::many_single_char_names)]

--- a/tests/ui/panic_unimplemented.rs
+++ b/tests/ui/panic_unimplemented.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::panic_params, clippy::unimplemented)]

--- a/tests/ui/patterns.rs
+++ b/tests/ui/patterns.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused)]
 #![warn(clippy::all)]

--- a/tests/ui/precedence.rs
+++ b/tests/ui/precedence.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::precedence)]

--- a/tests/ui/print.rs
+++ b/tests/ui/print.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::print_literal, clippy::write_literal)]
 #![warn(clippy::print_stdout, clippy::use_debug)]

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::print_literal)]
 

--- a/tests/ui/print_with_newline.rs
+++ b/tests/ui/print_with_newline.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::print_literal)]
 #![warn(clippy::print_with_newline)]

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused, clippy::many_single_char_names)]
 #![warn(clippy::ptr_arg)]

--- a/tests/ui/range.rs
+++ b/tests/ui/range.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 struct NotARange;
 impl NotARange {

--- a/tests/ui/range_plus_minus_one.rs
+++ b/tests/ui/range_plus_minus_one.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 fn f() -> usize {
     42

--- a/tests/ui/redundant_closure_call.rs
+++ b/tests/ui/redundant_closure_call.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::redundant_closure_call)]

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::redundant_field_names)]
 #![allow(unused_variables)]

--- a/tests/ui/reference.rs
+++ b/tests/ui/reference.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 fn get_number() -> usize {

--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(unused)]

--- a/tests/ui/replace_consts.rs
+++ b/tests/ui/replace_consts.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(integer_atomics)]
 #![allow(clippy::blacklisted_name)]

--- a/tests/ui/result_map_unit_fn.rs
+++ b/tests/ui/result_map_unit_fn.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(never_type)]
 #![warn(clippy::result_map_unit_fn)]

--- a/tests/ui/serde.rs
+++ b/tests/ui/serde.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::serde_api_misuse)]
 #![allow(dead_code)]

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all, clippy::pedantic, clippy::shadow_same, clippy::shadow_reuse, clippy::shadow_unrelated)]

--- a/tests/ui/short_circuit_statement.rs
+++ b/tests/ui/short_circuit_statement.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::short_circuit_statement)]

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 use std::collections::HashSet;
 

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::single_match)]
 

--- a/tests/ui/starts_ends_with.rs
+++ b/tests/ui/starts_ends_with.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(dead_code)]
 

--- a/tests/ui/strings.rs
+++ b/tests/ui/strings.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::string_add)]

--- a/tests/ui/stutter.rs
+++ b/tests/ui/stutter.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::stutter)]
 #![allow(dead_code)]

--- a/tests/ui/suspicious_arithmetic_impl.rs
+++ b/tests/ui/suspicious_arithmetic_impl.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::suspicious_arithmetic_impl)]

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/temporary_assignment.rs
+++ b/tests/ui/temporary_assignment.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::temporary_assignment)]

--- a/tests/ui/toplevel_ref_arg.rs
+++ b/tests/ui/toplevel_ref_arg.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::all)]

--- a/tests/ui/transmute.rs
+++ b/tests/ui/transmute.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code)]

--- a/tests/ui/transmute_64bit.rs
+++ b/tests/ui/transmute_64bit.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 //ignore-x86
 //no-ignore-x86_64

--- a/tests/ui/trivially_copy_pass_by_ref.rs
+++ b/tests/ui/trivially_copy_pass_by_ref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::many_single_char_names, clippy::blacklisted_name, clippy::redundant_field_names)]
 

--- a/tests/ui/unicode.rs
+++ b/tests/ui/unicode.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[warn(clippy::zero_width_space)]

--- a/tests/ui/unit_arg.rs
+++ b/tests/ui/unit_arg.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::unit_arg)]
 #![allow(clippy::no_effect)]

--- a/tests/ui/unit_cmp.rs
+++ b/tests/ui/unit_cmp.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::unit_cmp)]

--- a/tests/ui/unnecessary_clone.rs
+++ b/tests/ui/unnecessary_clone.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::clone_on_ref_ptr)]
 #![allow(unused)]

--- a/tests/ui/unnecessary_ref.rs
+++ b/tests/ui/unnecessary_ref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![feature(tool_attributes)]
 #![feature(stmt_expr_attributes)]

--- a/tests/ui/unneeded_field_pattern.rs
+++ b/tests/ui/unneeded_field_pattern.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::unneeded_field_pattern)]

--- a/tests/ui/unreadable_literal.rs
+++ b/tests/ui/unreadable_literal.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #[warn(clippy::unreadable_literal)]
 #[allow(unused_variables)]

--- a/tests/ui/unsafe_removed_from_name.rs
+++ b/tests/ui/unsafe_removed_from_name.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused_imports)]
 #![allow(dead_code)]

--- a/tests/ui/unused_io_amount.rs
+++ b/tests/ui/unused_io_amount.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code)]

--- a/tests/ui/unused_labels.rs
+++ b/tests/ui/unused_labels.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![allow(dead_code, clippy::items_after_statements, clippy::never_loop)]

--- a/tests/ui/unused_lt.rs
+++ b/tests/ui/unused_lt.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused, dead_code, clippy::needless_lifetimes, clippy::needless_pass_by_value, clippy::trivially_copy_pass_by_ref)]
 #![warn(clippy::extra_unused_lifetimes)]

--- a/tests/ui/unwrap_or.rs
+++ b/tests/ui/unwrap_or.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 #![warn(clippy::all)]
 
 fn main() {

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::use_self)]
 #![allow(dead_code)]

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::all)]
 

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![deny(clippy::useless_asref)]
 #![allow(clippy::trivially_copy_pass_by_ref)]

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![warn(clippy::useless_attribute)]
 

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::useless_vec)]

--- a/tests/ui/while_loop.rs
+++ b/tests/ui/while_loop.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::while_let_loop, clippy::empty_loop, clippy::while_let_on_iterator)]

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused_must_use)]
 #![warn(clippy::write_literal)]

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(clippy::write_literal)]
 #![warn(clippy::write_with_newline)]

--- a/tests/ui/writeln_empty_string.rs
+++ b/tests/ui/writeln_empty_string.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 #![allow(unused_must_use)]
 #![warn(clippy::writeln_empty_string)]

--- a/tests/ui/wrong_self_convention.rs
+++ b/tests/ui/wrong_self_convention.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #![warn(clippy::wrong_self_convention)]

--- a/tests/ui/zero_div_zero.rs
+++ b/tests/ui/zero_div_zero.rs
@@ -1,4 +1,4 @@
-#![feature(tool_lints)]
+
 
 
 #[allow(unused_variables)]


### PR DESCRIPTION
Waiting for rust-lang/rust#54870

This just removes all the `#![feature(tool_lints)]` from the clippy code base and the tests.