### PR TITLE
Pedantic dogfood: naming and docs

### DIFF
--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -40,6 +40,7 @@ declare_clippy_lint! {
     "unnecessary double comparisons that can be simplified"
 }
 
+#[allow(clippy::stutter)]
 pub struct DoubleComparisonPass;
 
 impl LintPass for DoubleComparisonPass {

--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -49,6 +49,7 @@ impl LintPass for DoubleComparisonPass {
 }
 
 impl<'a, 'tcx> DoubleComparisonPass {
+    #[allow(clippy::similar_names)]
     fn check_binop(
         &self,
         cx: &LateContext<'a, 'tcx>,

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -63,16 +63,16 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnportableVariant {
                 let variant = &var.node;
                 if let Some(ref anon_const) = variant.disr_expr {
                     let param_env = ty::ParamEnv::empty();
-                    let did = cx.tcx.hir.body_owner_def_id(anon_const.body);
-                    let substs = Substs::identity_for_item(cx.tcx.global_tcx(), did);
-                    let instance = ty::Instance::new(did, substs);
-                    let cid = GlobalId {
+                    let def_id = cx.tcx.hir.body_owner_def_id(anon_const.body);
+                    let substs = Substs::identity_for_item(cx.tcx.global_tcx(), def_id);
+                    let instance = ty::Instance::new(def_id, substs);
+                    let c_id = GlobalId {
                         instance,
                         promoted: None
                     };
-                    let constant = cx.tcx.const_eval(param_env.and(cid)).ok();
+                    let constant = cx.tcx.const_eval(param_env.and(c_id)).ok();
                     if let Some(Constant::Int(val)) = constant.and_then(|c| miri_to_const(cx.tcx, c)) {
-                        let mut ty = cx.tcx.type_of(did);
+                        let mut ty = cx.tcx.type_of(def_id);
                         if let ty::Adt(adt, _) = ty.sty {
                             if adt.is_enum() {
                                 ty = adt.repr.discr_type().to_ty(cx.tcx);

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -16,7 +16,7 @@ use crate::syntax::ast::*;
 use crate::syntax::source_map::Span;
 use crate::syntax::symbol::LocalInternedString;
 use crate::utils::{span_help_and_lint, span_lint};
-use crate::utils::{camel_case_from, camel_case_until, in_macro};
+use crate::utils::{camel_case, in_macro};
 
 /// **What it does:** Detects enumeration variants that are prefixed or suffixed
 /// by the same characters.
@@ -184,19 +184,19 @@ fn check_variant(
         }
     }
     let first = var2str(&def.variants[0]);
-    let mut pre = &first[..camel_case_until(&*first)];
-    let mut post = &first[camel_case_from(&*first)..];
+    let mut pre = &first[..camel_case::until(&*first)];
+    let mut post = &first[camel_case::from(&*first)..];
     for var in &def.variants {
         let name = var2str(var);
 
         let pre_match = partial_match(pre, &name);
         pre = &pre[..pre_match];
-        let pre_camel = camel_case_until(pre);
+        let pre_camel = camel_case::until(pre);
         pre = &pre[..pre_camel];
         while let Some((next, last)) = name[pre.len()..].chars().zip(pre.chars().rev()).next() {
             if next.is_lowercase() {
                 let last = pre.len() - last.len_utf8();
-                let last_camel = camel_case_until(&pre[..last]);
+                let last_camel = camel_case::until(&pre[..last]);
                 pre = &pre[..last_camel];
             } else {
                 break;
@@ -206,7 +206,7 @@ fn check_variant(
         let post_match = partial_rmatch(post, &name);
         let post_end = post.len() - post_match;
         post = &post[post_end..];
-        let post_camel = camel_case_from(post);
+        let post_camel = camel_case::from(post);
         post = &post[post_camel..];
     }
     let (what, value) = match (pre.is_empty(), post.is_empty()) {

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -255,6 +255,7 @@ impl EarlyLintPass for EnumVariantNames {
         assert!(last.is_some());
     }
 
+    #[allow(clippy::similar_names)]
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         let item_name = item.ident.as_str();
         let item_name_chars = item_name.chars().count();

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -63,6 +63,7 @@ impl LintPass for EqOp {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
+    #[allow(clippy::similar_names)]
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprKind::Binary(op, ref left, ref right) = e.node {
             if in_macro(e.span) {

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -108,6 +108,7 @@ impl ExcessivePrecision {
     }
 }
 
+#[allow(clippy::doc_markdown)]
 /// Should we exclude the float because it has a `.0` or `.` suffix
 /// Ex 1_000_000_000.0
 /// Ex 1_000_000_000.

--- a/clippy_lints/src/if_let_redundant_pattern_matching.rs
+++ b/clippy_lints/src/if_let_redundant_pattern_matching.rs
@@ -56,6 +56,7 @@ impl LintPass for Pass {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
+    #[allow(clippy::similar_names)]
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         if let ExprKind::Match(ref op, ref arms, MatchSource::IfLetDesugar { .. }) = expr.node {
             if arms[0].pats.len() == 1 {

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -179,7 +179,7 @@ fn unit_closure<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'a hir::Expr) -> Op
     None
 }
 
-/// Builds a name for the let binding variable (var_arg)
+/// Builds a name for the let binding variable (`var_arg`)
 ///
 /// `x.field` => `x_field`
 /// `y` => `_y`

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -44,6 +44,7 @@ declare_clippy_lint!{
     "checks for expressions that could be replaced by the question mark operator"
 }
 
+#[allow(clippy::stutter)]
 #[derive(Copy, Clone)]
 pub struct QuestionMarkPass;
 

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -227,6 +227,7 @@ impl LintPass for Transmute {
 }
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Transmute {
+    #[allow(clippy::similar_names)]
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprKind::Call(ref path_expr, ref args) = e.node {
             if let ExprKind::Path(ref qpath) = path_expr.node {

--- a/clippy_lints/src/utils/camel_case.rs
+++ b/clippy_lints/src/utils/camel_case.rs
@@ -10,7 +10,7 @@
 
 /// Return the index of the character after the first camel-case component of
 /// `s`.
-pub fn camel_case_until(s: &str) -> usize {
+pub fn until(s: &str) -> usize {
     let mut iter = s.char_indices();
     if let Some((_, first)) = iter.next() {
         if !first.is_uppercase() {
@@ -43,7 +43,7 @@ pub fn camel_case_until(s: &str) -> usize {
 }
 
 /// Return index of the last camel-case component of `s`.
-pub fn camel_case_from(s: &str) -> usize {
+pub fn from(s: &str) -> usize {
     let mut iter = s.char_indices().rev();
     if let Some((_, first)) = iter.next() {
         if !first.is_lowercase() {
@@ -73,52 +73,52 @@ pub fn camel_case_from(s: &str) -> usize {
 
 #[cfg(test)]
 mod test {
-    use super::{camel_case_from, camel_case_until};
+    use super::{from, until};
 
     #[test]
     fn from_full() {
-        assert_eq!(camel_case_from("AbcDef"), 0);
-        assert_eq!(camel_case_from("Abc"), 0);
+        assert_eq!(from("AbcDef"), 0);
+        assert_eq!(from("Abc"), 0);
     }
 
     #[test]
     fn from_partial() {
-        assert_eq!(camel_case_from("abcDef"), 3);
-        assert_eq!(camel_case_from("aDbc"), 1);
+        assert_eq!(from("abcDef"), 3);
+        assert_eq!(from("aDbc"), 1);
     }
 
     #[test]
     fn from_not() {
-        assert_eq!(camel_case_from("AbcDef_"), 7);
-        assert_eq!(camel_case_from("AbcDD"), 5);
+        assert_eq!(from("AbcDef_"), 7);
+        assert_eq!(from("AbcDD"), 5);
     }
 
     #[test]
     fn from_caps() {
-        assert_eq!(camel_case_from("ABCD"), 4);
+        assert_eq!(from("ABCD"), 4);
     }
 
     #[test]
     fn until_full() {
-        assert_eq!(camel_case_until("AbcDef"), 6);
-        assert_eq!(camel_case_until("Abc"), 3);
+        assert_eq!(until("AbcDef"), 6);
+        assert_eq!(until("Abc"), 3);
     }
 
     #[test]
     fn until_not() {
-        assert_eq!(camel_case_until("abcDef"), 0);
-        assert_eq!(camel_case_until("aDbc"), 0);
+        assert_eq!(until("abcDef"), 0);
+        assert_eq!(until("aDbc"), 0);
     }
 
     #[test]
     fn until_partial() {
-        assert_eq!(camel_case_until("AbcDef_"), 6);
-        assert_eq!(camel_case_until("CallTypeC"), 8);
-        assert_eq!(camel_case_until("AbcDD"), 3);
+        assert_eq!(until("AbcDef_"), 6);
+        assert_eq!(until("CallTypeC"), 8);
+        assert_eq!(until("AbcDD"), 3);
     }
 
     #[test]
     fn until_caps() {
-        assert_eq!(camel_case_until("ABCD"), 0);
+        assert_eq!(until("ABCD"), 0);
     }
 }

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -73,6 +73,7 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
             && both(&left.expr, &right.expr, |l, r| self.eq_expr(l, r))
     }
 
+    #[allow(clippy::similar_names)]
     pub fn eq_expr(&mut self, left: &Expr, right: &Expr) -> bool {
         if self.ignore_fn && differing_macro_contexts(left.span, right.span) {
             return false;
@@ -208,6 +209,7 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
         }
     }
 
+    #[allow(clippy::similar_names)]
     fn eq_qpath(&mut self, left: &QPath, right: &QPath) -> bool {
         match (left, right) {
             (&QPath::Resolved(ref lty, ref lpath), &QPath::Resolved(ref rty, ref rpath)) => {
@@ -262,6 +264,7 @@ impl<'a, 'tcx: 'a> SpanlessEq<'a, 'tcx> {
         self.eq_ty_kind(&left.node, &right.node)
     }
 
+    #[allow(clippy::similar_names)]
     pub fn eq_ty_kind(&mut self, left: &TyKind, right: &TyKind) -> bool {
         match (left, right) {
             (&TyKind::Slice(ref l_vec), &TyKind::Slice(ref r_vec)) => self.eq_ty(l_vec, r_vec),

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -166,6 +166,7 @@ fn print_decl(cx: &LateContext<'_, '_>, decl: &hir::Decl) {
     }
 }
 
+#[allow(clippy::similar_names)]
 fn print_expr(cx: &LateContext<'_, '_>, expr: &hir::Expr, indent: usize) {
     let ind = "  ".repeat(indent);
     println!("{}+", ind);
@@ -424,6 +425,7 @@ fn print_item(cx: &LateContext<'_, '_>, item: &hir::Item) {
     }
 }
 
+#[allow(clippy::similar_names)]
 fn print_pat(cx: &LateContext<'_, '_>, pat: &hir::Pat, indent: usize) {
     let ind = "  ".repeat(indent);
     println!("{}+", ind);

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -33,8 +33,7 @@ use crate::syntax::source_map::{Span, DUMMY_SP};
 use crate::syntax::errors::DiagnosticBuilder;
 use crate::syntax::symbol::keywords;
 
-mod camel_case;
-pub use self::camel_case::{camel_case_from, camel_case_until};
+pub mod camel_case;
 
 pub mod comparisons;
 pub mod conf;

--- a/clippy_lints/src/utils/usage.rs
+++ b/clippy_lints/src/utils/usage.rs
@@ -54,6 +54,7 @@ struct MutVarsDelegate {
 }
 
 impl<'tcx> MutVarsDelegate {
+    #[allow(clippy::similar_names)]
     fn update(&mut self, cat: &'tcx Categorization<'_>) {
         match *cat {
             Categorization::Local(id) => {


### PR DESCRIPTION
Fix #3172 

This covers the last of the pedantic dogfooding in #3172. Most of it is pretty straightforward, however I believe the `doc_markdown` link has a false positive for numbers. (I'll open an issue in a few minutes and add the link here.)