### PR TITLE
new_ret_no_self false positives

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -936,6 +936,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         if let hir::ImplItemKind::Method(_, _) = implitem.node {
             let ret_ty = return_ty(cx, implitem.id);
 
+//            println!("ret_ty: {:?}", ret_ty);
+//            println!("ret_ty.sty {:?}", ret_ty.sty);
+
             // if return type is impl trait
             if let TyKind::Opaque(def_id, _) = ret_ty.sty {
 
@@ -952,6 +955,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                         },
                         (_, _) => {},
                     }
+                }
+            }
+
+            // if return type is tuple
+            if let TyKind::Tuple(list) = ret_ty.sty {
+                // then at least one of the types in the tuple must be Self
+                for ret_type in list {
+                    if same_tys(cx, ty, ret_type) { return; }
                 }
             }
 

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -91,3 +91,31 @@ impl V {
         unimplemented!();
     }
 }
+
+struct TupleReturnerOk;
+
+impl TupleReturnerOk {
+    // should not trigger lint
+    pub fn new() -> (Self, u32) { unimplemented!(); }
+}
+
+struct TupleReturnerOk2;
+
+impl TupleReturnerOk2 {
+    // should not trigger lint (it doesn't matter which element in the tuple is Self)
+    pub fn new() -> (u32, Self) { unimplemented!(); }
+}
+
+struct TupleReturnerOk3;
+
+impl TupleReturnerOk3 {
+    // should not trigger lint (tuple can contain multiple Self)
+    pub fn new() -> (Self, Self) { unimplemented!(); }
+}
+
+struct TupleReturnerBad;
+
+impl TupleReturnerBad {
+    // should trigger lint
+    pub fn new() -> (u32, u32) { unimplemented!(); }
+}

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -24,5 +24,11 @@ error: methods called `new` usually return `Self`
 92 | |     }
    | |_____^
 
-error: aborting due to 3 previous errors
+error: methods called `new` usually return `Self`
+   --> $DIR/new_ret_no_self.rs:120:5
+    |
+120 |     pub fn new() -> (u32, u32) { unimplemented!(); }
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
WORK IN PROGRESS

I plan to fix all of the false positives in #3313 in this PR, but I wanted to open it now to start gathering feedback.

In this first commit, I've updated the lint to allow tuple return types as long as `Self` shows up at least once, in any position of the tuple. I believe this is the broadest possible interpretation of what should be allowed for tuple return types, but I would certainly be okay making the lint more strict. 

fixes #3313 