### PR TITLE
RIIR update lints: Generate modules section and lint group sections

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -22,6 +22,7 @@ cargo build --features debugging
 cargo test --features debugging
 cd clippy_lints && cargo test && cd ..
 cd rustc_tools_util && cargo test && cd ..
+cd clippy_dev && cargo test && cd ..
 # check that the lint lists are up-to-date
 ./util/update_lints.py -c
 

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -381,12 +381,12 @@ fn test_gen_modules_list() {
     let lints = vec![
         Lint::new("should_assert_eq", "group1", "abc", None, "module_name"),
         Lint::new("should_assert_eq2", "group2", "abc", Some("abc"), "deprecated"),
-        Lint::new("incorrect_internal", "internal_style", "abc", None, "another_module"),
+        Lint::new("incorrect_stuff", "group3", "abc", None, "another_module"),
         Lint::new("incorrect_internal", "internal_style", "abc", None, "module_name"),
     ];
     let expected = vec![
-        "pub mod another_module;\n".to_string(),
-        "pub mod module_name;\n".to_string(),
+        "pub mod another_module;".to_string(),
+        "pub mod module_name;".to_string(),
     ];
     assert_eq!(expected, gen_modules_list(lints));
 }

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -19,12 +19,17 @@ fn main() {
     let matches = App::new("Clippy developer tooling")
         .subcommand(
             SubCommand::with_name("update_lints")
-                .about("Update the lint list")
+                .about("Makes sure that:\n \
+                       * the lint count in README.md is correct\n \
+                       * the changelog contains markdown link references at the bottom\n \
+                       * all lints groups include the correct lints\n \
+                       * lint modules in `clippy_lints/*` are visible in `src/lib.rs` via `pub mod`\n \
+                       * all lints are registered in the lint store")
                 .arg(
                     Arg::with_name("print-only")
                         .long("print-only")
                         .short("p")
-                        .help("Print a table of lints to STDOUT. Does not modify any files."),
+                        .help("Print a table of lints to STDOUT. This does not include deprecated and internal lints. (Does not modify any files)"),
                 )
         )
         .get_matches();

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -90,4 +90,12 @@ fn update_lints() {
         false,
         || { gen_deprecated(&lint_list) }
     );
+
+    replace_region_in_file(
+        "../clippy_lints/src/lib.rs",
+        "begin lints modules",
+        "end lints modules",
+        false,
+        || { gen_modules_list(lint_list.clone()) }
+    );
 }

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
                 .about("Makes sure that:\n \
                        * the lint count in README.md is correct\n \
                        * the changelog contains markdown link references at the bottom\n \
-                       * all lints groups include the correct lints\n \
+                       * all lint groups include the correct lints\n \
                        * lint modules in `clippy_lints/*` are visible in `src/lib.rs` via `pub mod`\n \
                        * all lints are registered in the lint store")
                 .arg(


### PR DESCRIPTION
This adds the last missing parts of the generating code.

cc #2882