### PR TITLE
Reenable master build, unbreak CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 
-rust: nightly
+# change to nightly when https://github.com/rust-lang/rust/issues/55376 is fixed
+rust: nightly-2018-10-20
 
 os:
   - linux
@@ -75,14 +76,13 @@ matrix:
     - os: windows
 
 script:
-  # uncomment once https://github.com/rust-lang/rust/issues/55376 is fixed
-  # - |
-  #     rm rust-toolchain
-  #     cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
-  #     RUSTC_HASH=$(git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}')
-  #     travis_retry rustup-toolchain-install-master -f -n master $RUSTC_HASH
-  #     rustup default master
-  #     export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
+  - |
+    rm rust-toolchain
+    cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
+    RUSTC_HASH=$(git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}')
+    travis_retry rustup-toolchain-install-master -f -n master $RUSTC_HASH
+    rustup default master
+    export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
   - |
     if [ -z ${INTEGRATION} ]; then
       ./ci/base-tests.sh && sleep 5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,17 +15,17 @@ branches:
         - staging.tmp
 
 install:
-    - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-    - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly
-    - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-    - git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}' >rustc-hash.txt
-    - set /p RUSTC_HASH=<rustc-hash.txt
-# uncomment once https://github.com/rust-lang/rust/issues/55376 is fixed
-#    - del rust-toolchain
-#    - cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
-#    - rustup-toolchain-install-master %RUSTC_HASH% -f -n master
-#    - rustup default master
-#    - set PATH=%PATH%;C:\Users\appveyor\.rustup\toolchains\master\bin
+   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+   # change to nightly when https://github.com/rust-lang/rust/issues/55376 is fixed
+   - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly-2018-10-20
+   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+   - git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}' >rustc-hash.txt
+   - set /p RUSTC_HASH=<rustc-hash.txt
+   - del rust-toolchain
+   - cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
+   - rustup-toolchain-install-master %RUSTC_HASH% -f -n master
+   - rustup default master
+   - set PATH=%PATH%;C:\Users\appveyor\.rustup\toolchains\master\bin
     - rustc -V
     - cargo -V
 


### PR DESCRIPTION
In #3371 we disabled the master build, however we currently need master for green CI.

This attempts to reenable the master build by installing rustup-toolchain-install-master with an older rustc, temporarily till https://github.com/rust-lang/rust/issues/55376 is fixed


r? @phansch