### PR TITLE
match_ref_pats: don't emit suggestions inside of a macro

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -18,9 +18,9 @@ use std::collections::Bound;
 use crate::syntax::ast::LitKind;
 use crate::syntax::source_map::Span;
 use crate::utils::paths;
-use crate::utils::{expr_block, is_allowed, is_expn_of, match_qpath, match_type, multispan_sugg,
-            remove_blocks, snippet, span_lint_and_sugg, span_lint_and_then,
-            span_note_and_lint, walk_ptrs_ty};
+use crate::utils::{expr_block, in_macro, is_allowed, is_expn_of, match_qpath, match_type,
+    multispan_sugg, remove_blocks, snippet, span_lint_and_sugg, span_lint_and_then,
+    span_note_and_lint, walk_ptrs_ty};
 use crate::utils::sugg::Sugg;
 use crate::consts::{constant, Constant};
 use crate::rustc_errors::Applicability;
@@ -457,7 +457,9 @@ fn check_match_ref_pats(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr:
         }));
 
         span_lint_and_then(cx, MATCH_REF_PATS, expr.span, title, |db| {
-            multispan_sugg(db, msg.to_owned(), suggs);
+            if !in_macro(expr.span) {
+                multispan_sugg(db, msg.to_owned(), suggs);
+            }
         });
     }
 }

--- a/tests/ui/ice-2636.rs
+++ b/tests/ui/ice-2636.rs
@@ -1,0 +1,32 @@
+// Copyright 2014-2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+enum Foo {
+    A,
+    B,
+    C,
+}
+
+macro_rules! test_hash {
+    ($foo:expr, $($t:ident => $ord:expr),+ ) => {
+        use self::Foo::*;
+        match $foo {
+            $ ( & $t => $ord,
+            )*
+        };
+    };
+}
+
+fn main() {
+    let a = Foo::A;
+    test_hash!(&a, A => 0, B => 1, C => 2);
+}
+

--- a/tests/ui/ice-2636.stderr
+++ b/tests/ui/ice-2636.stderr
@@ -1,0 +1,16 @@
+error: you don't need to add `&` to both the expression and the patterns
+  --> $DIR/ice-2636.rs:21:9
+   |
+21 | /         match $foo {
+22 | |             $ ( & $t => $ord,
+23 | |             )*
+24 | |         };
+   | |_________^
+...
+30 |       test_hash!(&a, A => 0, B => 1, C => 2);
+   |       --------------------------------------- in this macro invocation
+   |
+   = note: `-D clippy::match-ref-pats` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #2636 