### PR TITLE
ci: when installing rust-toolchain-installer-master, install it in debug mode to save some time on ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
 script:
   - |
       rm rust-toolchain
-      cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
+      cargo install rustup-toolchain-install-master --debug || echo "rustup-toolchain-install-master already installed"
       RUSTC_HASH=$(git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}')
       travis_retry rustup-toolchain-install-master -f -n master $RUSTC_HASH
       rustup default master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
     - git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}' >rustc-hash.txt
     - set /p RUSTC_HASH=<rustc-hash.txt
     - del rust-toolchain
-    - cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
+    - cargo install rustup-toolchain-install-master --debug || echo "rustup-toolchain-install-master already installed"
     - rustup-toolchain-install-master %RUSTC_HASH% -f -n master
     - rustup default master
     - set PATH=%PATH%;C:\Users\appveyor\.rustup\toolchains\master\bin


### PR DESCRIPTION
the compiletime optimizations probably take longer than the speedup we get when executing the optimized binary vs debug build.