### PR TITLE
clippy: fix pedantic warnings and run clippy::pedantic lints on the codebase

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -27,12 +27,12 @@ cd rustc_tools_util && cargo test && cd ..
 
 CLIPPY="`pwd`/target/debug/cargo-clippy clippy"
 # run clippy on its own codebase...
-${CLIPPY} --all-targets --all-features -- -D clippy::all -D clippy::internal
+${CLIPPY} --all-targets --all-features -- -D clippy::all -D clippy::internal -Dclippy::pedantic
 # ... and some test directories
 for dir in clippy_workspace_tests clippy_workspace_tests/src clippy_workspace_tests/subcrate clippy_workspace_tests/subcrate/src clippy_dev rustc_tools_util
 do
     cd ${dir}
-    ${CLIPPY} -- -D clippy::all
+    ${CLIPPY} -- -D clippy::all -D clippy::pedantic
     cd -
 done
 

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 
-
 #![allow(clippy::default_hash_types)]
 
 use itertools::Itertools;

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -931,7 +931,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let TyKind::Opaque(def_id, _) = ret_ty.sty {
 
                 // one of the associated types must be Self
-                for predicate in cx.tcx.predicates_of(def_id).predicates.iter() {
+                for predicate in &cx.tcx.predicates_of(def_id).predicates {
                     match predicate {
                         (Predicate::Projection(poly_projection_predicate), _) => {
                             let binder = poly_projection_predicate.ty();

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -133,10 +133,12 @@ impl LintPass for BoolComparison {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
+        use self::Expression::*;
+
         if in_macro(e.span) {
             return;
         }
-        use self::Expression::*;
+
         if let ExprKind::Binary(Spanned { node: BinOpKind::Eq, .. }, ref left_side, ref right_side) = e.node {
             match (fetch_bool_expr(left_side), fetch_bool_expr(right_side)) {
                 (Bool(true), Other) => {

--- a/clippy_lints/src/redundant_pattern_matching.rs
+++ b/clippy_lints/src/redundant_pattern_matching.rs
@@ -83,8 +83,8 @@ fn find_sugg_for_if_let<'a, 'tcx>(
 ) {
     if arms[0].pats.len() == 1 {
         let good_method = match arms[0].pats[0].node {
-            PatKind::TupleStruct(ref path, ref pats, _) if pats.len() == 1 => {
-                if let PatKind::Wild = pats[0].node {
+            PatKind::TupleStruct(ref path, ref patterns, _) if patterns.len() == 1 => {
+                if let PatKind::Wild = patterns[0].node {
                     if match_qpath(path, &paths::RESULT_OK) {
                         "is_ok()"
                     } else if match_qpath(path, &paths::RESULT_ERR) {
@@ -135,10 +135,10 @@ fn find_sugg_for_match<'a, 'tcx>(
 
         let found_good_method = match node_pair {
             (
-                PatKind::TupleStruct(ref path_left, ref pats_left, _),
-                PatKind::TupleStruct(ref path_right, ref pats_right, _)
-            ) if pats_left.len() == 1 && pats_right.len() == 1 => {
-                if let (PatKind::Wild, PatKind::Wild) = (&pats_left[0].node, &pats_right[0].node) {
+                PatKind::TupleStruct(ref path_left, ref patterns_left, _),
+                PatKind::TupleStruct(ref path_right, ref patterns_right, _)
+            ) if patterns_left.len() == 1 && patterns_right.len() == 1 => {
+                if let (PatKind::Wild, PatKind::Wild) = (&patterns_left[0].node, &patterns_right[0].node) {
                     find_good_method_for_match(
                         arms,
                         path_left,
@@ -153,13 +153,13 @@ fn find_sugg_for_match<'a, 'tcx>(
                 }
             },
             (
-                PatKind::TupleStruct(ref path_left, ref pats, _),
+                PatKind::TupleStruct(ref path_left, ref patterns, _),
                 PatKind::Path(ref path_right)
             ) | (
                 PatKind::Path(ref path_left),
-                PatKind::TupleStruct(ref path_right, ref pats, _)
-            ) if pats.len() == 1 => {
-                if let PatKind::Wild = pats[0].node {
+                PatKind::TupleStruct(ref path_right, ref patterns, _)
+            ) if patterns.len() == 1 => {
+                if let PatKind::Wild = patterns[0].node {
                     find_good_method_for_match(
                         arms,
                         path_left,

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -200,6 +200,7 @@ impl EarlyLintPass for ReturnPass {
                         cx.sess().source_map()
                                  .span_to_snippet(span.with_hi(ty.span.hi())) {
                     if let Some(rpos) = fn_source.rfind("->") {
+                        #[allow(clippy::cast_possible_truncation)]
                         (ty.span.with_lo(BytePos(span.lo().0 + rpos as u32)),
                             Applicability::MachineApplicable)
                     } else {

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -23,7 +23,7 @@ fn dogfood() {
             .arg("--all-features")
             .arg("--manifest-path")
             .arg(root_dir.join("Cargo.toml"))
-            .args(&["--", "-W clippy::internal"])
+            .args(&["--", "-W clippy::internal -W clippy::pedantic"])
             .env("CLIPPY_DOGFOOD", "true")
             .output()
             .unwrap();


### PR DESCRIPTION
Turn on pedantic lints in dogfood and base tests.

needless_bool: fix clippy::items-after-statements
redundant_pattern_matching: fix clippy::similar-names
mods.rs: fix clippy::explicit-iter-loop
returns.rs: allow clippy::cast-possible-wrap

Fixes #3172