### PR TITLE
ci: allow all branches except trying.tmp and staging.tmp to be built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ os:
 sudo: false
 
 branches:
-  only:
-    # This is where pull requests from "bors r+" are built.
-    - staging
-    # This is where pull requests from "bors try" are built.
-    - trying
-    # Also build pull requests.
-    - master
+  # Don't build these branches
+  except:
+    # Used by bors
+    - trying.tmp
+    - staging.tmp
 
 env:
  global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,16 +6,14 @@ environment:
         #- TARGET: i686-pc-windows-msvc
         #- TARGET: x86_64-pc-windows-gnu
         - TARGET: x86_64-pc-windows-msvc
-        
+
 branches:
-    only:
-        # This is where pull requests from "bors r+" are built.
-        - staging
-        # This is where pull requests from "bors try" are built.
-        - trying
-        # Also build pull requests.
-        - master
-        
+    # Don't build these branches
+    except:
+        # Used by bors
+        - trying.tmp
+        - staging.tmp
+
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/
     - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly


### PR DESCRIPTION
r? @flip1995 

The problem was that with the current configuration, if I made a branch `feature1` and pushed it to travis to have it checked before making a PR, travis would skip it because it only built the 3 branches that were specified when setting up bors.

The change allows all branch names to be build by default again, except for travis.tmp.
The gh-pages branch is skipped as per travis-ci defaults: https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches