### PR TITLE
Website: Make lint categories linkable

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -167,6 +167,19 @@
             });
         }
 
+        function selectGroup($scope, selectedGroup) {
+            var groups = $scope.groups;
+            for (var group in groups) {
+                if (groups.hasOwnProperty(group)) {
+                    if (group === selectedGroup) {
+                        groups[group] = true;
+                    } else {
+                        groups[group] = false;
+                    }
+                }
+            }
+        }
+
         angular.module("clippy", [])
         .filter('markdown', function ($sce) {
             return function (text) {
@@ -223,6 +236,11 @@
                     return result;
                 }, {});
 
+                var selectedGroup = getQueryVariable("sel");
+                if (selectedGroup) {
+                    selectGroup($scope, selectedGroup.toLowerCase());
+                }
+
                 scrollToLintByURL($scope);
             })
             .error(function (data) {
@@ -243,6 +261,17 @@
             }, false);
         });
     })();
+
+    function getQueryVariable(variable) {
+        var query = window.location.search.substring(1);
+        var vars = query.split('&');
+        for (var i = 0; i < vars.length; i++) {
+            var pair = vars[i].split('=');
+            if (decodeURIComponent(pair[0]) == variable) {
+                return decodeURIComponent(pair[1]);
+            }
+        }
+    }
     </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #2973 

You can link lint groups like "Perf" using this URL.
https://rust-lang-nursery.github.io/rust-clippy/master/index.html?sel=perf 

Then only perf group is selected like below.
![preselected_group](https://user-images.githubusercontent.com/709900/46954277-1e4b7400-d0cb-11e8-909a-77cc1fdf7277.png)
