### PR TITLE
Fix single_match suggestions with expanded macros

### DIFF
--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -33,7 +33,7 @@ error: you seem to be trying to use match for destructuring a single pattern. Co
 51 | |         &(v, 1) => println!("{}", v),
 52 | |         _ => println!("none"),
 53 | |     }
-   | |_____^ help: try this: `if let &(v, 1) = tup { .. } else { .. }`
+   | |_____^ help: try this: `if let &(v, 1) = tup { println!("{}", v) } else { println!("none") }`
 
 error: you don't need to add `&` to all patterns
   --> $DIR/matches.rs:50:5

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -33,7 +33,7 @@ error: you seem to be trying to use match for destructuring a single pattern. Co
 51 | |         &(v, 1) => println!("{}", v),
 52 | |         _ => println!("none"),
 53 | |     }
-   | |_____^ help: try this: `if let &(v, 1) = tup { $ crate :: io :: _print ( format_args_nl ! ( $ ( $ arg ) * ) ) ; } else { $ crate :: io :: _print ( format_args_nl ! ( $ ( $ arg ) * ) ) ; }`
+   | |_____^ help: try this: `if let &(v, 1) = tup { .. } else { .. }`
 
 error: you don't need to add `&` to all patterns
   --> $DIR/matches.rs:50:5

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -23,6 +23,15 @@ fn single_match(){
         _ => ()
     };
 
+    let x = Some(1u8);
+    match x {
+        // Note the missing block braces.
+        // We suggest `if let Some(y) = x { .. }` because the macro
+        // is expanded before we can do anything.
+        Some(y) => println!("{:?}", y),
+        _ => ()
+    }
+
     let z = (1u8,1u8);
     match z {
         (2...3, 7...9) => dummy(),

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -12,38 +12,50 @@ error: you seem to be trying to use match for destructuring a single pattern. Co
 error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:27:5
    |
-27 | /     match z {
-28 | |         (2...3, 7...9) => dummy(),
-29 | |         _ => {}
-30 | |     };
+27 | /     match x {
+28 | |         // Note the missing block braces.
+29 | |         // We suggest `if let Some(y) = x { .. }` because the macro
+30 | |         // is expanded before we can do anything.
+31 | |         Some(y) => println!("{:?}", y),
+32 | |         _ => ()
+33 | |     }
+   | |_____^ help: try this: `if let Some(y) = x { .. }`
+
+error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:36:5
+   |
+36 | /     match z {
+37 | |         (2...3, 7...9) => dummy(),
+38 | |         _ => {}
+39 | |     };
    | |_____^ help: try this: `if let (2...3, 7...9) = z { dummy() }`
 
 error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:53:5
+  --> $DIR/single_match.rs:62:5
    |
-53 | /     match x {
-54 | |         Some(y) => dummy(),
-55 | |         None => ()
-56 | |     };
+62 | /     match x {
+63 | |         Some(y) => dummy(),
+64 | |         None => ()
+65 | |     };
    | |_____^ help: try this: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:58:5
+  --> $DIR/single_match.rs:67:5
    |
-58 | /     match y {
-59 | |         Ok(y) => dummy(),
-60 | |         Err(..) => ()
-61 | |     };
+67 | /     match y {
+68 | |         Ok(y) => dummy(),
+69 | |         Err(..) => ()
+70 | |     };
    | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:65:5
+  --> $DIR/single_match.rs:74:5
    |
-65 | /     match c {
-66 | |         Cow::Borrowed(..) => dummy(),
-67 | |         Cow::Owned(..) => (),
-68 | |     };
+74 | /     match c {
+75 | |         Cow::Borrowed(..) => dummy(),
+76 | |         Cow::Owned(..) => (),
+77 | |     };
    | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -19,7 +19,7 @@ error: you seem to be trying to use match for destructuring a single pattern. Co
 31 | |         Some(y) => println!("{:?}", y),
 32 | |         _ => ()
 33 | |     }
-   | |_____^ help: try this: `if let Some(y) = x { .. }`
+   | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y) }`
 
 error: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:36:5


### PR DESCRIPTION
`single_match` was expanding macros in the suggested if and else expressions. This fix checks if the suggested span is inside a macro. 

As far as I can tell this..

Fixes #1148
Fixes #2455