### PR TITLE
fix a few clippy::pedantic warnings

### DIFF
--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 
-
 #![allow(clippy::default_hash_types)]
 
 use itertools::Itertools;

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -951,7 +951,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let TyKind::Opaque(def_id, _) = ret_ty.sty {
 
                 // one of the associated types must be Self
-                for predicate in cx.tcx.predicates_of(def_id).predicates.iter() {
+                for predicate in &cx.tcx.predicates_of(def_id).predicates {
                     match predicate {
                         (Predicate::Projection(poly_projection_predicate), _) => {
                             let binder = poly_projection_predicate.ty();

--- a/clippy_lints/src/redundant_pattern_matching.rs
+++ b/clippy_lints/src/redundant_pattern_matching.rs
@@ -83,8 +83,8 @@ fn find_sugg_for_if_let<'a, 'tcx>(
 ) {
     if arms[0].pats.len() == 1 {
         let good_method = match arms[0].pats[0].node {
-            PatKind::TupleStruct(ref path, ref pats, _) if pats.len() == 1 => {
-                if let PatKind::Wild = pats[0].node {
+            PatKind::TupleStruct(ref path, ref patterns, _) if patterns.len() == 1 => {
+                if let PatKind::Wild = patterns[0].node {
                     if match_qpath(path, &paths::RESULT_OK) {
                         "is_ok()"
                     } else if match_qpath(path, &paths::RESULT_ERR) {
@@ -135,10 +135,10 @@ fn find_sugg_for_match<'a, 'tcx>(
 
         let found_good_method = match node_pair {
             (
-                PatKind::TupleStruct(ref path_left, ref pats_left, _),
-                PatKind::TupleStruct(ref path_right, ref pats_right, _)
-            ) if pats_left.len() == 1 && pats_right.len() == 1 => {
-                if let (PatKind::Wild, PatKind::Wild) = (&pats_left[0].node, &pats_right[0].node) {
+                PatKind::TupleStruct(ref path_left, ref patterns_left, _),
+                PatKind::TupleStruct(ref path_right, ref patterns_right, _)
+            ) if patterns_left.len() == 1 && patterns_right.len() == 1 => {
+                if let (PatKind::Wild, PatKind::Wild) = (&patterns_left[0].node, &patterns_right[0].node) {
                     find_good_method_for_match(
                         arms,
                         path_left,
@@ -153,13 +153,13 @@ fn find_sugg_for_match<'a, 'tcx>(
                 }
             },
             (
-                PatKind::TupleStruct(ref path_left, ref pats, _),
+                PatKind::TupleStruct(ref path_left, ref patterns, _),
                 PatKind::Path(ref path_right)
             ) | (
                 PatKind::Path(ref path_left),
-                PatKind::TupleStruct(ref path_right, ref pats, _)
-            ) if pats.len() == 1 => {
-                if let PatKind::Wild = pats[0].node {
+                PatKind::TupleStruct(ref path_right, ref patterns, _)
+            ) if patterns.len() == 1 => {
+                if let PatKind::Wild = patterns[0].node {
                     find_good_method_for_match(
                         arms,
                         path_left,

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -200,6 +200,7 @@ impl EarlyLintPass for ReturnPass {
                         cx.sess().source_map()
                                  .span_to_snippet(span.with_hi(ty.span.hi())) {
                     if let Some(rpos) = fn_source.rfind("->") {
+                        #[allow(clippy::cast_possible_truncation)]
                         (ty.span.with_lo(BytePos(span.lo().0 + rpos as u32)),
                             Applicability::MachineApplicable)
                     } else {


### PR DESCRIPTION
redundant pattern matching: fix clippy::similar-names pedantic lint warnings.
mods.rs: fix clippy::explicit-iter-loop pedantic lint warning
returns.rs: allow clippy::cast_possible_truncation