### PR TITLE
Fix fn_to_numeric_cast_with_truncation suppression

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -977,7 +977,8 @@ impl LintPass for CastPass {
             CAST_LOSSLESS,
             UNNECESSARY_CAST,
             CAST_PTR_ALIGNMENT,
-            FN_TO_NUMERIC_CAST
+            FN_TO_NUMERIC_CAST,
+            FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
         )
     }
 }


### PR DESCRIPTION
Fixes #3276