### PR TITLE
Setup bors for Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ os:
 
 sudo: false
 
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Also build pull requests.
+    - master
+
 env:
  global:
    - RUST_BACKTRACE=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,16 @@ environment:
         #- TARGET: i686-pc-windows-msvc
         #- TARGET: x86_64-pc-windows-gnu
         - TARGET: x86_64-pc-windows-msvc
-
+        
+branches:
+    only:
+        # This is where pull requests from "bors r+" are built.
+        - staging
+        # This is where pull requests from "bors try" are built.
+        - trying
+        # Also build pull requests.
+        - master
+        
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/
     - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "continuous-integration/travis-ci/push",
+  "continuous-integration/appveyor/branch"
+]


### PR DESCRIPTION
Since [bors-ng](https://app.bors.tech/repositories/3993) is already installed for this repo for a while (https://github.com/rust-lang-nursery/rust-clippy/pull/3279#issuecomment-427645938), the only thing missing, before we can use it, is the `bors.toml`. (bors-ng [docs](https://bors.tech/documentation/getting-started/))

If we want to move forward with this and this gets merged, the only thing left to do is to create the branches `staging` and `trying`.

@phansch @oli-obk 