### PR TITLE
contributing.md: fix command to manually test an example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,8 +149,8 @@ Therefore you should use `tests/ui/update-all-references.sh` (after running
 
 Manually testing against an example file is useful if you have added some
 `println!`s and test suite output becomes unreadable.  To try Clippy with your
-local modifications, run `cargo run --bin clippy-driver -- -L ./target/debug input.rs` from the
-working copy root.
+local modifications, run `env CLIPPY_TESTS=true cargo run --bin clippy-driver -- -L ./target/debug input.rs`
+from the working copy root.
 
 ### How Clippy works
 


### PR DESCRIPTION
I think the command in `CONTRIBUTING.MD` to manually run `clippy` on an example was outdated because it doesn't seem to correctly start clippy when compiling. 

I think it's because the driver detects that [`clippy_enabled=false`]( https://github.com/rust-lang-nursery/rust-clippy/blob/master/src/driver.rs#L89-L90) in this case. I'm not sure setting the `CLIPPY_TESTS` env variable is the best way to solve this issue, but it seems to work  :).