### PR TITLE
Resolve ICE in needless range loop lint

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -31,7 +31,7 @@ use std::mem;
 use crate::syntax::ast;
 use crate::syntax::source_map::Span;
 use crate::syntax_pos::BytePos;
-use crate::utils::{sugg, sext};
+use crate::utils::{in_macro, sugg, sext};
 use crate::utils::usage::mutated_variables;
 use crate::consts::{constant, Constant};
 
@@ -1030,6 +1030,10 @@ fn check_for_loop_range<'a, 'tcx>(
     body: &'tcx Expr,
     expr: &'tcx Expr,
 ) {
+    if in_macro(expr.span) {
+        return;
+    }
+
     if let Some(higher::Range {
         start: Some(start),
         ref end,

--- a/mini-macro/src/lib.rs
+++ b/mini-macro/src/lib.rs
@@ -17,5 +17,10 @@ use proc_macro::{TokenStream, quote};
 pub fn mini_macro(_: TokenStream) -> TokenStream {
     quote!(
         #[allow(unused)] fn needless_take_by_value(s: String) { println!("{}", s.len()); }
+        #[allow(unused)] fn needless_loop(items: &[u8]) {
+            for i in 0..items.len() {
+                println!("{}", items[i]);
+            }
+        }
     )
 }


### PR DESCRIPTION
An ICE would occur if the needless range loop was triggered
within a procedural macro, because Clippy would try to produce
a code suggestion which was invalid, and caused the compiler
to crash.

This commit takes the same approach which Clippy currently takes
to work around this type of crash in the needless pass by value lint,
which is to skip the lint if Clippy is inside of a macro.

Resolves #3309