### PR TITLE
Fixes #3347: Lint for wildcard dependencies in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,6 +893,7 @@ All notable changes to this project will be documented in this file.
 [`while_immutable_condition`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#while_immutable_condition
 [`while_let_loop`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#while_let_loop
 [`while_let_on_iterator`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#while_let_on_iterator
+[`wildcard_dependencies`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#wildcard_dependencies
 [`write_literal`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#write_literal
 [`write_with_newline`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#write_with_newline
 [`writeln_empty_string`]: https://rust-lang-nursery.github.io/rust-clippy/master/index.html#writeln_empty_string

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We are currently in the process of discussing Clippy 1.0 via the RFC process in 
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 280 lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
+[There are 281 lints included in this crate!](https://rust-lang-nursery.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -200,6 +200,7 @@ pub mod unused_label;
 pub mod unwrap;
 pub mod use_self;
 pub mod vec;
+pub mod wildcard_dependencies;
 pub mod write;
 pub mod zero_div_zero;
 // end lints modules, do not remove this comment, it’s used in `update_lints`
@@ -438,6 +439,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box question_mark::Pass);
     reg.register_late_lint_pass(box suspicious_trait_impl::SuspiciousImpl);
     reg.register_early_lint_pass(box multiple_crate_versions::Pass);
+    reg.register_early_lint_pass(box wildcard_dependencies::Pass);
     reg.register_late_lint_pass(box map_unit_fn::Pass);
     reg.register_late_lint_pass(box infallible_destructuring_match::Pass);
     reg.register_late_lint_pass(box inherent_impl::Pass::default());
@@ -967,6 +969,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
 
     reg.register_lint_group("clippy::cargo", Some("clippy_cargo"), vec![
         multiple_crate_versions::MULTIPLE_CRATE_VERSIONS,
+        wildcard_dependencies::WILDCARD_DEPENDENCIES,
     ]);
 
     reg.register_lint_group("clippy::nursery", Some("clippy_nursery"), vec![

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -53,7 +53,7 @@ impl EarlyLintPass for Pass {
         let metadata = if let Ok(metadata) = cargo_metadata::metadata_deps(None, true) {
             metadata
         } else {
-            span_lint(cx, MULTIPLE_CRATE_VERSIONS, krate.span, "could not read cargo metadata");
+            span_lint(cx, MULTIPLE_CRATE_VERSIONS, DUMMY_SP, "could not read cargo metadata");
 
             return;
         };

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -7,12 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
 //! lint on multiple versions of a crate being used
 
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
+use crate::syntax::{ast::*, source_map::DUMMY_SP};
 use crate::utils::span_lint;
 
 use cargo_metadata;
@@ -54,12 +53,7 @@ impl EarlyLintPass for Pass {
         let metadata = if let Ok(metadata) = cargo_metadata::metadata_deps(None, true) {
             metadata
         } else {
-            span_lint(
-                cx,
-                MULTIPLE_CRATE_VERSIONS,
-                krate.span,
-                "could not read cargo metadata"
-            );
+            span_lint(cx, MULTIPLE_CRATE_VERSIONS, krate.span, "could not read cargo metadata");
 
             return;
         };
@@ -76,7 +70,7 @@ impl EarlyLintPass for Pass {
                 span_lint(
                     cx,
                     MULTIPLE_CRATE_VERSIONS,
-                    krate.span,
+                    DUMMY_SP,
                     &format!("multiple versions for dependency `{}`: {}", name, versions),
                 );
             }

--- a/clippy_lints/src/wildcard_dependencies.rs
+++ b/clippy_lints/src/wildcard_dependencies.rs
@@ -1,0 +1,70 @@
+// Copyright 2014-2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::syntax::ast::*;
+use crate::utils::span_lint;
+
+use cargo_metadata;
+use lazy_static::lazy_static;
+use semver;
+
+/// **What it does:** Checks to see if wildcard dependencies are being used.
+///
+/// **Why is this bad?** [As the edition guide sais](https://rust-lang-nursery.github.io/edition-guide/rust-2018/cargo-and-crates-io/crates-io-disallows-wildcard-dependencies.html),
+/// it is highly unlikely that you work with any possible version of your dependency,
+/// and wildcard dependencies would cause unnecessary breakage in the ecosystem.
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```toml
+/// [dependencies]
+/// regex = "*"
+/// ```
+declare_clippy_lint! {
+    pub WILDCARD_DEPENDENCIES,
+    cargo,
+    "wildcard dependencies being used"
+}
+
+pub struct Pass;
+
+impl LintPass for Pass {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(WILDCARD_DEPENDENCIES)
+    }
+}
+
+impl EarlyLintPass for Pass {
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &Crate) {
+        let metadata = if let Ok(metadata) = cargo_metadata::metadata(None) {
+            metadata
+        } else {
+            span_lint(cx, WILDCARD_DEPENDENCIES, krate.span, "could not read cargo metadata");
+            return;
+        };
+
+        lazy_static! {
+            static ref WILDCARD_VERSION_REQ: semver::VersionReq = semver::VersionReq::parse("*").unwrap();
+        }
+
+        for dep in &metadata.packages[0].dependencies {
+            if dep.req == *WILDCARD_VERSION_REQ {
+                span_lint(
+                    cx,
+                    WILDCARD_DEPENDENCIES,
+                    krate.span,
+                    &format!("wildcard dependency for `{}`", dep.name),
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/wildcard_dependencies.rs
+++ b/clippy_lints/src/wildcard_dependencies.rs
@@ -48,7 +48,7 @@ impl EarlyLintPass for Pass {
         let metadata = if let Ok(metadata) = cargo_metadata::metadata(None) {
             metadata
         } else {
-            span_lint(cx, WILDCARD_DEPENDENCIES, krate.span, "could not read cargo metadata");
+            span_lint(cx, WILDCARD_DEPENDENCIES, DUMMY_SP, "could not read cargo metadata");
             return;
         };
 

--- a/clippy_lints/src/wildcard_dependencies.rs
+++ b/clippy_lints/src/wildcard_dependencies.rs
@@ -9,8 +9,7 @@
 
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
-use crate::syntax::source_map::DUMMY_SP;
+use crate::syntax::{ast::*, source_map::DUMMY_SP};
 use crate::utils::span_lint;
 
 use cargo_metadata;

--- a/clippy_lints/src/wildcard_dependencies.rs
+++ b/clippy_lints/src/wildcard_dependencies.rs
@@ -25,6 +25,7 @@ use semver;
 /// **Known problems:** None.
 ///
 /// **Example:**
+///
 /// ```toml
 /// [dependencies]
 /// regex = "*"
@@ -53,6 +54,7 @@ impl EarlyLintPass for Pass {
         };
 
         lazy_static! {
+            // VersionReq::any() does not work
             static ref WILDCARD_VERSION_REQ: semver::VersionReq = semver::VersionReq::parse("*").unwrap();
         }
 


### PR DESCRIPTION
Add a lint for wildcard dependencies in Cargo.toml.
How should I write a test for this lint?

Fixes #3347