### PR TITLE
Fix inspector pass documentation

### DIFF
--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -19,12 +19,12 @@ use crate::rustc::hir::print;
 use crate::syntax::ast::Attribute;
 use crate::utils::get_attr;
 
-/// **What it does:** Dumps every ast/hir node which has the `#[clippy_dump]`
+/// **What it does:** Dumps every ast/hir node which has the `#[clippy::dump]`
 /// attribute
 ///
 /// **Example:**
 /// ```rust
-/// #[clippy_dump]
+/// #[clippy::dump]
 /// extern crate foo;
 /// ```
 ///


### PR DESCRIPTION
When using `#[clippy_dump]`, the compiler complains about an unknown
attribute. The correct one seems to be `#[clippy::dump]`.