### PR TITLE
RIIR update lints: Generate deprecated lints

### DIFF
--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -82,4 +82,12 @@ fn update_lints() {
         false,
         || { gen_changelog_lint_list(lint_list.clone()) }
     );
+
+    replace_region_in_file(
+        "../clippy_lints/src/lib.rs",
+        "begin deprecated lints",
+        "end deprecated lints",
+        false,
+        || { gen_deprecated(lint_list.clone()) }
+    );
 }

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -88,6 +88,6 @@ fn update_lints() {
         "begin deprecated lints",
         "end deprecated lints",
         false,
-        || { gen_deprecated(lint_list.clone()) }
+        || { gen_deprecated(&lint_list) }
     );
 }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -270,6 +270,7 @@ pub fn read_conf(reg: &rustc_plugin::Registry<'_>) -> Conf {
 #[rustfmt::skip]
 pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     let mut store = reg.sess.lint_store.borrow_mut();
+    // begin deprecated lints, do not remove this comment, it’s used in `update_lints`
     store.register_removed(
         "should_assert_eq",
         "`assert!()` will be more flexible with RFC 2011",

--- a/util/update_lints.py
+++ b/util/update_lints.py
@@ -240,7 +240,7 @@ def main(print_only=False, check=False):
 
     # same for "deprecated" lint collection
     changed |= replace_region(
-        'clippy_lints/src/lib.rs', r'let mut store', r'end deprecated lints',
+        'clippy_lints/src/lib.rs', r'begin deprecated lints', r'end deprecated lints',
         lambda: gen_deprecated(deprecated_lints),
         replace_start=False,
         write_back=not check)


### PR DESCRIPTION
The update script now also generates the 'register_removed' section in
`clippy_lints/src/lib.rs`.

Also, instead of using `let mut store ...`, I added a new identifier
line so that the replacement will continue to work in case `let mut
store ...` ever changes.

cc #2882