### PR TITLE
RIIR update_lints: Replace lint count in README.md

### DIFF
--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -57,9 +57,9 @@ impl Lint {
         }
     }
 
-    /// Returns all non-deprecated lints
-    pub fn active_lints(lints: impl Iterator<Item=Self>) -> impl Iterator<Item=Self> {
-        lints.filter(|l| l.deprecation.is_none())
+    /// Returns all non-deprecated lints and non-internal lints
+    pub fn usable_lints(lints: impl Iterator<Item=Self>) -> impl Iterator<Item=Self> {
+        lints.filter(|l| l.deprecation.is_none() && !l.group.starts_with("internal"))
     }
 
     /// Returns the lints in a HashMap, grouped by the different lint groups
@@ -141,15 +141,17 @@ declare_deprecated_lint! {
 }
 
 #[test]
-fn test_active_lints() {
+fn test_usable_lints() {
     let lints = vec![
         Lint::new("should_assert_eq", "Deprecated", "abc", Some("Reason"), "module_name"),
-        Lint::new("should_assert_eq2", "Not Deprecated", "abc", None, "module_name")
+        Lint::new("should_assert_eq2", "Not Deprecated", "abc", None, "module_name"),
+        Lint::new("should_assert_eq2", "internal", "abc", None, "module_name"),
+        Lint::new("should_assert_eq2", "internal_style", "abc", None, "module_name")
     ];
     let expected = vec![
         Lint::new("should_assert_eq2", "Not Deprecated", "abc", None, "module_name")
     ];
-    assert_eq!(expected, Lint::active_lints(lints.into_iter()).collect::<Vec<Lint>>());
+    assert_eq!(expected, Lint::usable_lints(lints.into_iter()).collect::<Vec<Lint>>());
 }
 
 #[test]

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -106,6 +106,7 @@ fn lint_files() -> impl Iterator<Item=walkdir::DirEntry> {
 /// `path` is the relative path to the file on which you want to perform the replacement.
 ///
 /// See `replace_region_in_text` for documentation of the other options.
+#[allow(clippy::expect_fun_call)]
 pub fn replace_region_in_file<F>(path: &str, start: &str, end: &str, replace_start: bool, replacements: F) where F: Fn() -> Vec<String> {
     let mut f = fs::File::open(path).expect(&format!("File not found: {}", path));
     let mut contents = String::new();
@@ -116,7 +117,7 @@ pub fn replace_region_in_file<F>(path: &str, start: &str, end: &str, replace_sta
     f.write_all(replaced.as_bytes()).expect("Unable to write file");
     // Ensure we write the changes with a trailing newline so that
     // the file has the proper line endings.
-    f.write(b"\n").expect("Unable to write file");
+    f.write_all(b"\n").expect("Unable to write file");
 }
 
 /// Replace a region in a text delimited by two lines matching regexes.

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -32,6 +32,8 @@ fn main() {
     if let Some(matches) = matches.subcommand_matches("update_lints") {
         if matches.is_present("print-only") {
             print_lints();
+        } else {
+            update_lints();
         }
     }
 }
@@ -54,4 +56,22 @@ fn print_lints() {
     }
 
     println!("there are {} lints", lint_count);
+}
+
+fn update_lints() {
+    let lint_list = gather_all();
+    let usable_lints: Vec<Lint> = Lint::usable_lints(lint_list).collect();
+    let lint_count = usable_lints.len();
+
+    replace_region_in_file(
+        "../README.md",
+        r#"\[There are \d+ lints included in this crate!\]\(https://rust-lang-nursery.github.io/rust-clippy/master/index.html\)"#,
+        "",
+        true,
+        || {
+            vec![
+                format!("[There are {} lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)", lint_count)
+            ]
+        }
+    );
 }

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -37,8 +37,10 @@ fn main() {
 }
 
 fn print_lints() {
-    let lint_list = gather_all().collect::<Vec<Lint>>();
-    let grouped_by_lint_group = Lint::by_lint_group(&lint_list);
+    let lint_list = gather_all();
+    let usable_lints: Vec<Lint> = Lint::usable_lints(lint_list).collect();
+    let lint_count = usable_lints.len();
+    let grouped_by_lint_group = Lint::by_lint_group(&usable_lints);
 
     for (lint_group, mut lints) in grouped_by_lint_group {
         if lint_group == "Deprecated" { continue; }
@@ -51,5 +53,5 @@ fn print_lints() {
         }
     }
 
-    println!("there are {} lints", Lint::active_lints(lint_list.into_iter()).count());
+    println!("there are {} lints", lint_count);
 }


### PR DESCRIPTION
This enables the usage of `util/dev update_lints` which will write the current
lint count to the `README.md`.

This also adds two new methods: `replace_region_in_file` and `replace_region_in_text` which handle all the meaty stuff of replacing regions of text. For now these are only used to update the lint count in `README.md`

cc #2882