### PR TITLE
Check for known array length in `needless_range_loop`

### DIFF
--- a/tests/ui/for_loop.stderr
+++ b/tests/ui/for_loop.stderr
@@ -97,8 +97,8 @@ error: the loop variable `j` is only used to index `STATIC`.
     |              ^^^^
 help: consider using an iterator
     |
-110 |     for <item> in STATIC.iter().take(4) {
-    |         ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^
+110 |     for <item> in &STATIC {
+    |         ^^^^^^    ^^^^^^^
 
 error: the loop variable `j` is only used to index `CONST`.
    --> $DIR/for_loop.rs:114:14
@@ -107,8 +107,8 @@ error: the loop variable `j` is only used to index `CONST`.
     |              ^^^^
 help: consider using an iterator
     |
-114 |     for <item> in CONST.iter().take(4) {
-    |         ^^^^^^    ^^^^^^^^^^^^^^^^^^^^
+114 |     for <item> in &CONST {
+    |         ^^^^^^    ^^^^^^
 
 error: the loop variable `i` is used to index `vec`
    --> $DIR/for_loop.rs:118:14

--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -13,7 +13,7 @@ fn calc_idx(i: usize) -> usize {
 }
 
 fn main() {
-    let ns = [2, 3, 5, 7];
+    let ns = vec![2, 3, 5, 7];
 
     for i in 3..10 {
         println!("{}", ns[i]);
@@ -75,5 +75,19 @@ fn main() {
 
     for i in x..=x + 4 {
         vec[i] += 1;
+    }
+
+    let arr = [1,2,3];
+
+    for i in 0..3 {
+        println!("{}", arr[i]);
+    }
+
+    for i in 0..2 {
+        println!("{}", arr[i]);
+    }
+
+    for i in 1..3 {
+        println!("{}", arr[i]);
     }
 }

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -50,5 +50,35 @@ help: consider using an iterator
 76 |     for <item> in vec.iter_mut().skip(x).take(4 + 1) {
    |         ^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: the loop variable `i` is only used to index `arr`.
+  --> $DIR/needless_range_loop.rs:82:14
+   |
+82 |     for i in 0..3 {
+   |              ^^^^
+help: consider using an iterator
+   |
+82 |     for <item> in &arr {
+   |         ^^^^^^    ^^^^
+
+error: the loop variable `i` is only used to index `arr`.
+  --> $DIR/needless_range_loop.rs:86:14
+   |
+86 |     for i in 0..2 {
+   |              ^^^^
+help: consider using an iterator
+   |
+86 |     for <item> in arr.iter().take(2) {
+   |         ^^^^^^    ^^^^^^^^^^^^^^^^^^
+
+error: the loop variable `i` is only used to index `arr`.
+  --> $DIR/needless_range_loop.rs:90:14
+   |
+90 |     for i in 1..3 {
+   |              ^^^^
+help: consider using an iterator
+   |
+90 |     for <item> in arr.iter().skip(1) {
+   |         ^^^^^^    ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
In `VarVisitor`, we now keep track of the type of the thing that was directly indexed and, if it's an array, check if the range's end is (or is past) the array's length.

Fixes  #3033